### PR TITLE
AM62x: Add minimal platform board port guide

### DIFF
--- a/configs/AM62X/AM62X_linux_toc.txt
+++ b/configs/AM62X/AM62X_linux_toc.txt
@@ -142,6 +142,7 @@ linux/How_to_Guides/Host/Moving_Files_to_the_Target_System
 linux/How_to_Guides/Host/K3_Resource_Partitioning_Tool
 linux/How_to_Guides/Host/How_to_Setup_and_Debug_using_Lauterbach
 linux/How_to_Guides/Host/SYSFW_Trace_Parser
+linux/How_to_Guides/Host/Minimal_Platform_Development
 linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customization
 linux/How_to_Guides/Target/How_to_boot_quickly
 #linux/How_to_Guides/Target/How_to_manually_flash_emmc_device   # We do not support this for now

--- a/source/linux/How_to_Guides/Host/Minimal_Platform_Development.rst
+++ b/source/linux/How_to_Guides/Host/Minimal_Platform_Development.rst
@@ -1,0 +1,16 @@
+Minimal Platform Development
+============================
+
+When customers purchase or develop custom boards using the TI AM62x
+family of SoCs, the heavy integration of the existing code base results
+in upbringing time that ranges from a few days to several weeks. If a
+developer would like to create a custom board using TI's AM62x SoC, they
+must edit both the device tree and configuration files used for the TI
+boards to fit their new independent layout with differing peripherals.
+This application note introduces a minimal configuration to streamline
+this process and reduce the time of this initial upbringing process to
+around one day, and as shown in the case study, as little as two hours.
+Use the application note below to begin minimal platform development for
+custom boards using the TI AM62x.
+
+`Minimal Platform Development on AM62x Devices <https://www.ti.com/lit/pdf/spradd1>`__

--- a/source/linux/How_to_Guides_Developer_Notes.rst
+++ b/source/linux/How_to_Guides_Developer_Notes.rst
@@ -45,5 +45,6 @@ Developer Notes
    How_to_Guides/Host/K3_Resource_Partitioning_Tool
    How_to_Guides/Host/How_to_Setup_and_Debug_using_Lauterbach
    How_to_Guides/Host/SYSFW_Trace_Parser
+   How_to_Guides/Host/Minimal_Platform_Development
    How_to_Guides/Host/Program_MMC_boot_media
    How_to_Guides/FAQ/Tda4_Latest_FAQs


### PR DESCRIPTION
This reverts commit ef600ddd3fb335f745ac179f15eb0526ea2a6418.

https://www.ti.com/lit/pdf/spradd1 is now published.
Enable back the minimal platform board porting guide for AM62x.