### PR TITLE
Enable Dark Mode using sphinx-rtd-dark-mode

### DIFF
--- a/python-scripts/conf.py
+++ b/python-scripts/conf.py
@@ -36,7 +36,8 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx_rtd_theme',
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    'sphinx_rtd_dark_mode'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ snowballstemmer==2.2.0
 Sphinx==4.3.2
 sphinx-tabs==3.4.5
 sphinx-rtd-theme==1.0.0
+sphinx-rtd-dark-mode==1.3.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0


### PR DESCRIPTION
This Sphinx extension adds a toggleable dark mode with a little icon in the bottom right hand corner which allows the user to switch between light or dark mode.