### PR TITLE
source: devices: AM62*: linux: Updated LPM power measurements for SDK 10.0

### DIFF
--- a/source/devices/AM62AX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62AX/linux/Linux_Performance_Guide.rst
@@ -881,28 +881,28 @@ Low Power Performance
 Table:  **Deep sleep**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62axx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","14.66"
-    "vddr_core","0.85","1.80"
-    "soc_dvdd_3v3","3.30","4.04"
-    "soc_dvdd_1v8","1.80","1.91"
-    "vdda_1v8","1.80","10.71"
-    "vdd_lpddr4/vdd_ddr4","1.10","3.68"
-    "Total"," ","36.79"
+    "vdd_core","0.85","16.82"
+    "vddr_core","0.85","1.96"
+    "soc_dvdd_3v3","3.30","4.63"
+    "soc_dvdd_1v8","1.80","1.44"
+    "vdda_1v8","1.80","10.72"
+    "vdd_lpddr4/vdd_ddr4","1.10","6.07"
+    "Total"," ","41.64"
 
 Table:  **MCU only**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62axx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","198.21"
-    "vddr_core","0.85","3.08"
-    "soc_dvdd_3v3","3.30","9.55"
-    "soc_dvdd_1v8","1.80","1.80"
-    "vdda_1v8","1.80","19.12"
-    "vdd_lpddr4/vdd_ddr4","1.10","3.37"
-    "Total"," ","235.12"
+    "vdd_core","0.85","112.87"
+    "vddr_core","0.85","1.49"
+    "soc_dvdd_3v3","3.30","9.58"
+    "soc_dvdd_1v8","1.80","1.71"
+    "vdda_1v8","1.80","19.37"
+    "vdd_lpddr4/vdd_ddr4","1.10","5.79"
+    "Total"," ","150.82"
 
 Partial I/O Data
 - All voltage rails were measured to be near 0V

--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -1086,28 +1086,28 @@ Low Power Performance
 Table:  **Deep sleep**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62pxx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","14.08"
-    "vddr_core","0.85","1.24"
-    "soc_dvdd_3v3","3.30","5.36"
-    "soc_dvdd_1v8","1.80","2.87"
-    "vdda_1v8","1.80","9.26"
-    "vdd_lpddr4/vdd_ddr4","1.10","5.20"
-    "Total"," ","38.02"
+    "vdd_core","0.85","10.06"
+    "vddr_core","0.85","0.92"
+    "soc_dvdd_3v3","3.30","6.63"
+    "soc_dvdd_1v8","1.80","2.78"
+    "vdda_1v8","1.80","72.19"
+    "vdd_lpddr4/vdd_ddr4","1.10","4.40"
+    "Total"," ","96.98"
 
 Table:  **MCU only**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62pxx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","202.22"
-    "vddr_core","0.85","2.67"
-    "soc_dvdd_3v3","3.30","5.28"
-    "soc_dvdd_1v8","1.80","2.84"
-    "vdda_1v8","1.80","17.62"
-    "vdd_lpddr4/vdd_ddr4","1.10","3.36"
-    "Total"," ","233.99"
+    "vdd_core","0.85","207.60"
+    "vddr_core","0.85","2.46"
+    "soc_dvdd_3v3","3.30","6.56"
+    "soc_dvdd_1v8","1.80","2.63"
+    "vdda_1v8","1.80","80.23"
+    "vdd_lpddr4/vdd_ddr4","1.10","4.05"
+    "Total"," ","303.53"
 
 Partial I/O Data
 - All voltage rails were measured to be near 0V

--- a/source/devices/AM62X/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62X/linux/Linux_Performance_Guide.rst
@@ -1170,28 +1170,28 @@ Low Power Performance
 Table:  **Deep sleep**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62xx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","9.82"
+    "vdd_core","0.85","7.95"
     "vddr_core","0.85","n/a"
-    "soc_dvdd_3v3","3.30","6.33"
-    "soc_dvdd_1v8","1.80","4.00"
+    "soc_dvdd_3v3","3.30","6.20"
+    "soc_dvdd_1v8","1.80","1.98"
     "vdda_1v8","1.80","1.80"
-    "vdd_lpddr4/vdd_ddr4","1.10","8.60"
-    "Total"," ","30.55"
+    "vdd_lpddr4/vdd_ddr4","1.10","7.50"
+    "Total"," ","25.43"
 
 Table:  **MCU only**
 
 .. csv-table::
-    :header: "Rail name","Rail voltage(V)","am62xx_sk-fs"
+    :header: "Rail name","Rail voltage(V)","Power (mW)"
 
-    "vdd_core","0.85","107.97"
+    "vdd_core","0.85","121.81"
     "vddr_core","0.85","n/a"
-    "soc_dvdd_3v3","3.30","5.02"
-    "soc_dvdd_1v8","1.80","4.80"
-    "vdda_1v8","1.80","10.80"
-    "vdd_lpddr4/vdd_ddr4","1.10","8.06"
-    "Total"," ","136.66"
+    "soc_dvdd_3v3","3.30","12.72"
+    "soc_dvdd_1v8","1.80","1.62"
+    "vdda_1v8","1.80","10.71"
+    "vdd_lpddr4/vdd_ddr4","1.10","7.74"
+    "Total"," ","154.61"
 
 Partial I/O Data
 - All voltage rails were measured to be near 0V


### PR DESCRIPTION
Updated DeepSleep and MCU Only LPM power measurements in the Linux performance guide.