### PR TITLE
ci(commit-check): fix permissions and allow bot to comment on prs

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,7 +1,6 @@
 ---
 name: Commit Check
 on:
-  push:
   pull_request:
     branches: ['master']
 

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -8,6 +8,10 @@ jobs:
   commit-check:
     name: Commit Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout
@@ -15,7 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: commit-check/commit-check-action@v1
+      - name: Check commit
+        uses: commit-check/commit-check-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: true
           author-name: true


### PR DESCRIPTION
Fix permissions so that the bot can comment on PRs.

Also remove checks against the master branch. The bot as configured will try to comment on a PR that does not exist in these cases.