### PR TITLE
configs: J722S: Add IMG Encoder to J722s and AM67 Documentation

### DIFF
--- a/configs/AM67/AM67_linux_toc.txt
+++ b/configs/AM67/AM67_linux_toc.txt
@@ -45,6 +45,7 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Audio
 linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/CSI2RX
 linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto
 linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7
+linux/Foundational_Components/Kernel/Kernel_Drivers/E5010_JPEG_Encoder
 linux/Foundational_Components/Kernel/Kernel_Drivers/GPIO
 linux/Foundational_Components/Kernel/Kernel_Drivers/I2C
 linux/Foundational_Components/Kernel/Kernel_Drivers/MCAN

--- a/configs/J722S/J722S_linux_toc.txt
+++ b/configs/J722S/J722S_linux_toc.txt
@@ -46,6 +46,7 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Audio
 linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/CSI2RX
 linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto
 linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7
+linux/Foundational_Components/Kernel/Kernel_Drivers/E5010_JPEG_Encoder
 linux/Foundational_Components/Kernel/Kernel_Drivers/GPIO
 linux/Foundational_Components/Kernel/Kernel_Drivers/I2C
 linux/Foundational_Components/Kernel/Kernel_Drivers/MCAN


### PR DESCRIPTION
10.0 introduced support for the E5010 JPEG Encoder on the J722s platform. Add documentation to relevant config to pull in during build.