### PR TITLE
feat: Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, all below
+# owners will be requested for review when someone opens a pull request.
+
+*    @cshilwant @StaticRocket @praneethbajjuri @uditkumarti


### PR DESCRIPTION
Add CODEOWNERS file to define individuals or teams that are responsible for code in a repository.

Code owners will be automatically requested for review when someone opens a pull request that modifies code that they own.

Fixes https://github.com/TexasInstruments/processor-sdk-doc/issues/8