### PR TITLE
Update the references of Ubuntu versions for SITARA platforms

### DIFF
--- a/configs/AM335X/AM335X_linux_toc.txt
+++ b/configs/AM335X/AM335X_linux_toc.txt
@@ -122,7 +122,6 @@ linux/Examples_and_Demos_Matrix_User_Guide
 linux/Examples_and_Demos_Sub-system_Demos
 linux/How_to_Guides
 linux/How_to_Guides_Host
-linux/How_to_Guides/Host/How_to_Build_a_Ubuntu_Linux_host_under_VMware
 linux/How_to_Guides/Host/Connect_to_an_EVM_via_Telnet
 linux/How_to_Guides/Host/How_to_Setup_a_Samba_Server
 linux/How_to_Guides/Host/Boot_Sequence

--- a/configs/AM437X/AM437X_linux_toc.txt
+++ b/configs/AM437X/AM437X_linux_toc.txt
@@ -121,7 +121,6 @@ linux/Examples_and_Demos_Matrix_User_Guide
 linux/Examples_and_Demos_Sub-system_Demos
 linux/How_to_Guides
 linux/How_to_Guides_Host
-linux/How_to_Guides/Host/How_to_Build_a_Ubuntu_Linux_host_under_VMware
 linux/How_to_Guides/Host/Connect_to_an_EVM_via_Telnet
 linux/How_to_Guides/Host/How_to_Setup_a_Samba_Server
 linux/How_to_Guides/Host/Boot_Sequence

--- a/configs/AM65X/AM65X_linux_toc.txt
+++ b/configs/AM65X/AM65X_linux_toc.txt
@@ -128,7 +128,6 @@ linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux
 linux/How_to_Guides/FAQ/How_to_Integrate_Open_Source_Software
-linux/How_to_Guides/Host/How_to_Build_a_Ubuntu_Linux_host_under_VMware
 linux/How_to_Guides_Hardware_Setup_with_CCS
 linux/How_to_Guides/Hardware_Setup_with_CCS/TMDX654_EVM_Hardware_Setup
 linux/Documentation_Tarball

--- a/source/devices/AM335X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM335X/linux/Release_Specific_Release_Notes.rst
@@ -1,3 +1,5 @@
+.. include:: /_replacevars.rst
+
 .. _release-specific-release-notes:
 
 ************************************
@@ -309,8 +311,7 @@ Composer Studio.
 .. rubric:: Host Support
    :name: host-support
 
-The Processor SDK is developed, built and verified on Ubuntu 22.04. Details on how to create a virtual machine to load Ubuntu
-are described in :ref:`this page <how-to-build-a-ubuntu-linux-host-under-vmware>`.
+The Processor SDK is developed, built and verified on Ubuntu |__LINUX_UBUNTU_VERSION_SHORT__|.
 
 
 .. note::

--- a/source/devices/AM437X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM437X/linux/Release_Specific_Release_Notes.rst
@@ -1,3 +1,5 @@
+.. include:: /_replacevars.rst
+
 .. _release-specific-release-notes:
 
 ************************************
@@ -283,8 +285,7 @@ Composer Studio.
 .. rubric:: Host Support
    :name: host-support
 
-The Processor SDK is developed, built and verified on Ubuntu 22.04. Details on how to create a virtual machine to load Ubuntu
-are described in :ref:`this page <how-to-build-a-ubuntu-linux-host-under-vmware>`.
+The Processor SDK is developed, built and verified on Ubuntu |__LINUX_UBUNTU_VERSION_SHORT__|.
 
 
 .. note::

--- a/source/devices/AM65X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM65X/linux/Release_Specific_Release_Notes.rst
@@ -1,3 +1,5 @@
+.. include:: /_replacevars.rst
+
 .. _release-specific-release-notes:
 
 ************************************
@@ -350,8 +352,7 @@ Composer Studio.
 Host Support
 ============
 
-The Processor SDK is developed, built and verified on Ubuntu 16.04 and 18.04. Details on how to create a virtual machine to load Ubuntu
-are described in :ref:`this page <how-to-build-a-ubuntu-linux-host-under-vmware>`.
+The Processor SDK is developed, built and verified on Ubuntu |__LINUX_UBUNTU_VERSION_SHORT__|.
 
 
 .. note::

--- a/source/linux/Overview/Processor_SDK_Linux_Getting_Started_Guide.rst
+++ b/source/linux/Overview/Processor_SDK_Linux_Getting_Started_Guide.rst
@@ -207,8 +207,8 @@ which you can start development.
 
    .. ifconfig:: CONFIG_sdk in ('SITARA')
 
-       For example, at the time of this writing, Ubuntu 16.04 and Ubuntu 18.04
-       are the currently supported LTS versions).
+       For example, at the time of this writing, Ubuntu |__LINUX_UBUNTU_VERSION_SHORT__|
+       is the currently supported LTS version).
 
    Can you use other versions of Ubuntu or even other distributions?
    Theoretically, yes, as long as you can get it to work and there may


### PR DESCRIPTION
- Update the supported ubuntu version to 22.04
- Remove the reference of `How to Build a Ubuntu Linux host under VMware` since it is no longer maintained