### PR TITLE
fix(fitImage): Correct the path of keys folder in U-Boot src

### DIFF
--- a/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
+++ b/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
@@ -629,7 +629,7 @@ built during the initial u-boot build.
 
 .. code-block:: console
 
-    mkimage -r -f fitImage.its -k $UBOOT_PATH/board/ti/keys -K $UBOOT_PATH/build/$ARMV8/dts/dt.dtb fitImage
+    mkimage -r -f fitImage.its -k $UBOOT_PATH/arch/arm/mach-k3/keys -K $UBOOT_PATH/build/$ARMV8/dts/dt.dtb fitImage
 
 .. note::
 


### PR DESCRIPTION
keys directory is now located in arch/arm/mach-k3/. Fix the doc accordingly.