### PR TITLE
Feature/cicd builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,87 @@
+---
+name: "build"
+
+on:
+  push:
+    branches: [master]
+
+concurrency:
+  group: ${{ github.ref_name }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build Linux Documents
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/texasinstruments/processor-sdk-doc:latest
+      options: --entrypoint /bin/bash
+    strategy:
+      matrix:
+        os: [linux]
+        device:
+          - AM335X
+          - AM437X
+          - AM57X
+          - AM62AX
+          - AM62PX
+          - AM62X
+          - AM64X
+          - AM65X
+          - AM67
+          - AM68
+          - AM69
+          - CORESDK
+          - DRA821A
+          - GEN
+          - J7200
+          - J721E
+          - J721S2
+          - J722S
+          - J742S2
+          - J784S4
+        include:
+          - os: android
+            device: AM62PX
+          - os: android
+            device: AM62X
+          - os: android
+            device: GEN
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build ${{ matrix.device }}
+        run: |
+          make DEVFAMILY=${{ matrix.device }} OS=${{ matrix.os }} \
+          VERSION=${{ github.ref_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.device }}-${{ matrix.os }}
+          path: build/
+          retention-days: 1
+
+  agregate:
+    name: Agregate build artifacts
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: build
+          merge-multiple: true
+
+      - name: Upload static files as single artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,21 @@
+---
+name: "deploy"
+
+on:
+  workflow_run:
+    workflows:
+      - build
+    types:
+      - completed
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Update github page deployment
+        uses: actions/deploy-pages@v4

--- a/conf.py
+++ b/conf.py
@@ -163,6 +163,9 @@ html_additional_pages = {'index': 'index.html'}
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 


### PR DESCRIPTION
Automatic builds and deployment to GitHub pages for any updates to the master branch.  

Use a matrix to parallelize building the docs for listed DEVFAMILY and
OS combinations. Aggregate the results to build an expected pages
artifact. Deploy the monolithic artifact to GitHub pages.

If any platform fails for any reason, the arguments and logs for that
build will be logged under a separate section of this workflow, and the
results should not be deployed.

---

Fair warning, I have tested the build and aggregation step, but I am not currently able to test the deployment step as my master branch is still locked up in the codeowners draft. I'd appreciate someone taking a look at this on their fork.