### PR TITLE
docs(linux): U-Boot: Add a known issue

### DIFF
--- a/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
@@ -212,6 +212,7 @@ Known Issues
    :header: "Record ID", "Title", "Platform", "Workaround"
    :widths: 5, 10, 50, 35
 
+   "LCPD-42226","am64xx-evm : OSPI NOR boot fails","am64xx-hsevm","Refer :ref:`here <u-boot-introduction-qspi-ug>`"
    "LCPD-38695","Documentation: Kernel_Drivers/Network & PRU-ICSS sections doesn't follow sphinx convention","am64xx-evm",""
    "LCPD-38689","Linux benchmarks: add context to Boot-time measurement","am62axx_sk-fs,am62pxx_sk-fs,am62xx_lp_sk-fs,am64xx-evm,am654x-evm",""
    "LCPD-38688","RT Linux benchmarks: add histogram for cyclic test","am62axx_sk-fs,am62pxx_sk-fs,am62xx_lp_sk-fs,am62xx_sk-fs,am64xx-evm",""

--- a/source/linux/Foundational_Components/U-Boot/UG-QSPI.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-QSPI.rst
@@ -23,6 +23,34 @@ controllers work only in master mode.
    | AM64x      | OSPI NOR   | :file:`drivers/spi/cadence_qspi.c` |
    +------------+------------+------------------------------------+
 
+   .. important::
+
+      The BCDMA channel[0] is being allocated for read during OSPI NOR boot.
+      Currently, OSPI NOR boot fails in AM64x-EVM as the 'main_bcdma' node
+      is not passed in FDT to the early boot stage. Hence, user can apply the
+      following patch to add 'bootph-all' property to 'main_bcdma' node.
+
+      This issue (Record ID: LCPD-42226) has been listed in the :ref:`Known Issues <known-issues>`
+
+      .. code-block:: diff
+
+         diff --git a/arch/arm/dts/k3-am642-evm-u-boot.dtsi b/arch/arm/dts/k3-am642-evm-u-boot.dtsi
+         index 5d7cbe0477c3..e30e6cd63dd9 100644
+         --- a/arch/arm/dts/k3-am642-evm-u-boot.dtsi
+         +++ b/arch/arm/dts/k3-am642-evm-u-boot.dtsi
+         @@ -121,6 +121,10 @@
+            bootph-all;
+         };
+
+         +&main_bcdma {
+         +	bootph-all;
+         +};
+         +
+         &main_pktdma {
+            bootph-all;
+         };
+
+
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
    +-------------+------------+------------------------------------+


### PR DESCRIPTION
Add the OSPI NOR Boot failure in AM64x-EVM as a known issue and give a workaround for the same.