### PR TITLE
fix(PRU-ICSS): Fix broken links and switch to https

### DIFF
--- a/source/common/PRU-ICSS/Getting_Started_with_PSSP.rst
+++ b/source/common/PRU-ICSS/Getting_Started_with_PSSP.rst
@@ -3,8 +3,6 @@
 Getting Started with PRU Software Support Package
 =================================================
 
-.. http://processors.wiki.ti.com/index.php/PRU-ICSS_Getting_Started_Guide
-
 .. rubric:: Overview
    :name: overview-pruss-getting-started
 
@@ -35,7 +33,7 @@ contains:
 .. rubric:: Things to Obtain
    :name: things-to-obtain
 
--  `Code Composer Studio <http://processors.wiki.ti.com/index.php/Download_CCS>`__
+-  `Code Composer Studio <https://www.ti.com/tool/CCSTUDIO>`__
 -  `PRU Code Generation
    Tools <https://www.ti.com/tool/PRU-CGT>`__
    (you can also get these tools through the CCS App Center)

--- a/source/common/PRU-ICSS/Header_Files.rst
+++ b/source/common/PRU-ICSS/Header_Files.rst
@@ -3,8 +3,6 @@
 Header Files
 ============
 
-.. http://processors.wiki.ti.com/index.php/PRU-ICSS_Header_Files
-
 .. rubric:: Introduction
 
 The header files for the PRU-ICSS were written in such a way so as to
@@ -12,7 +10,7 @@ sit on top of the memory-mapped registers. They can be directly linked
 to that address range via the Linker Command File, but in the existing
 examples the header files are accessed via the Constant Table registers. The
 process of using cregister attributes to link header files to an address range
-through the Constant Table registers is described in the `PRU Optimizing C/C++ Compiler User's Guide <http://ti.com/lit/pdf/spruhv7>`__.
+through the Constant Table registers is described in the `PRU Optimizing C/C++ Compiler User's Guide <https://ti.com/lit/pdf/spruhv7>`__.
 Information on cregisters are in the "Type
 Attributes" section. Information on the near and far keywords used in
 the current examples can be found in the section "The near and far Keywords".
@@ -30,7 +28,7 @@ the need to do bit-masking at the register level.
    :name: using-the-headers
 
 The process of using the headers is described in more detail in the
-"Type Attributes" section of the `PRU Optimizing C/C++ Compiler User's Guide <http://ti.com/lit/pdf/spruhv7>`__.
+"Type Attributes" section of the `PRU Optimizing C/C++ Compiler User's Guide <https://ti.com/lit/pdf/spruhv7>`__.
 
 In order to tie the structures to the appropriate Constant Table
 register we have to use a special trick with the PRU Code Generation

--- a/source/common/PRU-ICSS/Overview.rst
+++ b/source/common/PRU-ICSS/Overview.rst
@@ -71,9 +71,9 @@ Getting Started Information
 
 Detailed information for getting started with PRU development can be found here:
 
-`PRU-ICSS / PRU_ICSSG Getting Starting Guide on Linux <http://www.ti.com/lit/pdf/sprace9>`__
+`PRU-ICSS / PRU_ICSSG Getting Starting Guide on Linux <https://www.ti.com/lit/pdf/sprace9>`__
 
-`PRU-ICSS / PRU_ICSSG Getting Started Guide on TI-RTOS <http://www.ti.com/lit/pdf/sprach5>`__
+`PRU-ICSS / PRU_ICSSG Getting Started Guide on TI-RTOS <https://www.ti.com/lit/pdf/sprach5>`__
 
 :ref:`getting_started_with_pssp`
 
@@ -93,14 +93,14 @@ Manuals (TRMs).
 PRU Differences Between Devices
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`PRU-ICSS / PRU_ICSSG Feature Comparison Across Devices <http://www.ti.com/lit/sprac90>`__
+`PRU-ICSS / PRU_ICSSG Feature Comparison Across Devices <https://www.ti.com/lit/sprac90>`__
 
-`PRU-ICSS / PRU_ICSSG Migration Guide <http://www.ti.com/lit/spracj8>`__
+`PRU-ICSS / PRU_ICSSG Migration Guide <https://www.ti.com/lit/spracj8>`__
 
 Miscellaneous
 ^^^^^^^^^^^^^
 
-`PRU Read Latencies <http://www.ti.com/lit/sprace8>`__
+`PRU Read Latencies <https://www.ti.com/lit/sprace8>`__
 
 |
 
@@ -131,14 +131,14 @@ PRU C Compiler
 PRU C compiler is available for download through the Code Composer Studio (CCS)
 App Center, or through the `PRU-CGT page <https://www.ti.com/tool/PRU-CGT>`__.
 
-`PRU Optimizing C/C++ Compiler User's Guide <http://www.ti.com/lit/pdf/spruhv7>`__
+`PRU Optimizing C/C++ Compiler User's Guide <https://www.ti.com/lit/pdf/spruhv7>`__
 
-`PRU Assembly Language Tools User's Guide <http://www.ti.com/lit/pdf/spruhv6>`__
+`PRU Assembly Language Tools User's Guide <https://www.ti.com/lit/pdf/spruhv6>`__
 
 PRU Assembly Instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`PRU Assembly Instruction Guide <http://www.ti.com/lit/pdf/spruij2>`__
+`PRU Assembly Instruction Guide <https://www.ti.com/lit/pdf/spruij2>`__
 
 
 |
@@ -182,7 +182,7 @@ Information about specific components of PRU projects can be found at
 :ref:`pru_resource_tables`, :ref:`pru_intc_configuration`, and
 :ref:`pru_header_files`.
 
-`PRU-ICSS / PRU_ICSSG Migration Guide <http://www.ti.com/lit/spracj8>`__
+`PRU-ICSS / PRU_ICSSG Migration Guide <https://www.ti.com/lit/spracj8>`__
 
 |
 
@@ -317,7 +317,7 @@ The Beagleboard community discusses PRU `here <https://forum.beagleboard.org/>`_
 
 :ref:`pru_overview_faq`
 
-`FAQ for PRU-ICSS Industrial Software <http://software-dl.ti.com/processor-industrial-sw/esd/docs/indsw/FAQ_Sitara_Industrial.html>`__
+`FAQ for PRU-ICSS Industrial Software <https://software-dl.ti.com/processor-industrial-sw/esd/docs/indsw/FAQ_Sitara_Industrial.html>`__
 
 |
 
@@ -356,7 +356,7 @@ Can I develop my own industrial protocols on the PRU-ICSS?
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 TI only supports the industrial protocols enabled in the IDK (Industrial
-Development Kit) available on `ti.com <http://www.ti.com>`__.
+Development Kit) available on `ti.com <https://www.ti.com>`__.
 Independent development of industrial protocols using the MII_RT and
 IEP (Industrial Ethernet Peripheral) blocks in not supported or enabled.
 
@@ -507,7 +507,7 @@ On devices with multiple PRU-ICSSs, how can one PRU-ICSS interrupt the other?
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 Check the PRU-ICSS System Event table in your device-specific reference
-manual on `ti.com <http://www.ti.com>`__. There will be a System event
+manual on `ti.com <https://www.ti.com>`__. There will be a System event
 tied to a PRU Host event from the other PRU-ICSS. By generating an
 interrupt of this Host, one PRU-ICSS can interrupt another PRU-ICSS. The
 other PRU-ICSS will detect this interrupt as the corresponding System

--- a/source/common/PRU-ICSS/PRU-Cape-Building-Demos.rst
+++ b/source/common/PRU-ICSS/PRU-Cape-Building-Demos.rst
@@ -42,7 +42,7 @@ required:
    Code <https://git.ti.com/pru-software-support-package/pru-software-support-package/trees/master/pru_cape>`__
    *(available in the pru\_cape/pru\_demo and pru\_cape/pru\_fw
    directories of the PRU Software Support Package)*
--  `AM335x Starterware <http://www.ti.com/tool/starterware-sitara>`__
+-  `AM335x Starterware <https://www.ti.com/tool/starterware-sitara>`__
 -  `CCSv6 <https://software-dl.ti.com/ccs/esd/documents/ccs_downloads.html>`__
 -  PRU Code Generation Tools (through CCS App Center)
 

--- a/source/common/PRU-ICSS/PRU-Cape-Getting-Started-Guide.rst
+++ b/source/common/PRU-ICSS/PRU-Cape-Getting-Started-Guide.rst
@@ -35,9 +35,9 @@ started demo are listed below.
 .. rubric::  Hardware
 
 -  BeagleBone or BeagleBone Black `(Can be ordered from
-   beagleboard.org) <http://beagleboard.org/Products>`__
+   beagleboard.org) <https://www.beagleboard.org/boards/beaglebone-black>`__
 -  BeagleBone PRU Cape `(Can be ordered from
-   ti.com) <http://www.ti.com/tool/PRUCAPE>`__
+   ti.com) <https://www.ti.com/tool/PRUCAPE>`__
 -  MicroSD card formatted as FAT32
 -  USB cable to power BeagleBone or BeagleBone Black
 -  FTDI cable for BeagleBone Black serial debug port *(not required for

--- a/source/common/PRU-ICSS/PRU-Cape-Hardware-User-Guide.rst
+++ b/source/common/PRU-ICSS/PRU-Cape-Hardware-User-Guide.rst
@@ -39,7 +39,7 @@ The PRU Cape is shown below.
 Schematics/Design/Errata Files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`Design Files <http://www.ti.com/tool/prucape>`__ (located under
+`Design Files <https://www.ti.com/tool/prucape>`__ (located under
 Technical Documents), includes:
 
 - Schematic

--- a/source/common/PRU-ICSS/PRU-Getting-Started-Labs.rst
+++ b/source/common/PRU-ICSS/PRU-Getting-Started-Labs.rst
@@ -125,10 +125,10 @@ Started Labs:
     The notation **<PSSP_PATH>** will be used throughout the labs to reference
     the PSSP installation location.
 
-* `Code Composer Studio (CCS) <http://www.ti.com/tool/CCSTUDIO>`__
+* `Code Composer Studio (CCS) <https://www.ti.com/tool/CCSTUDIO>`__
 
 * `PRU Code Generation
-  Tools <http://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU>`__
+  Tools <https://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU>`__
   (also available through the CCS App Center)
 
 .. note::

--- a/source/common/PRU-ICSS/PRU-Hands-on-Labs.rst
+++ b/source/common/PRU-ICSS/PRU-Hands-on-Labs.rst
@@ -36,8 +36,8 @@ Hardware
 """"""""
 
 -  AM335x Beaglebone Black - `Order
-   Now <http://beagleboard.org/Products>`__
--  BeagleBone PRU Cape - `Order Now <http://www.ti.com/tool/PRUCAPE>`__
+   Now <https://www.beagleboard.org/boards/beaglebone-black>`__
+-  BeagleBone PRU Cape - `Order Now <https://www.ti.com/tool/PRUCAPE>`__
 -  5V power supply *or* USB cable connection
 -  JTAG emulator
 -  FTDI cable
@@ -45,7 +45,7 @@ Hardware
 Software
 """"""""
 
--  `Linux Processor SDK <http://www.ti.com/tool/PROCESSOR-SDK-AM335X>`__
+-  `Linux Processor SDK <https://www.ti.com/tool/PROCESSOR-SDK-AM335X>`__
    installed. This lab assumes the latest Linux Processor SDK is
    installed in /home/sitara. If you use a different location please
    modify the below steps accordingly.
@@ -62,7 +62,7 @@ Software
    a different location please modify the steps below.
 -  `CCSv6 <https://www.ti.com/tool/download/CCSTUDIO>`__
 -  `PRU Code Generation
-   Tools <http://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU>`__
+   Tools <https://software-dl.ti.com/codegen/non-esd/downloads/download.htm#PRU>`__
    (also available through the CCS App Center)
 
 |

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/AM65X_PRU_ICSSG_boards.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/AM65X_PRU_ICSSG_boards.rst
@@ -4,7 +4,7 @@
 
 |
 
-.. rubric:: `AM65x evaluation module (EVM) <http://www.ti.com/tool/TMDX654GPEVM>`__
+.. rubric:: `AM65x evaluation module (EVM) <https://www.ti.com/tool/TMDX654GPEVM>`__
 
 The AM65x Evaluation Module provides a platform to quickly start evaluation of Sitara™ Arm® Cortex®-A53 AM65x Processors (AM6548, AM6546, AM6528, AM6527, AM6526) and accelerate development for HMI, networking, patient monitoring, and other industrial applications. It is a development platform based on the quad core Cortex-A53, dual Cortex-R5F processor that is integrated with ample connectivity such as PCIe, USB 3.0/2.0, Gigabit Ethernet,  PRU_ICSSG Ethernet, etc.
 
@@ -13,7 +13,7 @@ On this platform one CPSW Ethernet port and two ICSSG2 Ethernet ports are availa
 .. Image:: /images/Am65x_GP_EVM.jpg
 
 .. rubric:: `AM65x industrial development kit
-     (IDK) <http://www.ti.com/tool/TMDX654IDKEVM>`__
+     (IDK) <https://www.ti.com/tool/TMDX654IDKEVM>`__
 
 The AM65x Industrial Development Kit (IDK) is a development platform for evaluating the industrial communication and control capabilities of Sitara AM65x processors for applications in factory automation, drives, robotics, grid infrastructure, and more. AM65x processors include three PRU_ICSSG (Programmable Real-time Unit for Industrial Communications) sub-systems which can be used for gigabit industrial Ethernet protocols such as Profinet, EtherCAT, Ethernet/IP, and others.
 

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU-ICSS_Ethernet.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU-ICSS_Ethernet.rst
@@ -23,7 +23,7 @@ Archives section at the bottom of this page.
 .. Image:: /images/Am335x_ice.jpg
 
 .. rubric:: `AM3359 Industrial Communications Engine
-   (ICE) <http://www.ti.com/tool/tmdsice3359>`__
+   (ICE) <https://www.ti.com/tool/tmdsice3359>`__
    :name: am3359-industrial-communications-engine-ice
 
 The AM3359 Industrial Communications Engine (ICE) is a development
@@ -40,7 +40,7 @@ external components and with best in class low power performance.
 .. Image:: /images/Am437x_idk_500x300.jpg
 
 .. rubric:: `AM437x Industrial Development Kit
-   (IDK) <http://www.ti.com/tool/tmdsidk437x>`__
+   (IDK) <https://www.ti.com/tool/tmdsidk437x>`__
    :name: am437x-industrial-development-kit-idk
 
 The AM437x Industrial Development Kit (IDK) is an application
@@ -59,7 +59,7 @@ with best in class low power performance.
 .. Image:: /images/Am571x_idk.JPG
 
 .. rubric:: `AM571x Industrial Development Kit
-   (IDK) <http://www.ti.com/tool/TMDXIDK5718>`__
+   (IDK) <https://www.ti.com/tool/TMDXIDK5718>`__
    :name: am571x-industrial-development-kit-idk
 
 The AM571x IDK is a standalone test, development, and evaluation module
@@ -90,7 +90,7 @@ industrial communication network.
 .. Image:: /images/Am572x_idk.PNG
 
 .. rubric:: `AM572x Industrial Development Kit
-   (IDK) <http://www.ti.com/tool/TMDXIDK5728>`__
+   (IDK) <https://www.ti.com/tool/TMDXIDK5728>`__
    :name: am572x-industrial-development-kit-idk
 
 The AM572x Industrial Development Kit (IDK) is a development platform
@@ -114,7 +114,7 @@ subsystems.
 .. Image:: /images/K2g_ice.PNG
 
 .. rubric:: `K2G Industrial Communication Engine
-   (ICE) <http://www.ti.com/tool/k2gice>`__
+   (ICE) <https://www.ti.com/lit/pdf/spruie3>`__
    :name: k2g-industrial-communication-engine-ice
 
 The K2G Industrial Communications Engine (ICE) enables 66AK2Gx processor
@@ -201,26 +201,26 @@ Here are the steps needed to test out the new Ethernet interfaces:
 -  Get your hands on one of the industrial boards
 
    -  `AM3359 Industrial Communications Engine
-      (ICE) <http://www.ti.com/tool/tmdsice3359>`__
+      (ICE) <https://www.ti.com/tool/tmdsice3359>`__
    -  `AM437x Industrial Development Kit
-      (IDK) <http://www.ti.com/tool/tmdsidk437x>`__
+      (IDK) <https://www.ti.com/tool/tmdsidk437x>`__
    -  `AM571x Industrial Development Kit
-      (IDK) <http://www.ti.com/tool/TMDXIDK5718>`__
+      (IDK) <https://www.ti.com/tool/TMDXIDK5718>`__
    -  `AM572x Industrial Development Kit
-      (IDK) <http://www.ti.com/tool/TMDXIDK5728>`__
+      (IDK) <https://www.ti.com/tool/TMDXIDK5728>`__
    -  `K2G Industrial Communication Engine
-      (ICE) <http://www.ti.com/tool/k2gice>`__
+      (ICE) <https://www.ti.com/lit/pdf/spruie3>`__
 
 -  Download the Linux Processor SDK (v3.1.0.6 or higher)
 
    -  `Linux Processor SDK for AM335x
-      devices <http://www.ti.com/tool/PROCESSOR-SDK-AM335x>`__
+      devices <https://www.ti.com/tool/PROCESSOR-SDK-AM335x>`__
    -  `Linux Processor SDK for AM437x
-      devices <http://www.ti.com/tool/PROCESSOR-SDK-AM437X>`__
+      devices <https://www.ti.com/tool/PROCESSOR-SDK-AM437X>`__
    -  `Linux Processor SDK for AM57x
-      devices <http://www.ti.com/tool/PROCESSOR-SDK-AM57X>`__
+      devices <https://www.ti.com/tool/PROCESSOR-SDK-AM57X>`__
    -  `Linux Processor SDK for K2G
-      devices <http://www.ti.com/tool/PROCESSOR-SDK-K2G>`__
+      devices <https://www.ti.com/tool/PROCESSOR-SDK-K2G>`__
 
 -  Run the 'create SD card' script provided in the SDK to create a
    bootable SD card

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet.rst
@@ -86,8 +86,8 @@ Device tree bindings
 
 The DT bindings description can be found at:
 
-| `Documentation/devicetree/bindings/net/ti,icssg-prueth.txt <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt?h=ti-linux-5.10.y>`__
-| `Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml?h=ti-linux-5.10.y>`__
+| `Documentation/devicetree/bindings/net/ti,icssg-prueth.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,icssg-prueth.yaml?h=ti-linux-6.6.y>`__
+| `Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml?h=ti-linux-6.6.y>`__
 |
 
 User guide
@@ -606,7 +606,7 @@ Example oc.cfg for OC,
 where **eth1** is the intended PRU-ICSSG Ethernet port over which the OC
 functionality is provided.
 
-See `The Linux PTP Project <http://linuxptp.sourceforge.net#>`__ for
+See `The Linux PTP Project <https://linuxptp.sourceforge.net#>`__ for
 more details about linuxptp in general and `ptp4l(8) - Linux man
 page <https://man.cx/ptp4l>`__ about ptp4l configurations in particular.
 

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_sr10.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_sr10.rst
@@ -514,7 +514,7 @@ functionality is provided.
 On AM65X SR1.0 ICSS-G both IEP0 and IEP1 are available and assigned to the corresponding PRU Ethernet ports:
 IEP0 - MII0 and IEP1 - MII1, which require to use jbod mode in case of boundary cock with external synchronization (phc2sys).
 
-See `The Linux PTP Project <http://linuxptp.sourceforge.net#>`__ for
+See `The Linux PTP Project <https://linuxptp.sourceforge.net#>`__ for
 more details about linuxptp in general and `ptp4l(8) - Linux man
 page <https://man.cx/ptp4l>`__ about ptp4l configurations in particular.
 

--- a/source/linux/Foundational_Components/PRU-ICSS/RPMsg_Quick_Start_Guide.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/RPMsg_Quick_Start_Guide.rst
@@ -294,7 +294,7 @@ Booting the Board and Testing RPMsg
 
    -  In the case of the BeagleBone Black you will need an FTDI to TTL
       cable like the one found
-      `here <http://elinux.org/Beagleboard:BeagleBone_Black_Accessories#Serial_Debug_Cables>`__
+      `here <https://elinux.org/Beagleboard:BeagleBone_Black_Accessories#Serial_Debug_Cables>`__
 
 #. Find out which tty device on your Ubuntu host computer corresponds to
    your evaluation board


### PR DESCRIPTION
The PRU-ICSS files have have many references of http protocol for external URLs. Fix this by switching to equivalent https URLs.

Fix the broken links as well by switching to correct URLs.