### PR TITLE
fix(Kernel_Drivers): Update kernel drivers for Networking

### DIFF
--- a/configs/AM65X/AM65X_linux_toc.txt
+++ b/configs/AM65X/AM65X_linux_toc.txt
@@ -53,8 +53,9 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/DCAN
 linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7
 linux/Foundational_Components/Kernel/Kernel_Drivers/GPIO
 linux/Foundational_Components/Kernel/Kernel_Drivers/I2C
-linux/Foundational_Components/Kernel/Kernel_Drivers/Network/PRUSS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW2g
+linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-EST
+linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PWM

--- a/source/linux/Foundational_Components_Kernel_Drivers.rst
+++ b/source/linux/Foundational_Components_Kernel_Drivers.rst
@@ -27,6 +27,7 @@ Kernel Drivers
    Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_Non_Offload
    Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_Offload
    Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-Ethernet
+   Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW2g
    Foundational_Components/Kernel/Kernel_Drivers/Network/NETCONF-YANG
    Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
    Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane


### PR DESCRIPTION
PRUSS is only appliable for legacy devices (AM57x, AM43x, AM33x) but it is included for AM65x as well. Drop PRUSS from AM65X_linux_toc as the documentation related to PRU-ICSSG on AM65x is covered by PRU-ICSSG_Ethernet.rst file.

AM65x has CPSW2g and the AM65X_linux_toc file includes CPSW2g however CPSW2g is not added in the kernel drivers and as a result AM65x documentation doesn't show CPSW. Add CPSW2g to kernel drivers.