### PR TITLE
chore(ci): disable color for rstcheck

### DIFF
--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Run rstcheck
         run: |
+          # Disable color output
+          export NO_COLOR=true
+
           # Run the test
           bin/delta.sh -a master -b pr -- rstcheck -r source/
 


### PR DESCRIPTION
Disable the color output for rstcheck so the summary messages are readable in the event of a traceback.