### PR TITLE
feat: debian: Add guide to enable Wifi

### DIFF
--- a/configs/AM62PX/AM62PX_debian_tags.py
+++ b/configs/AM62PX/AM62PX_debian_tags.py
@@ -15,7 +15,7 @@ master_doc = 'devices/AM62PX/debian/index'
 
 # AM62x RTOS docs are not in this project, rather referenced externally,
 # so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'example_code', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'linux']
+exclude_patterns = ['android', 'example_code', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX']
 
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'

--- a/configs/AM62PX/AM62PX_debian_toc.txt
+++ b/configs/AM62PX/AM62PX_debian_toc.txt
@@ -7,5 +7,7 @@ debian/Overview/Overview_Technical_Support
 devices/AM62PX/debian/Getting_Started_Guide
 debian/Building_Debian_Image
 debian/Building_Debian_Packages
+debian/How_to_Guides/index_How_to_Guides
+linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux
 debian/Demo_User_Guides/index_Demos
 debian/Demo_User_Guides/Chromium_Browser

--- a/configs/AM62X/AM62X_debian_tags.py
+++ b/configs/AM62X/AM62X_debian_tags.py
@@ -15,7 +15,7 @@ master_doc = 'devices/AM62X/debian/index'
 
 # AM62x RTOS docs are not in this project, rather referenced externally,
 # so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'example_code', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'linux']
+exclude_patterns = ['android', 'example_code', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX']
 
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'

--- a/configs/AM62X/AM62X_debian_toc.txt
+++ b/configs/AM62X/AM62X_debian_toc.txt
@@ -7,5 +7,7 @@ debian/Overview/Overview_Technical_Support
 devices/AM62X/debian/Getting_Started_Guide
 debian/Building_Debian_Image
 debian/Building_Debian_Packages
+debian/How_to_Guides/index_How_to_Guides
+linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux
 debian/Demo_User_Guides/index_Demos
 debian/Demo_User_Guides/Chromium_Browser

--- a/source/debian/How_to_Guides/index_How_to_Guides.rst
+++ b/source/debian/How_to_Guides/index_How_to_Guides.rst
@@ -1,0 +1,11 @@
+.. include:: /_replacevars.rst
+
+#############
+How to Guides
+#############
+
+.. toctree::
+   :maxdepth: 1
+
+   /linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux
+

--- a/source/devices/AM62PX/debian/index.rst
+++ b/source/devices/AM62PX/debian/index.rst
@@ -18,6 +18,7 @@ Debian Developer's Guide
    Getting_Started_Guide
    /debian/Building_Debian_Image
    /debian/Building_Debian_Packages
+   /debian/How_to_Guides/index_How_to_Guides
    /debian/Demo_User_Guides/index_Demos
 
 |

--- a/source/devices/AM62X/debian/index.rst
+++ b/source/devices/AM62X/debian/index.rst
@@ -18,6 +18,7 @@ Debian Developer's Guide
    Getting_Started_Guide
    /debian/Building_Debian_Image
    /debian/Building_Debian_Packages
+   /debian/How_to_Guides/index_How_to_Guides
    /debian/Demo_User_Guides/index_Demos
 
 |

--- a/source/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.rst
+++ b/source/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.rst
@@ -81,12 +81,23 @@ Connect to Wi-Fi
 Using scripts provided in the SDK makes connecting to an Access Point or router straightforward.
 The following are steps to connect to a WPA password-secured Access Point. 
 
-.. code-block:: console
+.. ifconfig:: CONFIG_sdk in ('SITARA')
 
-    cd /usr/share/cc33xx
-    ./sta_start.sh
-    ./sta_connect.sh -s WPA-PSK -n <SSID> -p <PASSWORD>
-    udhcpc -i wlan0
+    .. code-block:: console
+
+        cd /usr/share/cc33xx
+        ./sta_start.sh
+        ./sta_connect.sh -s WPA-PSK -n <SSID> -p <PASSWORD>
+        udhcpc -i wlan0
+
+.. ifconfig:: CONFIG_sdk in ('DebianSDK')
+
+    .. code-block:: console
+
+        cd /usr/share/cc33xx
+        bash ./sta_start.sh
+        bash ./sta_connect.sh -s WPA-PSK -n <SSID> -p <PASSWORD>
+        udhcpc -i wlan0
 
 For more information on the Wi-Fi capabilities of the CC33xx devices, please 
 see the documentation that can be found in the `CC33xx SDK <https://www.ti.com/tool/CC33XX-SOFTWARE>`_.

--- a/source/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.rst
+++ b/source/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.rst
@@ -36,7 +36,14 @@ M.2 card is held down by the screw. The end result should be as shown in the ima
 Enable DT Overlay for M.2-CC33x1
 ********************************
 
-After flashing the SD card with the :file:`tisdk-default-image`, mount the SD card onto a host computer, if not done already.
+.. ifconfig:: CONFIG_sdk in ('SITARA')
+
+    After flashing the SD card with the :file:`tisdk-default-image`, mount the SD card onto a host computer, if not done already.
+
+.. ifconfig:: CONFIG_sdk in ('DebianSDK')
+
+    After flashing the SD card with the :file:`tisdk-debian-trixie-image`, mount the SD card onto a host computer, if not done already.
+
 On the boot partition of the SD card, add one of the following variables, corresponding to the starter kit,
 into the :file:`uEnv.txt` file. This will let u-boot enable the m.2-cc33x1 devicetree overlay. The :file:`uEnv.txt` file can be found on the ``boot``
 partition of the SD card. 


### PR DESCRIPTION
Support was recently added to Debian for OOB Wifi experience using CC33xx cards. So add documentation for it.