### PR TITLE
Lpm documentation update

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -49,6 +49,7 @@ What's new
   - Important Bug Fixes on top of Processor SDK 10.00.07.04 Release
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here :ref:`RT Interrupt Latencies <RT-linux-performance>`
   - Support for streaming from OV2312 camera with `DS90UB954-Q1EVM <https://www.ti.com/tool/DS90UB954-Q1EVM>`_
+  - Power Management: :ref:`I/O Only Plus DDR <pm_io_only_plus_ddr>` mode
 
 **Component version:**
 

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -49,8 +49,8 @@ What's new
   - LTS Stable Kernel update to 6.6.58
   - Important Bug Fixes on top of Processor SDK 10.00.07.04 Release
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here - :ref:`RT Interrupt Latencies <RT-linux-performance>`
-  - Power Management: DeepSleep, MCU-Only and Partial IO mode - :ref:`Power Management Overview <Power-Management>`
   - Support for streaming from multiple 0V5640 cameras with `Arducam V3Link (Fusion Mini) <https://www.arducam.com/product/arducam-v3link-camera-kit-for-ti-development-boards/>`_
+  - Power Management: :ref:`I/O Only Plus DDR <pm_io_only_plus_ddr>` mode
 
 
 **Component version:**

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -48,8 +48,6 @@ What's new
   - LTS Stable Kernel update to 6.6.58
   - Important Bug Fixes on top of Processor SDK 10.00.07.04 Release
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here - :ref:`RT Interrupt Latencies <RT-linux-performance>`
-  - Power Management: DeepSleep, MCU-Only and Partial IO mode - :ref:`Power Management Overview <Power-Management>`
-
 
 **Component version:**
 

--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -13,202 +13,18 @@ device. If your application requires inactive power management, you must determi
 low power mode described below satisfies your requirements. Each mode must be evaluated
 based on power consumption and latency (the time it takes to wakeup to Active mode) requirements. Specific
 values are detailed in the device-specific data sheet. As part of this SDK offering,
-Texas Instruments has added support for the following low power modes:
+Texas Instruments has added support for the following low power modes (ordered from lowest power consumption
+to highest power consumption):
 
-#. Deep Sleep
-#. MCU Only
 #. Partial I/O
 #. I/O Only Plus DDR
+#. Deep Sleep
+#. MCU Only
 
 TI SDK 10.0 (ti-linux-6.6.y kernel and 10.0 DM firmware) adds support for
 an updated LPM Software Architecture that seamlessly manages the various
 Suspend-to-RAM modes supported by AM62 family of devices. More details about
 this architecture can be found in :ref:`LPM constraints framework<pm_constraints_fwk>` section.
-
-**********
-Deep Sleep
-**********
-
-Deep Sleep AKA Suspend-to-RAM is a low-power mode that allows an embedded device
-to retain its state in RAM while the processor is turned off.
-This can save a significant amount of power, especially in devices that are
-battery-powered.
-
-The benefits of using deep sleep in embedded devices:
-
-#. Faster wake-up: devices can wake up from this low-power state much faster than
-   a complete power cycle.
-#. Better efficiency: deep sleep can help to improve the efficiency of embedded devices by
-   reducing the amount of time that the processor is idle. This is because the processor can
-   be kept in a low-power state when it is not needed.
-
-In order to enter deep sleep, use the following command:
-
-.. ifconfig:: CONFIG_part_variant in ('AM62X')
-
-   .. code-block:: console
-
-      root@am62xx-evm:~# echo mem > /sys/power/state
-      [  444.719520] PM: suspend entry (deep)
-      [  444.723374] Filesystems sync: 0.000 seconds
-      [  444.751309] Freezing user space processes
-      [  444.756923] Freezing user space processes completed (elapsed 0.001 seconds)
-      [  444.763924] OOM killer disabled.
-      [  444.767141] Freezing remaining freezable tasks
-      [  444.772908] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
-      [  444.780328] printk: Suspending console(s) (use no_console_suspend to debug)
-      [  444.796853] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
-      [  444.797037] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
-      [  444.805604] omap8250 2800000.serial: PM domain pd:146 will not be powered off
-      [  444.806188] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
-      [  444.816592] remoteproc remoteproc0: stopped remote processor 5000000.m4fss
-      [  444.820627] Disabling non-boot CPUs ...
-      [  444.822859] psci: CPU1 killed (polled 0 ms)
-      [  444.826567] psci: CPU2 killed (polled 0 ms)
-      [  444.830170] psci: CPU3 killed (polled 0 ms)
-
-.. ifconfig:: CONFIG_part_variant in ('AM62AX' , 'AM62PX')
-
-   .. code-block:: console
-
-      root@<machine>:~# echo mem > /sys/power/state
-      [  230.181404] PM: suspend entry (deep)
-      [  230.185406] Filesystems sync: 0.000 seconds
-      [  230.219094] Freezing user space processes
-      [  230.224495] Freezing user space processes completed (elapsed 0.001 seconds)
-      [  230.231506] OOM killer disabled.
-      [  230.234736] Freezing remaining freezable tasks
-      [  230.240432] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
-      [  230.247825] printk: Suspending console(s) (use no_console_suspend to debug)
-      [  230.266309] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
-      [  230.266456] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
-      [  230.273953] omap8250 2800000.serial: PM domain pd:146 will not be powered off
-      [  230.274450] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
-      [  230.284177] remoteproc remoteproc1: stopped remote processor 79000000.r5f
-      [  230.287440] Disabling non-boot CPUs ...
-      [  230.289569] psci: CPU1 killed (polled 0 ms)
-      [  230.292413] psci: CPU2 killed (polled 4 ms)
-      [  230.295457] psci: CPU3 killed (polled 0 ms)
-
-This partially indicates that linux has finished it's deep sleep sequence.
-For further confirmation, one can take a look at the PMIC_LPM_EN pin on the EVM
-(after programming the PMCTRL_SYS register (0x43018080) to 0x15). Here, if the pin is 3.3V when active and
-0V when in deep sleep.
-
-.. note::
-
-   The system will enter deep sleep mode only if DM selects it based on existing constraints.
-
-Refer to the :ref:`Wakeup Sources<pm_wakeup_sources>` section for information on how to wakeup the device from
-Deep Sleep mode using one of the supported wakeup sources.
-
-********
-MCU Only
-********
-
-.. _pm_mcu_only:
-
-Similar to Deep Sleep, with the major distinction being that the MCU core is kept alive to run applications.
-The benefits of using MCU Only mode:
-
-#. Low power consumption: MCU Only mode can save a significant amount of power, especially in battery-powered
-   devices. This is because The rest of the SoC status is the same as Deep Sleep and DDR is in self-refresh.
-#. Run background tasks: This mode can be used to run background tasks that do not require the full power of the system.
-   For example, you could use the firmware on the MCU core to run a watchdog timer, a sensor polling loop,
-   or a network communication task.
-#. Respond to interrupts: This allows the system to still respond to external events, while it is in a low-power state.
-
-To enter MCU Only mode, set :code:`100 usec` resume latency for CPU0 in linux:
-
-.. code-block:: console
-
-   root@<machine>:~# echo 100 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
-
-.. important::
-
-        Note that the step below to set "enabled" won't work for SDK 10.00
-        and will be supported in future release
-
-.. ifconfig:: CONFIG_part_variant in ('AM62X')
-
-   To enter MCU Only mode, enable MCU M4 core as a wakeup source in linux:
-
-   .. code-block:: console
-
-      root@am62xx-evm:~# echo enabled > /sys/bus/platform/devices/5000000.m4fss/power/wakeup
-
-.. ifconfig:: CONFIG_part_variant in ('AM62AX', 'AM62PX')
-
-   To enter MCU Only mode, enable MCU R5 core as a wakeup source in linux:
-
-   .. code-block:: console
-
-      root@<machine>:~# echo enabled > /sys/bus/platform/devices/79000000.r5f/power/wakeup
-
-Now, the SoC can be suspended using the following command:
-
-.. code-block:: console
-
-    root@<machine>:~# rtcwake -s 5 -m mem
-    rtcwake: wakeup from "mem" using /dev/rtc0 at Thu Jan  1 00:01:02 1970
-    [   45.548480] PM: suspend entry (deep)
-    [   45.552187] Filesystems sync: 0.000 seconds
-    [   45.566606] Freezing user space processes
-    [   45.572093] Freezing user space processes completed (elapsed 0.001 seconds)
-    [   45.579083] OOM killer disabled.
-    [   45.582309] Freezing remaining freezable tasks
-    [   45.587984] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
-    [   45.595432] printk: Suspending console(s) (use no_console_suspend to debug)
-    [   45.627136] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
-    [   45.640758] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
-    [   45.648341] omap8250 2800000.serial: PM domain pd:146 will not be powered off
-    [   45.648892] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
-    [   45.648993] cpu cpu3: ti_sci_suspend: sending max CPU latency=100
-    [   45.649033] ti-sci 44043000.system-controller: ti_sci_cmd_set_latency_constraint: latency: 100: state: 1: ret 0
-    [   45.669270] Disabling non-boot CPUs ...
-    [   45.671353] psci: CPU1 killed (polled 0 ms)
-    [   45.674819] psci: CPU2 killed (polled 0 ms)
-    [   45.676640] psci: CPU3 killed (polled 4 ms)
-    [   45.677311] Enabling non-boot CPUs ...
-    [   45.677632] Detected VIPT I-cache on CPU1
-    [   45.677672] GICv3: CPU1: found redistributor 1 region 0:0x00000000018a0000
-    [   45.677724] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
-    [   45.678694] CPU1 is up
-    [   45.678934] Detected VIPT I-cache on CPU2
-    [   45.678962] GICv3: CPU2: found redistributor 2 region 0:0x00000000018c0000
-    [   45.679002] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
-    [   45.679778] CPU2 is up
-    [   45.680016] Detected VIPT I-cache on CPU3
-    [   45.680045] GICv3: CPU3: found redistributor 3 region 0:0x00000000018e0000
-    [   45.680088] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
-    [   45.680939] CPU3 is up
-    [   45.681332] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
-    [   45.703650] am65-cpsw-nuss 8000000.ethernet: set new flow-id-base 19
-    [   45.719704] am65-cpsw-nuss 8000000.ethernet eth0: PHY [8000f00.mdio:00] driver [TI DP83867] (irq=POLL)
-    [   45.719730] am65-cpsw-nuss 8000000.ethernet eth0: configuring for phy/rgmii-rxid link mode
-    [   46.004264] OOM killer enabled.
-    [   46.007406] Restarting tasks ... done.
-    [   46.012454] random: crng reseeded on system resumption
-    [   46.026923] platform 79000000.r5f: Core is on in resume
-    [   46.032206] platform 79000000.r5f: received echo reply from 79000000.r5f
-    [   46.032262] PM: suspend exit
-
-Once the SoC enters MCU Only mode, the following log should be printed
-on the MCU UART (in most cases it will be /dev/ttyUSB3)
-
-.. code-block:: text
-
-    [IPC RPMSG ECHO] Next MCU mode is 1
-    [IPC RPMSG ECHO] Suspend request to MCU-only mode received
-    [IPC RPMSG ECHO] Press a single key on this terminal to resume the kernel from MCU only mode
-
-.. note::
-
-   The system will enter MCU Only mode only if DM selects it based on existing constraints.
-
-Refer to the :ref:`Wakeup Sources<pm_wakeup_sources>` section for information on how to wakeup the device from
-MCU Only mode using one of the supported wakeup sources.
-
 
 ***********
 Partial I/O
@@ -399,13 +215,13 @@ I/O Only Plus DDR
 
    .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-         For further confirmation, one can take a look at the on board LED LD2 on the SK
-         (LED should turn off).
+      For further confirmation, one can take a look at the on board LED LD2 on the SK
+      (LED should turn off).
 
    .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-         For further confirmation, one can take a look at the on board LED LD1 on the SK
-         (LED should turn off).
+      For further confirmation, one can take a look at the on board LED LD1 on the SK
+      (LED should turn off).
 
    The system has entered I/O Only plus DDR and can be woken up either with an
    activity on the I/O pin programmed for wakeup or key press on wkup_uart0 (third serial port :file:`/dev/ttyUSB2`) or
@@ -414,6 +230,190 @@ I/O Only Plus DDR
    .. note::
 
       The system will enter I/O Only plus DDR mode only if DM selects it based on existing constraints.
+
+**********
+Deep Sleep
+**********
+
+Deep Sleep AKA Suspend-to-RAM is a low-power mode that allows an embedded device
+to retain its state in RAM while the processor is turned off.
+This can save a significant amount of power, especially in devices that are
+battery-powered.
+
+The benefits of using deep sleep in embedded devices:
+
+#. Faster wake-up: devices can wake up from this low-power state much faster than
+   a complete power cycle.
+#. Better efficiency: deep sleep can help to improve the efficiency of embedded devices by
+   reducing the amount of time that the processor is idle. This is because the processor can
+   be kept in a low-power state when it is not needed.
+
+In order to enter deep sleep, use the following command:
+
+.. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+   .. code-block:: console
+
+      root@am62xx-evm:~# echo mem > /sys/power/state
+      [  444.719520] PM: suspend entry (deep)
+      [  444.723374] Filesystems sync: 0.000 seconds
+      [  444.751309] Freezing user space processes
+      [  444.756923] Freezing user space processes completed (elapsed 0.001 seconds)
+      [  444.763924] OOM killer disabled.
+      [  444.767141] Freezing remaining freezable tasks
+      [  444.772908] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
+      [  444.780328] printk: Suspending console(s) (use no_console_suspend to debug)
+      [  444.796853] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
+      [  444.797037] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
+      [  444.805604] omap8250 2800000.serial: PM domain pd:146 will not be powered off
+      [  444.806188] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
+      [  444.816592] remoteproc remoteproc0: stopped remote processor 5000000.m4fss
+      [  444.820627] Disabling non-boot CPUs ...
+      [  444.822859] psci: CPU1 killed (polled 0 ms)
+      [  444.826567] psci: CPU2 killed (polled 0 ms)
+      [  444.830170] psci: CPU3 killed (polled 0 ms)
+
+.. ifconfig:: CONFIG_part_variant in ('AM62AX' , 'AM62PX')
+
+   .. code-block:: console
+
+      root@<machine>:~# echo mem > /sys/power/state
+      [  230.181404] PM: suspend entry (deep)
+      [  230.185406] Filesystems sync: 0.000 seconds
+      [  230.219094] Freezing user space processes
+      [  230.224495] Freezing user space processes completed (elapsed 0.001 seconds)
+      [  230.231506] OOM killer disabled.
+      [  230.234736] Freezing remaining freezable tasks
+      [  230.240432] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
+      [  230.247825] printk: Suspending console(s) (use no_console_suspend to debug)
+      [  230.266309] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
+      [  230.266456] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
+      [  230.273953] omap8250 2800000.serial: PM domain pd:146 will not be powered off
+      [  230.274450] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
+      [  230.284177] remoteproc remoteproc1: stopped remote processor 79000000.r5f
+      [  230.287440] Disabling non-boot CPUs ...
+      [  230.289569] psci: CPU1 killed (polled 0 ms)
+      [  230.292413] psci: CPU2 killed (polled 4 ms)
+      [  230.295457] psci: CPU3 killed (polled 0 ms)
+
+This partially indicates that linux has finished it's deep sleep sequence.
+For further confirmation, one can take a look at the PMIC_LPM_EN pin on the EVM
+(after programming the PMCTRL_SYS register (0x43018080) to 0x15). Here, if the pin is 3.3V when active and
+0V when in deep sleep.
+
+.. note::
+
+   The system will enter deep sleep mode only if DM selects it based on existing constraints.
+
+Refer to the :ref:`Wakeup Sources<pm_wakeup_sources>` section for information on how to wakeup the device from
+Deep Sleep mode using one of the supported wakeup sources.
+
+********
+MCU Only
+********
+
+.. _pm_mcu_only:
+
+Similar to Deep Sleep, with the major distinction being that the MCU core is kept alive to run applications.
+The benefits of using MCU Only mode:
+
+#. Low power consumption: MCU Only mode can save a significant amount of power, especially in battery-powered
+   devices. This is because The rest of the SoC status is the same as Deep Sleep and DDR is in self-refresh.
+#. Run background tasks: This mode can be used to run background tasks that do not require the full power of the system.
+   For example, you could use the firmware on the MCU core to run a watchdog timer, a sensor polling loop,
+   or a network communication task.
+#. Respond to interrupts: This allows the system to still respond to external events, while it is in a low-power state.
+
+To enter MCU Only mode, set :code:`100 usec` resume latency for CPU0 in linux:
+
+.. code-block:: console
+
+   root@<machine>:~# echo 100 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
+
+.. important::
+
+   Note that the step below to set "enabled" won't work for current SDK
+   and will be supported in future release
+
+.. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+   To enter MCU Only mode, enable MCU M4 core as a wakeup source in linux:
+
+   .. code-block:: console
+
+      root@am62xx-evm:~# echo enabled > /sys/bus/platform/devices/5000000.m4fss/power/wakeup
+
+.. ifconfig:: CONFIG_part_variant in ('AM62AX', 'AM62PX')
+
+   To enter MCU Only mode, enable MCU R5 core as a wakeup source in linux:
+
+   .. code-block:: console
+
+      root@<machine>:~# echo enabled > /sys/bus/platform/devices/79000000.r5f/power/wakeup
+
+Now, the SoC can be suspended using the following command:
+
+.. code-block:: console
+
+   root@<machine>:~# rtcwake -s 5 -m mem
+   rtcwake: wakeup from "mem" using /dev/rtc0 at Thu Jan  1 00:01:02 1970
+   [   45.548480] PM: suspend entry (deep)
+   [   45.552187] Filesystems sync: 0.000 seconds
+   [   45.566606] Freezing user space processes
+   [   45.572093] Freezing user space processes completed (elapsed 0.001 seconds)
+   [   45.579083] OOM killer disabled.
+   [   45.582309] Freezing remaining freezable tasks
+   [   45.587984] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
+   [   45.595432] printk: Suspending console(s) (use no_console_suspend to debug)
+   [   45.627136] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
+   [   45.640758] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
+   [   45.648341] omap8250 2800000.serial: PM domain pd:146 will not be powered off
+   [   45.648892] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
+   [   45.648993] cpu cpu3: ti_sci_suspend: sending max CPU latency=100
+   [   45.649033] ti-sci 44043000.system-controller: ti_sci_cmd_set_latency_constraint: latency: 100: state: 1: ret 0
+   [   45.669270] Disabling non-boot CPUs ...
+   [   45.671353] psci: CPU1 killed (polled 0 ms)
+   [   45.674819] psci: CPU2 killed (polled 0 ms)
+   [   45.676640] psci: CPU3 killed (polled 4 ms)
+   [   45.677311] Enabling non-boot CPUs ...
+   [   45.677632] Detected VIPT I-cache on CPU1
+   [   45.677672] GICv3: CPU1: found redistributor 1 region 0:0x00000000018a0000
+   [   45.677724] CPU1: Booted secondary processor 0x0000000001[0x410fd034]
+   [   45.678694] CPU1 is up
+   [   45.678934] Detected VIPT I-cache on CPU2
+   [   45.678962] GICv3: CPU2: found redistributor 2 region 0:0x00000000018c0000
+   [   45.679002] CPU2: Booted secondary processor 0x0000000002[0x410fd034]
+   [   45.679778] CPU2 is up
+   [   45.680016] Detected VIPT I-cache on CPU3
+   [   45.680045] GICv3: CPU3: found redistributor 3 region 0:0x00000000018e0000
+   [   45.680088] CPU3: Booted secondary processor 0x0000000003[0x410fd034]
+   [   45.680939] CPU3 is up
+   [   45.681332] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
+   [   45.703650] am65-cpsw-nuss 8000000.ethernet: set new flow-id-base 19
+   [   45.719704] am65-cpsw-nuss 8000000.ethernet eth0: PHY[8000f00.mdio:00] driver[TI DP83867] (irq=POLL)
+   [   45.719730] am65-cpsw-nuss 8000000.ethernet eth0: configuring for phy/rgmii-rxid link mode
+   [   46.004264] OOM killer enabled.
+   [   46.007406] Restarting tasks ... done.
+   [   46.012454] random: crng reseeded on system resumption
+   [   46.026923] platform 79000000.r5f: Core is on in resume
+   [   46.032206] platform 79000000.r5f: received echo reply from 79000000.r5f
+   [   46.032262] PM: suspend exit
+
+Once the SoC enters MCU Only mode, the following log should be printed
+on the MCU UART (in most cases it will be /dev/ttyUSB3)
+
+.. code-block:: text
+
+   [IPC RPMSG ECHO] Next MCU mode is 1
+   [IPC RPMSG ECHO] Suspend request to MCU-only mode received
+   [IPC RPMSG ECHO] Press a single key on this terminal to resume the kernel from MCU only mode
+
+.. note::
+
+   The system will enter MCU Only mode only if DM selects it based on existing constraints.
+
+Refer to the :ref:`Wakeup Sources<pm_wakeup_sources>` section for information on how to wakeup the device from
+MCU Only mode using one of the supported wakeup sources.
 
 ***********
 Limitations

--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -106,6 +106,8 @@ system and it will go through a normal Linux boot process.
    The capability to detect whether system is resuming from Partial I/O
    or doing a normal cold boot will be added in future release.
 
+.. _pm_io_only_plus_ddr:
+
 *****************
 I/O Only Plus DDR
 *****************

--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -200,7 +200,7 @@ on the MCU UART (in most cases it will be /dev/ttyUSB3)
 
     [IPC RPMSG ECHO] Next MCU mode is 1
     [IPC RPMSG ECHO] Suspend request to MCU-only mode received
-    [IPC RPMSG ECHO] Press a sinlge key on this terminal to resume the kernel from MCU only mode
+    [IPC RPMSG ECHO] Press a single key on this terminal to resume the kernel from MCU only mode
 
 .. note::
 

--- a/source/linux/Foundational_Components/Power_Management/pm_overview.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_overview.rst
@@ -48,7 +48,7 @@ supported by the Linux kernel.
 
    The static power management features on |__PART_FAMILY_DEVICE_NAMES__| are:
 
-   #. Deep Sleep
-   #. MCU Only Mode
    #. Partial I/O
    #. I/O Only Plus DDR
+   #. Deep Sleep
+   #. MCU Only Mode

--- a/source/linux/Foundational_Components/Power_Management/pm_overview.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_overview.rst
@@ -51,3 +51,4 @@ supported by the Linux kernel.
    #. Deep Sleep
    #. MCU Only Mode
    #. Partial I/O
+   #. I/O Only Plus DDR

--- a/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
@@ -7,15 +7,49 @@ Wakeup Sources
 This section talks about the multiple ways in which we can wakeup the |__PART_FAMILY_DEVICE_NAMES__| SoC from Low Power modes like Deep Sleep or MCU only.
 The |__PART_FAMILY_DEVICE_NAMES__| SoC support various wakeup sources like GP Timers, RTC Timer, UART, I2C, WKUP GPIO, and I/O Daisy Chain.
 
-The following wakeup sources are supported in this SDK release:
+The table below lists the wakeup sources supported in this SDK release and whether that source is
+valid for given low power modes:
 
-#. Real-Time Clock (RTC)
-#. MCU (WKUP) GPIO
-#. Main I/O Daisy Chain (Main GPIO and Main UART)
-#. USB Wakeup
-#. WKUP UART
-#. MCU IPC (for MCU Only mode)
-#. CAN UART (for Partial I/O mode)
+.. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+   +------------------------------------------------+------------+----------+-------------+
+   |  Wakeup Source                                 | Deep Sleep | MCU Only | Partial I/O |
+   +================================================+============+==========+=============+
+   | Real-Time Clock (RTC)                          | Yes        | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | MCU (WKUP) GPIO                                | Yes        | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | Main I/O Daisy Chain (Main GPIO and Main UART) | Yes        | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | USB Wakeup                                     | Yes        | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | WKUP UART                                      | Yes        | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | MCU IPC (for MCU Only mode)                    | No         | Yes      | No          |
+   +------------------------------------------------+------------+----------+-------------+
+   | CAN UART I/O Daisy Chain                       | No         | No       | Yes         |
+   +------------------------------------------------+------------+----------+-------------+
+
+.. ifconfig:: CONFIG_part_variant in ('AM62AX', 'AM62PX')
+
+   +------------------------------------------------+-------+------+---------+----------+
+   |  Wakeup Source                                 | Deep  | MCU  | Partial | I/O Only |
+   |                                                | Sleep | Only | I/O     | Plus DDR |
+   +================================================+=======+======+=========+==========+
+   | Real-Time Clock (RTC)                          | Yes   | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | MCU (WKUP) GPIO                                | Yes   | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | Main I/O Daisy Chain (Main GPIO and Main UART) | Yes   | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | USB Wakeup                                     | Yes   | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | WKUP UART                                      | Yes   | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | MCU IPC (for MCU Only mode)                    | No    | Yes  | No      | No       |
+   +------------------------------------------------+-------+------+---------+----------+
+   | CAN UART I/O Daisy Chain                       | No    | No   | Yes     | Yes      |
+   +------------------------------------------------+-------+------+---------+----------+
 
 *********************
 Real-Time Clock (RTC)

--- a/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
@@ -25,25 +25,25 @@ It's possible to use the SoC's internal RTC to wakeup the system using the comma
 
 .. code-block:: console
 
-    rtcwake
+   rtcwake
 
-    - Show whether an alarm is set or not:
-        rtcwake -m show -v
+   - Show whether an alarm is set or not:
+      rtcwake -m show -v
 
-    - Suspend to RAM and wakeup after 10 seconds:
-        rtcwake -m mem -s {{10}}
+   - Suspend to RAM and wakeup after 10 seconds:
+      rtcwake -m mem -s {{10}}
 
-    - Suspend to disk (higher power saving) and wakeup 15 minutes later:
-        rtcwake -m disk --date +{{15}}min
+   - Suspend to disk (higher power saving) and wakeup 15 minutes later:
+      rtcwake -m disk --date +{{15}}min
 
-    - Freeze the system (more efficient than suspend-to-RAM but version 3.9 or newer of the Linux kernel is required) and wakeup at a given date and time:
-        rtcwake -m freeze --date {{YYYYMMDDhhmm}}
+   - Freeze the system (more efficient than suspend-to-RAM but version 3.9 or newer of the Linux kernel is required) and wakeup at a given date and time:
+      rtcwake -m freeze --date {{YYYYMMDDhhmm}}
 
-    - Disable a previously set alarm:
-        rtcwake -m disable
+   - Disable a previously set alarm:
+      rtcwake -m disable
 
-    - Perform a dry run to wakeup the computer at a given time. (Press Ctrl + C to abort):
-        rtcwake -m on --date {{hh:ss}}
+   - Perform a dry run to wakeup the computer at a given time. (Press Ctrl + C to abort):
+      rtcwake -m on --date {{hh:ss}}
 
 For example, if you wish to wakeup from Deep Sleep or MCU Only mode in 10 seconds, use the command like this:
 
@@ -109,66 +109,130 @@ For example, if you wish to wakeup from Deep Sleep or MCU Only mode in 10 second
       [ 34.645777] PM: suspend exit
       root@am62xx-evm:~#
 
-.. ifconfig:: CONFIG_part_variant in ('AM62AX', 'AM62PX')
-
-    .. code-block:: console
-
-        root@<machine>:~# rtcwake -s 10 -m mem
-        rtcwake: wakeup from "mem" using rtc1 at Thu Jan  1 00:01:31 1970
-        [   73.746948] PM: suspend entry (deep)
-        [   73.750871] Filesystems sync: 0.000 seconds
-        [   73.775161] remoteproc remoteproc1: stopped remote processor 79000000.r5f
-        [   73.782461] Freezing user space processes
-        [   73.788375] Freezing user space processes completed (elapsed 0.001 seconds)
-        [   73.795379] OOM killer disabled.
-        [   73.798607] Freezing remaining freezable tasks
-        [   73.804381] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
-        [   73.811829] printk: Suspending console(s) (use no_console_suspend to debug)
-        [   73.833546] omap8250 2800000.serial: PM domain pd:146 will not be powered off
-        [   73.840117] Disabling non-boot CPUs ...
-        [   73.842096] psci: CPU1 killed (polled 0 ms)
-        [   73.844713] psci: CPU2 killed (polled 0 ms)
-        [   73.846454] psci: CPU3 killed (polled 0 ms)
-        [   73.847206] Enabling non-boot CPUs ...
-        [   73.847520] Detected VIPT I-cache on CPU1
-        [   73.847587] GICv3: CPU1: found redistributor 1 region 0:0x00000000018a0000
-        [   73.847639] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
-        [   73.848395] CPU1 is up
-        [   73.848618] Detected VIPT I-cache on CPU2
-        [   73.848657] GICv3: CPU2: found redistributor 2 region 0:0x00000000018c0000
-        [   73.848696] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
-        [   73.849255] CPU2 is up
-        [   73.849482] Detected VIPT I-cache on CPU3
-        [   73.849524] GICv3: CPU3: found redistributor 3 region 0:0x00000000018e0000
-        [   73.849563] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
-        [   73.850193] CPU3 is up
-        [   73.850730] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
-        [   73.859380] am65-cpsw-nuss 8000000.ethernet: set new flow-id-base 19
-        [   73.873298] am65-cpsw-nuss 8000000.ethernet eth0: PHY [8000f00.mdio:00] driver [TI DP83867] (irq=POLL)
-        [   73.873320] am65-cpsw-nuss 8000000.ethernet eth0: configuring for phy/rgmii-rxid link mode
-        [   74.121919] OOM killer enabled.
-        [   74.125062] Restarting tasks ... done.
-        [   74.130925] random: crng reseeded on system resumption
-        [   74.136177] remoteproc remoteproc1: powering up 79000000.r5f
-        [   74.141903] remoteproc remoteproc1: Booting fw image am62a-mcu-r5f0_0-fw, size 52148
-        [   74.150715] rproc-virtio rproc-virtio.6.auto: assigned reserved memory node r5f-dma-memory@9b800000
-        [   74.160761] virtio_rpmsg_bus virtio1: rpmsg host is online
-        [   74.161014] virtio_rpmsg_bus virtio1: creating channel ti.ipc4.ping-pong addr 0xd
-        [   74.166372] rproc-virtio rproc-virtio.6.auto: registered virtio1 (type 7)
-        [   74.176785] virtio_rpmsg_bus virtio1: creating channel rpmsg_chrdev addr 0xe
-        [   74.180714] remoteproc remoteproc1: remote processor 79000000.r5f is now up
-        [   74.194846] PM: suspend exit
-
-    .. note::
-
-        The system will enter the mode selected by DM on the basis on existing constraints.
-
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-    .. note::
+   .. code-block:: console
 
-        AM62A requires additional -d rtc1 option as SoC's internal RTC gets
-        probed as rtc1.
+      root@am62axx-evm:~# rtcwake -s 10 -m mem
+      rtcwake: wakeup from "mem" using rtc1 at Thu Jan  1 00:01:31 1970
+      [   68.915144] PM: suspend entry (deep)
+      [   68.918851] Filesystems sync: 0.000 seconds
+      [   68.926581] Freezing user space processes
+      [   68.932192] Freezing user space processes completed (elapsed 0.001 seconds)
+      [   68.939174] OOM killer disabled.
+      [   68.942402] Freezing remaining freezable tasks
+      [   68.948218] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
+      [   68.955615] printk: Suspending console(s) (use no_console_suspend to debug)
+      [   68.967023] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
+      [   68.967177] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
+      [   68.975296] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
+      [   68.982165] remoteproc remoteproc0: stopped remote processor 7e000000.dsp
+      [   68.007805] remoteproc remoteproc1: stopped remote processor 79000000.r5f
+      [   68.010972] Disabling non-boot CPUs ...
+      [   68.013268] psci: CPU1 killed (polled 0 ms)
+      [   68.016262] psci: CPU2 killed (polled 4 ms)
+      [   68.019303] psci: CPU3 killed (polled 4 ms)
+      [   68.020139] Enabling non-boot CPUs ...
+      [   68.020472] Detected VIPT I-cache on CPU1
+      [   68.020515] GICv3: CPU1: found redistributor 1 region 0:0x00000000018a0000
+      [   68.020568] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
+      [   68.021670] CPU1 is up
+      [   68.021915] Detected VIPT I-cache on CPU2
+      [   68.021943] GICv3: CPU2: found redistributor 2 region 0:0x00000000018c0000
+      [   68.021982] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
+      [   68.022911] CPU2 is up
+      [   68.023158] Detected VIPT I-cache on CPU3
+      [   68.023188] GICv3: CPU3: found redistributor 3 region 0:0x00000000018e0000
+      [   68.023233] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
+      [   68.024279] CPU3 is up
+      [   68.024692] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
+      [   68.037668] am65-cpsw-nuss 8000000.ethernet: set new flow-id-base 19
+      [   68.053755] am65-cpsw-nuss 8000000.ethernet eth0: PHY [8000f00.mdio:00] driver [TI DP83867] (irq=POLL)
+      [   68.053779] am65-cpsw-nuss 8000000.ethernet eth0: configuring for phy/rgmii-rxid link mode
+      [   68.214438] OOM killer enabled.
+      [   68.217581] Restarting tasks ... done.
+      [   68.222831] random: crng reseeded on system resumption
+      [   68.228121] k3-dsp-rproc 7e000000.dsp: Core is off in resume
+      [   68.233990] remoteproc remoteproc0: powering up 7e000000.dsp
+      [   68.239783] remoteproc remoteproc0: Booting fw image am62a-c71_0-fw, size 8391984
+      [   68.254785] k3-dsp-rproc 7e000000.dsp: booting DSP core using boot addr = 0x9a000000
+      [   68.262806] rproc-virtio rproc-virtio.7.auto: assigned reserved memory node c7x-dma-memory@99800000
+      [   68.273026] virtio_rpmsg_bus virtio0: rpmsg host is online
+      [   68.274647] virtio_rpmsg_bus virtio0: creating channel ti.ipc4.ping-pong addr 0xd
+      [   68.278683] rproc-virtio rproc-virtio.7.auto: registered virtio0 (type 7)
+      [   68.286349] virtio_rpmsg_bus virtio0: creating channel rpmsg_chrdev addr 0xe
+      [   68.292879] remoteproc remoteproc0: remote processor 7e000000.dsp is now up
+      [   68.307022] platform 79000000.r5f: Core is off in resume
+      [   68.312378] remoteproc remoteproc1: powering up 79000000.r5f
+      [   68.318064] remoteproc remoteproc1: Booting fw image am62a-mcu-r5f0_0-fw, size 53172
+      [   68.326761] rproc-virtio rproc-virtio.8.auto: assigned reserved memory node r5f-dma-memory@9b800000
+      [   68.336811] virtio_rpmsg_bus virtio1: rpmsg host is online
+      [   68.337372] virtio_rpmsg_bus virtio1: creating channel ti.ipc4.ping-pong addr 0xd
+      [   68.342463] rproc-virtio rproc-virtio.8.auto: registered virtio1 (type 7)
+      [   68.350242] virtio_rpmsg_bus virtio1: creating channel rpmsg_chrdev addr 0xe
+      [   68.356706] remoteproc remoteproc1: remote processor 79000000.r5f is now up
+      [   68.370906] PM: suspend exit
+
+.. ifconfig:: CONFIG_part_variant in ('AM62PX')
+
+   .. code-block:: console
+
+      root@am62pxx-evm:~# rtcwake -s 10 -m mem
+      rtcwake: wakeup from "mem" using /dev/rtc0 at Thu Jan  1 00:01:06 1970
+      [   34.312057] PM: suspend entry (deep)
+      [   34.315781] Filesystems sync: 0.000 seconds
+      [   34.333057] Freezing user space processes
+      [   34.338700] Freezing user space processes completed (elapsed 0.001 seconds)
+      [   34.345697] OOM killer disabled.
+      [   34.348924] Freezing remaining freezable tasks
+      [   34.354679] Freezing remaining freezable tasks completed (elapsed 0.001 seconds)
+      [   34.362078] printk: Suspending console(s) (use no_console_suspend to debug)
+      [   34.377118] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 179: state: 1: ret 0
+      [   34.377267] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 178: state: 1: ret 0
+      [   34.378162] am65-cpsw-nuss 8000000.ethernet eth0: Link is Down
+      [   34.387141] omap8250 2800000.serial: PM domain pd:146 will not be powered off
+      [   34.387736] ti-sci 44043000.system-controller: ti_sci_cmd_set_device_constraint: device: 117: state: 1: ret 0
+      [   34.416958] remoteproc remoteproc0: stopped remote processor 79000000.r5f
+      [   34.420565] Disabling non-boot CPUs ...
+      [   34.422781] psci: CPU1 killed (polled 0 ms)
+      [   34.426363] psci: CPU2 killed (polled 0 ms)
+      [   34.429526] psci: CPU3 killed (polled 0 ms)
+      [   34.430459] Enabling non-boot CPUs ...
+      [   34.430798] Detected VIPT I-cache on CPU1
+      [   34.430841] GICv3: CPU1: found redistributor 1 region 0:0x00000000018a0000
+      [   34.430895] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
+      [   34.431987] CPU1 is up
+      [   34.432232] Detected VIPT I-cache on CPU2
+      [   34.432262] GICv3: CPU2: found redistributor 2 region 0:0x00000000018c0000
+      [   34.432306] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
+      [   34.433233] CPU2 is up
+      [   34.433485] Detected VIPT I-cache on CPU3
+      [   34.433515] GICv3: CPU3: found redistributor 3 region 0:0x00000000018e0000
+      [   34.433557] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
+      [   34.434504] CPU3 is up
+      [   34.434948] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
+      [   34.447824] am65-cpsw-nuss 8000000.ethernet: set new flow-id-base 19
+      [   34.463954] am65-cpsw-nuss 8000000.ethernet eth0: PHY [8000f00.mdio:00] driver [TI DP83867] (irq=POLL)
+      [   34.463980] am65-cpsw-nuss 8000000.ethernet eth0: configuring for phy/rgmii-rxid link mode
+      [   34.477401] am65-cpsw-nuss 8000000.ethernet eth1: PHY [8000f00.mdio:01] driver [TI DP83867] (irq=POLL)
+      [   34.477414] am65-cpsw-nuss 8000000.ethernet eth1: configuring for phy/rgmii-rxid link mode
+      [   34.661705] OOM killer enabled.
+      [   34.664848] Restarting tasks ... done.
+      [   34.670624] random: crng reseeded on system resumption
+      [   34.676468] platform 79000000.r5f: Core is off in resume
+      [   34.681906] remoteproc remoteproc0: powering up 79000000.r5f
+      [   34.687692] remoteproc remoteproc0: Booting fw image am62p-mcu-r5f0_0-fw, size 58344
+      [   34.699283] rproc-virtio rproc-virtio.5.auto: assigned reserved memory node mcu-r5fss-dma-memory-region@9b800000
+      [   34.710642] virtio_rpmsg_bus virtio0: rpmsg host is online
+      [   34.716279] virtio_rpmsg_bus virtio0: creating channel ti.ipc4.ping-pong addr 0xd
+      [   34.717435] rproc-virtio rproc-virtio.5.auto: registered virtio0 (type 7)
+      [   34.724381] virtio_rpmsg_bus virtio0: creating channel rpmsg_chrdev addr 0xe
+      [   34.731147] remoteproc remoteproc0: remote processor 79000000.r5f is now up
+      [   34.754176] PM: suspend exit
+
+   .. note::
+
+      The system will enter the mode selected by DM on the basis on existing constraints.
 
 ********
 MCU GPIO
@@ -189,40 +253,40 @@ for details.
 
 .. code-block:: dts
 
-    compatible = "gpio-keys";
+   compatible = "gpio-keys";
 
 
 Set the desired pinctrl,
 
 .. code-block:: dts
 
-    pinctrl-names = "default";
-    pinctrl-0 = <&wake_mcugpio1_pins_default>;
+   pinctrl-names = "default";
+   pinctrl-0 = <&wake_mcugpio1_pins_default>;
 
 Setup the interrupt parent and interrupt as MCU_GPIO0,
 
 .. code-block:: dts
 
-    interrupt-parent = <&mcu_gpio0>;
-    interrupts = <16 IRQ_TYPE_EDGE_RISING>;
+   interrupt-parent = <&mcu_gpio0>;
+   interrupts = <16 IRQ_TYPE_EDGE_RISING>;
 
 Now, under the switch node we add the following:
 
 .. code-block:: dts
 
-    switch {
-                label = "MCUGPIO";
-                linux,code = <143>;
-                gpios = <&mcu_gpio0 16 GPIO_ACTIVE_LOW>;
-                wakeup-source;
-    };
+   switch {
+               label = "MCUGPIO";
+               linux,code = <143>;
+               gpios = <&mcu_gpio0 16 GPIO_ACTIVE_LOW>;
+               wakeup-source;
+   };
 
 #. The label is the descriptive name of the key. The string will reflect under /proc/interrupts as:
 
     .. code-block:: console
 
-        root@<machine>:~# cat /proc/interrupts | grep "MCUGPIO"
-        262:          0          0          0          0      GPIO  16 Edge    -davinci_gpio  MCUGPIO
+       root@<machine>:~# cat /proc/interrupts | grep "MCUGPIO"
+       262:          0          0          0          0      GPIO  16 Edge    -davinci_gpio  MCUGPIO
 
 #. linux,code: Keycode to emit.
 #. gpios: the gpio required to be used as the gpio-key.
@@ -266,9 +330,9 @@ Setting the 29th Bit in the desired padconfig register, allows the pad to act as
 triggering a wake irq to the DM R5 in deep sleep states.
 
 .. note::
-    |__PART_FAMILY_DEVICE_NAMES__| supports the ability to wakeup using pad based wake event ONLY in Deep Sleep or MCU Only Mode.
-    During active system usage, even if the wake_enable bit is set the system will be unresponsive to any wakeup
-    activity on that pad.
+   |__PART_FAMILY_DEVICE_NAMES__| supports the ability to wakeup using pad based wake event ONLY in Deep Sleep or MCU Only Mode.
+   During active system usage, even if the wake_enable bit is set the system will be unresponsive to any wakeup
+   activity on that pad.
 
 
 To demonstrate I/O daisy chain wakeup as part of |__PART_FAMILY_DEVICE_NAMES__| offering, two reference examples are provided:
@@ -285,9 +349,9 @@ main_uart0 node in `k3-am62x-sk-common.dtsi <https://git.ti.com/cgit/ti-linux-ke
 
 .. code-block:: dts
 
-    interrupts-extended = <&gic500 GIC_SPI 178 IRQ_TYPE_LEVEL_HIGH>,
+   interrupts-extended = <&gic500 GIC_SPI 178 IRQ_TYPE_LEVEL_HIGH>,
                 <&main_pmx0 0x1c8>; /* (D14) UART0_RXD PADCONFIG114 */
-    interrupt-names = "irq", "wakeup";
+   interrupt-names = "irq", "wakeup";
 
 Here, we chain the IRQ to the pinctrl driver using the second interrupts-extended entry.
 The wake IRQ framework in linux works in such a way that the second entry gets marked as a
@@ -298,34 +362,34 @@ To use main_uart0 as a wakeup source, ensure serial is a wake-irq in /proc/inter
 
 .. code-block:: console
 
-    root@<machine>:~# grep wakeup /proc/interrupts
-    231:          0          0          0          0   pinctrl 456 Edge 2800000.serial:wakeup
+   root@<machine>:~# grep wakeup /proc/interrupts
+   231:          0          0          0          0   pinctrl 456 Edge 2800000.serial:wakeup
 
 Then, run this script:
 
 .. code-block:: bash
 
-    #!/bin/bash -xe
+   #!/bin/bash -xe
 
-    # Detach kernel serial console
-    consoles=$(find /sys/bus/platform/devices/*.serial/ -name console)
-    for console in ${consoles}; do
-            echo -n N > ${console}
-    done
+   # Detach kernel serial console
+   consoles=$(find /sys/bus/platform/devices/*.serial/ -name console)
+   for console in ${consoles}; do
+           echo -n N > ${console}
+   done
 
-    # Configure PM runtime autosuspend
-    uarts=$(find /sys/bus/platform/devices/*.serial/power/ -type d)
-    for uart in $uarts; do
-            echo -n 3000 > $uart/autosuspend_delay_ms
-            echo -n enabled > $uart/wakeup
-            echo -n auto > $uart/control
-    done
+   # Configure PM runtime autosuspend
+   uarts=$(find /sys/bus/platform/devices/*.serial/power/ -type d)
+   for uart in $uarts; do
+           echo -n 3000 > $uart/autosuspend_delay_ms
+           echo -n enabled > $uart/wakeup
+           echo -n auto > $uart/control
+   done
 
-    # Configure wake-up from suspend
-    uarts=$(find /sys/class/tty/tty[SO]*/power/ -type d 2>/dev/null)
-    for uart in $uarts; do
-            echo -n enabled > $uart/wakeup
-    done
+   # Configure wake-up from suspend
+   uarts=$(find /sys/class/tty/tty[SO]*/power/ -type d 2>/dev/null)
+   for uart in $uarts; do
+           echo -n enabled > $uart/wakeup
+   done
 
 
 This will configure UART to act as deep sleep wakeup source, and
@@ -354,8 +418,8 @@ To use main_gpio as a wakeup source, ensure gpio is a wake-irq in /proc/interrup
 
 .. code-block:: console
 
-    root@<machine>:~# grep wakeup /proc/interrupts
-    531:          0          0          0          0   pinctrl 416 Edge      WKGPIO:wakeup
+   root@<machine>:~# grep wakeup /proc/interrupts
+   531:          0          0          0          0   pinctrl 416 Edge      WKGPIO:wakeup
 
 Once the system has entered Deep Sleep or MCU Only mode as shown in the
 :ref:`LPM section<lpm_modes>`, wakeup from MAIN GPIO1_10 can be triggered
@@ -480,7 +544,7 @@ below command on the Host system
 
 .. code-block:: console
 
-  HOST:~$ > lsusb -t
+   HOST:~$ > lsusb -t
 
 
 ********************
@@ -492,15 +556,15 @@ from the firmware side, please refer to the relevant documentation:
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-    `MCU+ SDK for AM62x <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/index.html>`__
+   `MCU+ SDK for AM62x <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/index.html>`__
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-    `MCU+ SDK for AM62Ax <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/latest/exports/docs/api_guide_am62ax/index.html>`__
+   `MCU+ SDK for AM62Ax <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/latest/exports/docs/api_guide_am62ax/index.html>`__
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    `MCU+ SDK for AM62Px <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/index.html>`__
+   `MCU+ SDK for AM62Px <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/index.html>`__
 
 To use MCU IPC based wakeup, system should be placed into MCU Only mode
 as shown in the :ref:`LPM section<pm_mcu_only>`.
@@ -510,16 +574,16 @@ on the MCU UART (in most cases it will be /dev/ttyUSB3)
 
 .. code-block:: text
 
-    [IPC RPMSG ECHO] Next MCU mode is 1
-    [IPC RPMSG ECHO] Suspend request to MCU-only mode received
-    [IPC RPMSG ECHO] Press a sinlge key on this terminal to resume the kernel from MCU only mode
+   [IPC RPMSG ECHO] Next MCU mode is 1
+   [IPC RPMSG ECHO] Suspend request to MCU-only mode received
+   [IPC RPMSG ECHO] Press a single key on this terminal to resume the kernel from MCU only mode
 
 Any *key press* on the same terminal should trigger a wakeup from MCU Only
 mode and the following message printed:
 
 .. code-block:: text
 
-    [IPC RPMSG ECHO] Main domain resumed due to MCU UART
+   [IPC RPMSG ECHO] Main domain resumed due to MCU UART
 
 
 ********************************
@@ -533,7 +597,7 @@ This wake reason is printed as part of the Linux suspend/resume log:
 
 .. code-block:: console
 
-    [   37.357109] CPU3 is up
-    [   37.357710] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
+   [   37.357109] CPU3 is up
+   [   37.357710] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
 
 In the above example, 0x50 means that WKUP_RTC0 is the wakeup source.


### PR DESCRIPTION
Update Low power mode documentation to include the following:
1. Add details about newly added I/O Only plus DDR low power mode.
2. Update the suspend resume logs as per the latest changes.
3. Change the wakeup sources list to table to clearly describe wakeup sources supported in given low power modes.