### PR TITLE
chore(rstcheck): ignore unreferenced hyperlinks

### DIFF
--- a/.rstcheck.cfg
+++ b/.rstcheck.cfg
@@ -4,3 +4,4 @@ ignore_directives = ifconfig
 # snippets in this repo depend on external code
 ignore_languages = c,cpp,c++
 ignore_substitutions = __PART_FAMILY_NAME__,__PART_FAMILY_DEVICE_NAMES__,__PRODUCT_LINE_NAME__,__SDK_BUILD_MACHINE__,__SDK_FULL_NAME__,__SDK_SHORT_NAME__,__SDK_INSTALL_FILE__,__SDK_INSTALL_DIR__,__SDK_DOWNLOAD_URL__,__LINUX_UBUNTU_VERSION_LONG__,__LINUX_UBUNTU_VERSION_SHORT__,__OPTEE_PLATFORM_FLAVOR__,__RTOS_UBUNTU_VERSION_LONG__,__WINDOWS_SUPPORTED_LONG__,__FEATURINGMATRIX__,__SYSFW_CORE_NAME__,__PCIE_BASE_ADDRESS__,__PCIE_DEVICE_ID__,__IMAGE_TYPE__
+ignore_messages = (Hyperlink target.*is not referenced\.)


### PR DESCRIPTION
This warning is very rarely correct and normally doesn't mean anything. Having unused hyperlinks is one of the only way to resolve duplicate implicit target names.

Relevant issue regarding false positives:
https://github.com/rstcheck/rstcheck/issues/76