### PR TITLE
feat: Update component-owners for legacy devices

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -28,9 +28,10 @@ components:
   source/devices/AM335x/linux: &sitara_legacy_list
     - jeevantelukula
     - jmenti
-  source/devices/AM437x/linux: *sitara_legacy_list
-  source/devices/AM65X/linux: *sitara_legacy_list
-
+  source/devices/AM437x/linux: &sitara_legacy_list
+    - jmenti
+  source/devices/AM65X/linux: &sitara_legacy_list
+    - jmenti
   source/devices/AM64X/linux: *mpu_list
   source/devices/AM62X/linux:
     - DhruvaG2000


### PR DESCRIPTION
Update component-owners for legacy devices which also include am437x and am65x.