### PR TITLE
fix: AM64X: linux: RT_Linux_Performance_Guide: correct PCIe Speed to 5 GT/s

### DIFF
--- a/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
+++ b/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
@@ -485,7 +485,7 @@ AM64xx-EVM
 
 - Filesize used is: 10G
 - FIO command options: --ioengine=libaio --iodepth=4 --numjobs=1 --direct=1 --runtime=60 --time_based 
-- Platform: Speed 8GT/s, Width x1
+- Platform: Speed 5GT/s, Width x1
 - SSD being used: Lite-On Technology Corporation M8Pe Series NVMe SSD [14a4:22f1] (rev 01)
 
 |


### PR DESCRIPTION
The PCIe Controller on AM64 SoC is a Gen 2 Controller [0]. Hence, correct the speed from 8 GT/s (Gen 3) to 5 GT/s (Gen 2).

[0]: https://www.ti.com/lit/ds/symlink/am6442.pdf
Signed-off-by: Siddharth Vadapalli <s-vadapalli@ti.com>