### PR TITLE
feat(linux): AM62AX, AM62PX: Highlight daughter board support in rele…

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -48,6 +48,7 @@ What's new
   - LTS Stable Kernel update to 6.6.58
   - Important Bug Fixes on top of Processor SDK 10.00.07.04 Release
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here :ref:`RT Interrupt Latencies <RT-linux-performance>`
+  - Support for streaming from OV2312 camera with `DS90UB954-Q1EVM <https://www.ti.com/tool/DS90UB954-Q1EVM>`_
 
 **Component version:**
 

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -50,6 +50,7 @@ What's new
   - Important Bug Fixes on top of Processor SDK 10.00.07.04 Release
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here - :ref:`RT Interrupt Latencies <RT-linux-performance>`
   - Power Management: DeepSleep, MCU-Only and Partial IO mode - :ref:`Power Management Overview <Power-Management>`
+  - Support for streaming from multiple 0V5640 cameras with `Arducam V3Link (Fusion Mini) <https://www.arducam.com/product/arducam-v3link-camera-kit-for-ti-development-boards/>`_
 
 
 **Component version:**


### PR DESCRIPTION
…ase summary

Highlight SK-AM62P + Arducam V3Link (Fusion Mini) and SK-AM62A + DS90UB954-Q1EVM support in the release notes.