### PR TITLE
feat(devices): Update build information for AM62x & AM62P

### DIFF
--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -183,12 +183,12 @@ Yocto
 .. rubric:: meta-edgeai
    :name: meta-edgeai
 
-| Head Commit: 836b1a3aa89d087474495ab4f77fc7a06ffcef0f edgeai-test-data.bb: edgeai-tidl-models.bb: Updated EDGEAI_SDK_VERSION
-| Date: 2024-07-30 05:58:20 -0500
+| Head Commit: 4cba875d5173dee6b4ca34bd41d5a8b47891e0c7 ti-tidl: Update concerto SRC_REV
+| Date: 2024-12-04 12:21:41 -0600
 
 | Clone: https://git.ti.com/git/edgeai/meta-edgeai.git
 | Branch: scarthgap
-| Release Tag: 10.00.00.04
+| Release Tag: 10.01.10.04
 |
 
 

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -179,17 +179,17 @@ Yocto
 .. rubric:: meta-edgeai
    :name: meta-edgeai
 
-| Head Commit: 836b1a3aa89d087474495ab4f77fc7a06ffcef0f edgeai-test-data.bb: edgeai-tidl-models.bb: Updated EDGEAI_SDK_VERSION
-| Date: 2024-07-30 05:58:20 -0500
+| Head Commit: 4cba875d5173dee6b4ca34bd41d5a8b47891e0c7 ti-tidl: Update concerto SRC_REV
+| Date: 2024-12-04 12:21:41 -0600
 
 | Clone: https://git.ti.com/git/edgeai/meta-edgeai.git
 | Branch: scarthgap
-| Release Tag: 10.00.00.04
+| Release Tag: 10.01.10.04
 |
 
 .. important::
 
-    meta-edgeai layer is not applicable in case of SK-AM62-SIP (i.e. am62xxsip-evm)
+   meta-edgeai layer is not applicable in case of SK-AM62-SIP (i.e. am62xxsip-evm)
 
 Issues Tracker
 ==============


### PR DESCRIPTION
- For SDK 10.1, update commit SHA & Release tag of meta-edegai
layer in AM62x family & AM62P which is used for ARM only Analytics [1]

- Fix indentation of important directive based on CONTRIBUTING guidelines [2]

[1]: https://git.ti.com/cgit/edgeai/meta-edgeai/tag/?h=10.01.10.04

[2]: https://github.com/TexasInstruments/processor-sdk-doc/blob/master/CONTRIBUTING.md#indentation-and-whitespace