### PR TITLE
ci(deploy): move aggregation step into deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,21 +67,3 @@ jobs:
           name: ${{ matrix.device }}-${{ matrix.os }}
           path: build/
           retention-days: 1
-
-  agregate:
-    name: Agregate build artifacts
-    runs-on: ubuntu-latest
-    needs: build
-
-    steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: build
-          merge-multiple: true
-
-      - name: Upload static files as single artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,60 @@ on:
       - completed
 
 jobs:
+  agregate:
+    name: Agregate build artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: build
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Generate root index
+        run: |
+          cat << EOF > build/index.html
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>PSDK Documentation Landing Page</title>
+            </head>
+            <body>
+              <main>
+                <h1>PSDK Documentation Landing Page</h1>
+                <ul>
+          EOF
+
+          for path in build/*/; do
+            root_index=$(find "$path" -name index.html | sort -u | tail -1)
+            if [ -n "$root_index" ]; then
+              text=$(basename "$path")
+              relative_path=$(realpath "$root_index" --relative-to=build)
+              printf '        <li><a href="%s">%s</a></li>\n' \
+                "$relative_path" "$text" >> build/index.html
+            fi
+          done
+
+          cat << EOF >> build/index.html
+                </ul>
+              </main>
+            </body>
+          </html>
+          EOF
+
+      - name: Upload static files as single artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    needs: agregate
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
The workflows for working with pages artifacts are not as smart as the standard artifact routines. As such, the aggregation of previous artifacts must take place in the deploy script so the final artifact generated will have the same run-id as the deploy step that fetches it.

Fixes: 2d64c496 (feat(cicd): automated builds and deployment to pages, 2024-11-19)