### PR TITLE
fix(graphics): include isonum for reg definition

### DIFF
--- a/source/linux/Foundational_Components/Graphics/Common/OpenGL_ES.rst
+++ b/source/linux/Foundational_Components/Graphics/Common/OpenGL_ES.rst
@@ -1,3 +1,4 @@
+.. include:: <isonum.txt>
 
 #########
 OpenGL ES

--- a/source/linux/Foundational_Components/Graphics/Common/Vulkan.rst
+++ b/source/linux/Foundational_Components/Graphics/Common/Vulkan.rst
@@ -1,3 +1,4 @@
+.. include:: <isonum.txt>
 
 ######
 Vulkan

--- a/source/linux/Foundational_Components/Graphics/Rogue/Overview.rst
+++ b/source/linux/Foundational_Components/Graphics/Rogue/Overview.rst
@@ -1,3 +1,4 @@
+.. include:: <isonum.txt>
 .. include:: <isopub.txt>
 
 ############

--- a/source/linux/Foundational_Components/Graphics/SGX/Overview.rst
+++ b/source/linux/Foundational_Components/Graphics/SGX/Overview.rst
@@ -1,3 +1,4 @@
+.. include:: <isonum.txt>
 
 Introduction
 ============


### PR DESCRIPTION
The reg substitution is part of the isonum standard symbol definitions. The GFX sections that were already including isonum were accidentally broken when we removed the old include directives for replacevars.

Fixes: 58170050 (chore: remove all references to old include file, 2024-11-30)