### PR TITLE
fix(docker): tweak makefile to fetch updated requirements

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -19,5 +19,5 @@ all: Dockerfile setup
 
 setup: requirements.txt
 
-requirements.txt:
+requirements.txt: ../requirements.txt
 	cp -ar ../requirements.txt .


### PR DESCRIPTION
Tweak the makefile so we check the modification time of the parent requirements.txt before we continue with the current one. This only affects people building this locally, as CI always starts with a fresh copy.