### PR TITLE
feat(linux): Foundational components: Bump up to 10.01.10

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/E5010_JPEG_Encoder.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/E5010_JPEG_Encoder.rst
@@ -13,7 +13,7 @@ in both TI SDK and upstream at below paths:
 - `E5010 JPEG encoder source code in Upstream Linux kernel
   <https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/media/platform/imagination>`__
 - `E5010 JPEG encoder source code in TI Linux kernel
-  <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/media/platform/imagination/e5010/e5010-jpeg-enc.c?h=10.00.07>`__
+  <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/media/platform/imagination/e5010/e5010-jpeg-enc.c?h=10.01.10>`__
 
 Hardware Specification
 ======================

--- a/source/linux/Foundational_Components/U-Boot/UG-Splash-Screen.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Splash-Screen.rst
@@ -216,14 +216,14 @@ To enable splash screen on custom board based on |__PART_FAMILY_DEVICE_NAMES__| 
  2. Enable the A53 SPL splash screen related configurations in the |__PART_FAMILY_DEVICE_NAMES__| defconfig by referring to below patches and files:
 
   * `configs: am62px: Enable A53 splashscreen <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/commit/?h=ti-u-boot-2024.04&id=82c3fa8a15602248df035e423059236e00a01519>`_
-  * `Splash screen config fragment for AM62x and AM62P  <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/configs/am62x_a53_splashscreen.config?h=10.00.07>`_
+  * `Splash screen config fragment for AM62x and AM62P  <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/configs/am62x_a53_splashscreen.config?h=10.01.10>`_
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
  2. Enable the A53 SPL splash screen related configurations in the |__PART_FAMILY_DEVICE_NAMES__| defconfig by referring to below patches and files:
 
   * `configs: am62x_evm_a53_defconfig: Enable A53 splashscreen at U-Boot SPL <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/commit/?h=ti-u-boot-2024.04&id=aed6660b3edf348c91208322d8ff9cd530def7fa>`_
-  * `Splash screen config fragment for AM62x and AM62P  <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/configs/am62x_a53_splashscreen.config?h=10.00.07>`_
+  * `Splash screen config fragment for AM62x and AM62P  <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/configs/am62x_a53_splashscreen.config?h=10.01.10>`_
 
 .. note::
 
@@ -396,8 +396,8 @@ Flicker free display across boot stages and Linux Kernel
 
 .. note::
 
-  More information regarding simple-framebuffer can be found in `the simple-framebuffer device-tree binding doc <https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/display/simple-framebuffer.yaml>`_
-  Even if a non-Linux based custom bootloader is used to display the splash screen before transitioning to Linux, the framebuffer-related information can be updated in aforementioned device-tree nodes to enable seamless and flicker-free transition during operating system bootup along with reduced memory footprint.
+   More information regarding simple-framebuffer can be found in `the simple-framebuffer device-tree binding doc <https://github.com/torvalds/linux/blob/master/Documentation/devicetree/bindings/display/simple-framebuffer.yaml>`_
+   Even if a non-Linux based custom bootloader is used to display the splash screen before transitioning to Linux, the framebuffer-related information can be updated in aforementioned device-tree nodes to enable seamless and flicker-free transition during operating system bootup along with reduced memory footprint.
 
 
 Flicker free and persistent display until display server

--- a/source/linux/Foundational_Components_IPC62px.rst
+++ b/source/linux/Foundational_Components_IPC62px.rst
@@ -252,6 +252,6 @@ M4F and R5F external memory section sizes in their respective linker mapfiles.
    The reserved memory sizes listed above are provided as a reference only and
    subject to change between releases. For latest memory reservations, please
    refer to the kernel device tree repository :
-   'https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62p5-sk.dts?h=10.00.07'
+   'https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62p5-sk.dts?h=10.01.10'
 
 .. include:: Foundational_Components/IPC/_RPMsg_char_driver.rst

--- a/source/linux/Foundational_Components_IPC62x.rst
+++ b/source/linux/Foundational_Components_IPC62x.rst
@@ -243,6 +243,6 @@ M4F and R5F external memory section sizes in their respective linker mapfiles.
 .. warning:: Be careful not to overlap carveouts!
 
 .. note:: The DT fragments are provided as a reference and subject to change between releases. For latest memory reservations, please refer to the kernel device tree repository :
-          'https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-common.dtsi?h=10.00.07'
+          'https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-common.dtsi?h=10.01.10'
 
 .. include:: Foundational_Components/IPC/_RPMsg_char_driver.rst


### PR DESCRIPTION
- Bump up the URLs under Foundational Components to 10.01.10

- Indent content under note directive as per guidelines [1]

[1]: https://github.com/TexasInstruments/processor-sdk-doc/blob/master/CONTRIBUTING.md#indentation-and-whitespace