### PR TITLE
feat: debian: Update version in docs

### DIFF
--- a/source/debian/Building_Debian_Image.rst
+++ b/source/debian/Building_Debian_Image.rst
@@ -55,7 +55,7 @@ Repository Structure
     │   ├── bsp_sources.toml
     │   └── machines --> Machine configurations for each BSP version
     │       ├── 09.02.00.010.toml
-    │       └── 10.00.05.toml
+    │       └── 10.01.10.04.toml
     ├── create-sdcard.sh
     ├── create-wic.sh
     ├── LICENSE
@@ -165,13 +165,13 @@ Then, select a release tag and checkout to it:
 
    git checkout <tag-name>
 
-For example, to checkout to the `10.00.07-release` tag, use the following command:
+For example, to checkout to the `10.01.10.04-release` tag, use the following command:
 
 .. code-block:: console
 
-   git checkout 10.00.07-release
+   git checkout 10.01.10.04-release
 
-The :file:`builds.toml` and other config files will now support building images corresponding to the `10.00.07` release.
+The :file:`builds.toml` and other config files will now support building images corresponding to the `10.01.10.04` release.
 
 Building the Image
 -------------------

--- a/source/debian/Building_Debian_Packages.rst
+++ b/source/debian/Building_Debian_Packages.rst
@@ -14,8 +14,8 @@ This repository is useful to the following audience:
 2. Users who want to create a new package with the latest changes or customizations.
 3. Anyone who wants to study Debian packaging.
 
-Structure:
-==========
+Structure
+=========
 
 The `run.sh` file is the "main" script that should be run. It takes as argument the name of the package to be built.
 


### PR DESCRIPTION
We have a tree structure in the docs, which gives an overview of the ti-bdebstrap repository. We also have example bash commands for checking out release tags of each release, for ti-bdebstrap.

In all these cases, update the version from 10.00.07 to 10.01.10.04.