### PR TITLE
fix(PRU-ICSS): Remove the PRU-ICSS table that comes up on Sitara Legacy devices docs index page for now

### DIFF
--- a/configs/AM335X/AM335X_linux_toc.txt
+++ b/configs/AM335X/AM335X_linux_toc.txt
@@ -111,12 +111,6 @@ linux/Foundational_Components/Graphics/SGX/Overview
 linux/Foundational_Components/Graphics/SGX/SGX_Debug_Info
 linux/Foundational_Components/Graphics/SGX/Build_Guide
 
-linux/Industrial_Protocols
-linux/Industrial_Protocols_HSR_PRP
-linux/Industrial_Protocols_PTP
-linux/Industrial_Protocols_RSTP
-linux/Industrial_Protocols_CCLINK
-linux/Industrial_Protocols_OPCUA
 linux/Examples_and_Demos
 linux/Examples_and_Demos_Application_Demos
 linux/Examples_and_Demos/Application_Demos/QT_Thermostat_HMI_Demo

--- a/configs/AM437X/AM437X_linux_toc.txt
+++ b/configs/AM437X/AM437X_linux_toc.txt
@@ -111,12 +111,6 @@ linux/Foundational_Components/Graphics/SGX/Overview
 linux/Foundational_Components/Graphics/SGX/SGX_Debug_Info
 linux/Foundational_Components/Graphics/SGX/Build_Guide
 
-linux/Industrial_Protocols
-linux/Industrial_Protocols_HSR_PRP
-linux/Industrial_Protocols_PTP
-linux/Industrial_Protocols_RSTP
-linux/Industrial_Protocols_CCLINK
-linux/Industrial_Protocols_OPCUA
 linux/Examples_and_Demos
 linux/Examples_and_Demos_Application_Demos
 linux/Examples_and_Demos/Application_Demos/QT_Thermostat_HMI_Demo

--- a/source/linux/Overview/_Processor_SDK_Linux_Software_Developers_Guide.rst
+++ b/source/linux/Overview/_Processor_SDK_Linux_Software_Developers_Guide.rst
@@ -111,7 +111,7 @@ suggestions at `E2E <https://e2e.ti.com/>`__.
 
 .. ifconfig:: CONFIG_sdk in ('SITARA')
 
-    .. ifconfig:: CONFIG_part_variant not in ('AM62X', 'AM62AX', 'AM62PX')
+    .. ifconfig:: CONFIG_part_variant not in ('AM62X', 'AM62AX', 'AM62PX', 'AM335X', 'AM437X', 'AM65X')
 
         +-----------------+------------------------+------------------+-----------------------------------+
         | **PRU-ICSS / PRU_ICSSG Protocols** (more information on each piece of the distribution)         |


### PR DESCRIPTION
Currently there was no support on these protocols, so remove from the docs index page until further clarity.