### PR TITLE
fix: add proper diffutils to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,7 @@ FROM alpine:3
 
 RUN apk add --no-cache \
 		bash \
+		diffutils \
 		dumb-init \
 		git \
 		make \


### PR DESCRIPTION
Alpine's default diff provider is Busybox diff. This is not adequate for our scripts like delta.sh or check-warn.sh. These require proper gnu-diff for advanced parameters like changed-group-format.

Fixes: 23fbd1ae (feat(docker): use alpine for the base image, 2024-11-09)