### PR TITLE
fix(android): bootloaders: Fix repo init to use release manifest

### DIFF
--- a/source/android/Foundational_Components_Bootloaders.rst
+++ b/source/android/Foundational_Components_Bootloaders.rst
@@ -37,7 +37,7 @@ Downloading sources
    .. code-block:: console
 
       $ mkdir ${YOUR_PATH}/ti-bootloader-aosp/ && cd $_
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m bootloaders.xml
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_Bootloader.xml
       $ repo sync
 
    For more information about ``repo``, visit `Android's official


### PR DESCRIPTION
Right now, we point to the bootloaders.xml file, which is the latest (developement) manifest.

To be consistent with kernel build, pass the release manifest instead to the repo init command.

@vishalmti @glaroque 