### PR TITLE
feat: Update mcu-plus-sdk versions in hyperlinks

### DIFF
--- a/source/common/PRU-ICSS/PRU-Getting-Started-Labs.rst
+++ b/source/common/PRU-ICSS/PRU-Getting-Started-Labs.rst
@@ -45,8 +45,8 @@ The PRU Getting Started Labs demonstrate:
       "MCU-PLUS-SDK" or "PROCESSOR-SDK-LINUX".
 
    #. Select "Download options" -> "Documentation". Click the link to the
-      latest SDK documentation. (AM64x example for MCU+ SDK 8.2:
-      https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/index.html)
+      latest SDK documentation. (AM64x example for MCU+ SDK 10.1:
+      https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html)
 
    #. If using an SDK that is not the latest SDK, it is suggested to use that
       release's SDK documentation instead of the latest SDK documentation.

--- a/source/devices/AM62AX/index_RTOS.rst
+++ b/source/devices/AM62AX/index_RTOS.rst
@@ -4,5 +4,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/08_06_00_18/exports/docs/api_guide_am62ax/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/index.html>`__
 

--- a/source/devices/AM62AX/linux/Overview/Build_and_Run_the_Demos.rst
+++ b/source/devices/AM62AX/linux/Overview/Build_and_Run_the_Demos.rst
@@ -14,6 +14,6 @@ Processor SDK AM62A support GNU make based build system.
 Refer the respective user guides to build Linux and other RTOS/NO-RTOS packages
 
 -  For Linux Kernel, u-boot & DTB     `[Use Link] <../../../linux/Foundational_Components.html>`__
--  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/08_06_00_18/exports/docs/api_guide_am62ax/index.html>`__
+-  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/index.html>`__
 
 

--- a/source/devices/AM62PX/index_RTOS.rst
+++ b/source/devices/AM62PX/index_RTOS.rst
@@ -8,4 +8,4 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/09_02_00_38/exports/docs/api_guide_am62px/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/index.html>`__

--- a/source/devices/AM62PX/linux/Overview/Build_and_Run_the_Demos.rst
+++ b/source/devices/AM62PX/linux/Overview/Build_and_Run_the_Demos.rst
@@ -18,4 +18,4 @@ Processor SDK AM62Px support GNU make based build system.
 Refer the respective user guides to build Linux and other RTOS/NO-RTOS packages
 
 -  For Linux Kernel, u-boot & DTB - `[Use Link] <foundational-components-linux>`
--  For RTOS/NO-RTOS source (MCU+ SDK) - `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/09_02_00_38/exports/docs/api_guide_am62px/index.html>`__
+-  For RTOS/NO-RTOS source (MCU+ SDK) - `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/index.html>`__

--- a/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
@@ -85,8 +85,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    Processor SDK Linux AM62Px contains only the Linux specific source and application intended
    to runs on A53/Linux core. For R5F and RTOS/NO-RTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/09_02_00_38/exports/docs/api_guide_am62px/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/index.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/09_02_00_38/exports/docs/api_guide_am62px/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/CCS_SETUP_PAGE.html>`__

--- a/source/devices/AM62X/index_RTOS.rst
+++ b/source/devices/AM62X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/09_02_00_38/exports/docs/api_guide_am62x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/index.html>`__
 

--- a/source/devices/AM62X/linux/Overview/Build_and_Run_the_Demos.rst
+++ b/source/devices/AM62X/linux/Overview/Build_and_Run_the_Demos.rst
@@ -18,7 +18,7 @@ Processor SDK AM62x support GNU make based build system.
 Refer the respective user guides to build Linux and other RTOS/NO-RTOS packages
 
 -  For Linux Kernel, u-boot & DTB - :ref:`[Use Link] <foundational-components-linux>`
--  For RTOS/NO-RTOS source (MCU+ SDK) - `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/09_02_00_38/exports/docs/api_guide_am62x/index.html>`__
+-  For RTOS/NO-RTOS source (MCU+ SDK) - `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/index.html>`__
 
 
 

--- a/source/devices/AM62X/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62X/linux/Overview/Download_and_Install_the_SDK.rst
@@ -91,8 +91,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    Processor SDK Linux AM62x contains only the Linux specific source and application intended
    to runs on A53/Linux core. For R5F and RTOS/NO-RTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/09_02_00_38/exports/docs/api_guide_am62x/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/index.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/09_02_00_38/exports/docs/api_guide_am62x/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/CCS_SETUP_PAGE.html>`__

--- a/source/devices/AM64X/index_RTOS.rst
+++ b/source/devices/AM64X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html>`__
 

--- a/source/devices/AM64X/linux/Overview/Build_and_Run_the_Demos.rst
+++ b/source/devices/AM64X/linux/Overview/Build_and_Run_the_Demos.rst
@@ -29,9 +29,9 @@ Below is a list of build targets supported by processor SDK AM64x:
 Refer the respective user guides to build Linux and other RTOS/NO-RTOS packages
 
 -  For Linux Kernel, u-boot & DTB     `[Use Link] <../../../linux/Foundational_Components.html>`__
--  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/index.html>`__
--  For Industrial Protocols (ECAT)    `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/INDUSTRIAL_COMMS.html>`__
--  For Industrial Drives (EnDAT,HDSL) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/EXAMPLES_MOTORCONTROL.html>`__
+-  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html>`__
+-  For Industrial Protocols (ECAT)    `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/INDUSTRIAL_COMMS.html>`__
+-  For Industrial Drives (EnDAT,HDSL) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/EXAMPLES_MOTORCONTROL.html>`__
 
 
 

--- a/source/linux/Foundational_Components_IPC64x.rst
+++ b/source/linux/Foundational_Components_IPC64x.rst
@@ -30,7 +30,7 @@ Prerequisites
    Please be sure that you have the same version number
    for both Processor SDK RTOS and Linux.
 
-`Please refer to the MCU+SDK IPC documentation for R5F and M4F IPC architecture and builds: <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/IPC_GUIDE.html>`__
+`Please refer to the MCU+SDK IPC documentation for R5F and M4F IPC architecture and builds: <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/IPC_GUIDE.html>`__
 
 Typical Boot Flow on AM64x for ARM Linux users
 ----------------------------------------------

--- a/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
+++ b/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
@@ -123,22 +123,22 @@ Reducing bootloader time
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-    You can track current performance numbers here: `AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_00_00_14/exports/docs/api_guide_am62x/DATASHEET_AM62X_EVM.html#autotoc_md105>`_
+    You can track current performance numbers here: `AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/DATASHEET_AM62X_EVM.html#autotoc_md105>`_
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-    You can track current performance numbers here: `AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_00_00_14/exports/docs/api_guide_am62ax/DATASHEET_AM62AX_EVM.html#autotoc_md75>`_
+    You can track current performance numbers here: `AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/DATASHEET_AM62AX_EVM.html#autotoc_md75>`_
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_00_00_14/exports/docs/api_guide_am62px/DATASHEET_AM62PX_EVM.html#autotoc_md47>`_
+    You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/DATASHEET_AM62PX_EVM.html#autotoc_md47>`_
 
 
 - Flashing binaries:
 
     .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-        - `UART flashing tool AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_00_00_14/exports/docs/api_guide_am62x/TOOLS_FLASH.html>`_
+        - `UART flashing tool AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/TOOLS_FLASH.html>`_
 
         - `U-Boot eMMC flashing tool AM62X <https://software-dl.ti.com/processor-sdk-linux/esd/AM62X/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
 
@@ -146,7 +146,7 @@ Reducing bootloader time
 
     .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-        - `UART flashing tool AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_00_00_14/exports/docs/api_guide_am62ax/TOOLS_FLASH.html>`_
+        - `UART flashing tool AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/TOOLS_FLASH.html>`_
 
         - `U-Boot eMMC flashing tool AM62AX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
 
@@ -154,7 +154,7 @@ Reducing bootloader time
 
     .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-        - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_00_00_14/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
+        - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
 
         - `U-Boot eMMC flashing tool AM62PX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62PX/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
 
@@ -164,27 +164,27 @@ Secondary Boot Loader (SBL)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-    The following section will reference `AM62X MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_00_00_14/exports/docs/api_guide_am62x/EXAMPLES_DRIVERS_SBL.html>`_.
+    The following section will reference `AM62X MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/EXAMPLES_DRIVERS_SBL.html>`_.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-    The following section will reference `AM62AX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_00_00_14/exports/docs/api_guide_am62ax/EXAMPLES_DRIVERS_SBL.html>`_.
+    The following section will reference `AM62AX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/EXAMPLES_DRIVERS_SBL.html>`_.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_00_00_14/exports/docs/api_guide_am62px/EXAMPLES_DRIVERS_SBL.html>`_.
+    The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/EXAMPLES_DRIVERS_SBL.html>`_.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-    - `AM62X Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_00_00_14/exports/docs/api_guide_am62x/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
+    - `AM62X Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-    - `AM62AX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_00_00_14/exports/docs/api_guide_am62ax/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
+    - `AM62AX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/10_01_00_33/exports/docs/api_guide_am62ax/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_00_00_14/exports/docs/api_guide_am62px/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
+    - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
 
 - Removing unnecessary prints
 
@@ -233,7 +233,7 @@ Secondary Boot Loader (SBL)
 
                 It is not possible to assign the first 2 channels to DM R5, the next 2 to A53, next 4 again to DM R5 and so on.
 
-        - Rebuild the boardcfg : `BOARCFG_GEN <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_00_00_14/exports/docs/api_guide_am62px/TOOLS_SYSFW.html#BOARCFG_GEN>`_
+        - Rebuild the boardcfg : `BOARCFG_GEN <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/TOOLS_SYSFW.html#BOARCFG_GEN>`_
 
         - Flash the binaries
 

--- a/source/system/Demo_User_Guides/Benchmark_Demo_User_Guide.rst
+++ b/source/system/Demo_User_Guides/Benchmark_Demo_User_Guide.rst
@@ -167,9 +167,9 @@ will then be displayed on the GUI every second.     
 Build Baremetal Demos and Update SD card
 ----------------------------------------
 
-1. Install MCU+ SDK `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/SDK_DOWNLOAD_PAGE.html>`__.
+1. Install MCU+ SDK `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/SDK_DOWNLOAD_PAGE.html>`__.
    Refer MCU+ SDK benchmark demo user guide
-   `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/08_05_00_24/exports/docs/api_guide_am64x/EXAMPLE_MOTORCONTROL_BENCHMARKDEMO.html>`__
+   `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/EXAMPLE_MOTORCONTROL_BENCHMARKDEMO.html>`__
    on how to build demos.
    Generated binaries will be in  <MCU+ SDK>/examples/motor_control/benchmark_demo/am64x-evm/system_nortos
 

--- a/source/system/Demo_User_Guides/Display_Cluster_User_Guide.rst
+++ b/source/system/Demo_User_Guides/Display_Cluster_User_Guide.rst
@@ -84,6 +84,6 @@ Building the Linux Demo binary from sources
 Building the MCU Firmware from sources
 --------------------------------------
 
-    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/09_02_00_38/exports/docs/api_guide_am62px/group__DRV__DSS__MODULE.html>`__
+    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/group__DRV__DSS__MODULE.html>`__
 
 


### PR DESCRIPTION
To make MCU+ SDK links work with 10.1 docs:

    * update AM64X links to 10_01_00_32
    * update AM62X, AM62AX, AM62PX links to 10_01_00_33