### PR TITLE
fix: Update GCC_Toolchain instructions for AM335x/AM437x/AM57x

### DIFF
--- a/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
+++ b/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
@@ -5,7 +5,7 @@ Overview
 
 This document will cover the basic steps for building the Linux kernel.
 
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
    .. rubric:: Install host dependencies
 
@@ -56,7 +56,7 @@ Compiler
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
    Before compiling the kernel or kernel modules the SDK's toolchain needs
    to be added to the PATH environment variable
@@ -67,7 +67,7 @@ Compiler
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
    .. include:: Overview/GCC_ToolChain.rst
       :start-after: .. start_include_yocto_toolchain_host_setup
@@ -94,7 +94,7 @@ The command to clean the kernel is:
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -102,7 +102,7 @@ The command to clean the kernel is:
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -127,7 +127,7 @@ a command of the form:
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -135,7 +135,7 @@ a command of the form:
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -150,7 +150,7 @@ as a starting point).
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     platformName is am335x-evm for AM335x, am437x-evm for AM437x, am57xx-evm for
     AM57xx, k2hk-evm for K2H/K2K, k2e-evm for K2E, k2l-evm for K2L, k2g-evm for
@@ -173,7 +173,7 @@ as a starting point).
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     For example, to apply the recommended kernel configuration for K3 devices, use:
 
@@ -209,7 +209,7 @@ To invoke the kernel configuration you simply use a command like:
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -223,7 +223,7 @@ To invoke the kernel configuration you simply use a command like:
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -250,7 +250,7 @@ Compiling the Kernel
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     Once the kernel has been configured it must be compiled to generate the
     bootable kernel image as well as any dynamic kernel modules that were
@@ -269,7 +269,7 @@ Compiling the Kernel
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     By default U-boot expects to boot kernel `Image`, DTB, and DTOs found in root/boot of the
     SD card if using SD/MMC boot. The exception is for HS-SE (High Security - Security Enforced)
@@ -297,7 +297,7 @@ Compiling the Device Tree Binaries
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     Starting with the 3.8 kernel each TI evm has an unique device tree
     binary file required by the kernel. Therefore, you will need to build
@@ -370,7 +370,7 @@ Compiling the Device Tree Binaries
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     Each TI evm has an unique device tree
     binary file required by the kernel. Therefore, you will need to build
@@ -439,7 +439,7 @@ Compiling the Kernel Modules
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     By default the majority of the Linux drivers used in the sdk are not
     integrated into the kernel image file (zImage). These drivers are built as
@@ -451,7 +451,7 @@ Compiling the Kernel Modules
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     By default the majority of the Linux drivers used in the sdk are not
     integrated into the kernel image file (Image). These drivers are built as
@@ -483,10 +483,19 @@ But developers may want to deploy and test new Kernel and DTB without going
 through the standard build system. For the specific purpose, board specific
 fitImage.its will be present in the prebuilt-images directory.
 
-Pre-requisites ( Already part of SDK installations ):
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
-- Uboot build directory for ARMV8
-- Linux Image and DTB
+   Pre-requisites ( Already part of SDK installations ):
+
+   - Uboot build directory for ARMV7
+   - Linux Image and DTB
+
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
+
+   Pre-requisites ( Already part of SDK installations ):
+
+   - Uboot build directory for ARMV8
+   - Linux Image and DTB
 
 .. note::
 
@@ -626,9 +635,17 @@ Generating the fitImage
 This step will embed the public key in the u-boot.dtb file that was already
 built during the initial u-boot build.
 
-.. code-block:: console
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
-    mkimage -r -f fitImage.its -k $UBOOT_PATH/arch/arm/mach-k3/keys -K $UBOOT_PATH/build/$ARMV8/dts/dt.dtb fitImage
+   .. code-block:: console
+
+      mkimage -r -f fitImage.its -k $UBOOT_PATH/board/ti/keys -K $UBOOT_PATH/build/$ARMV7/dts/dt.dtb fitImage
+
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
+
+   .. code-block:: console
+
+      mkimage -r -f fitImage.its -k $UBOOT_PATH/arch/arm/mach-k3/keys -K $UBOOT_PATH/build/$ARMV8/dts/dt.dtb fitImage
 
 .. note::
 
@@ -639,8 +656,15 @@ built during the initial u-boot build.
 Build uboot again
 ^^^^^^^^^^^^^^^^^
 
-The updated u-boot.dtb needs to be packed in u-boot.img for authentication
-so rebuild uboot ARMV8 without changing any parameters.
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
+
+   The updated u-boot.dtb needs to be packed in u-boot.img for authentication
+   so rebuild uboot ARMV7 without changing any parameters.
+
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
+
+   The updated u-boot.dtb needs to be packed in u-boot.img for authentication
+   so rebuild uboot ARMV8 without changing any parameters.
 
 Refer to :ref:`top-level-makefile`
 
@@ -658,7 +682,7 @@ Installing the Kernel Image and Device Tree Binaries
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -678,7 +702,7 @@ Installing the Kernel Image and Device Tree Binaries
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -714,7 +738,7 @@ file system. The general format of the command is:
 
 ..
   [comment] instructions for 32 bit processors
-.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 
@@ -729,7 +753,7 @@ file system. The general format of the command is:
 
 ..
   [comment] instructions for 64 bit processors
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family')
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
     .. code-block:: console
 

--- a/source/linux/Overview/GCC_ToolChain.rst
+++ b/source/linux/Overview/GCC_ToolChain.rst
@@ -111,8 +111,7 @@ yourself.
 
 .. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
 
-   These libraries include packages from alsa to zlib.
-   or a list of the
+   These libraries include packages from ALSA to zlib, for a list of the
    libraries you can refer to the software manifest found in the **<SDK
    INSTALL DIR>/manifest** directory or look at the list of libraries
    available in the **<SYSROOT_32>/usr/lib** directory. You will
@@ -127,8 +126,7 @@ yourself.
 
 .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
 
-   These libraries include packages from alsa to zlib.
-   or a list of the
+   These libraries include packages from ALSA to zlib, for a list of the
    libraries you can refer to the software manifest found in the **<SDK
    INSTALL DIR>/manifest** directory or look at the list of libraries
    available in the **<SYSROOT_64>/usr/lib** directory. You will

--- a/source/linux/Overview/GCC_ToolChain.rst
+++ b/source/linux/Overview/GCC_ToolChain.rst
@@ -13,7 +13,8 @@ Before compiling any of the sources referenced in this document, set the cross c
 
       host# export CROSS_COMPILE_32="${SDK_INSTALL_DIR}/linux-devkit/sysroots/x86_64-arago-linux/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-"
       host# export SYSROOT_32="${SDK_INSTALL_DIR}/linux-devkit/sysroots/armv7at2hf-neon-oe-linux-gnueabi"
-      host# export CC_32="${CROSS_COMPILE_32}gcc --sysroot=${SYSROOT_32}"
+      host# export CFLAGS="-march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard"
+      host# export CC_32="${CROSS_COMPILE_32}gcc ${CFLAGS} --sysroot=${SYSROOT_32}"
 
 .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
 
@@ -33,9 +34,17 @@ If the Processor SDK is not installed, the Arm GNU toolchains can be downloaded 
 Yocto-built SDK Toolchains
 --------------------------
 
-The |__SDK_FULL_NAME__| package contains cross compile toolchains for the ARMv8
-(:ref:`linux-devkit`) and ARMv7 (:ref:`k3r5-devkit`) architectures. These toolchains
-are used by the :ref:`top level makefile <top-level-makefile>` when
+.. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
+
+   The |__SDK_FULL_NAME__| package contains cross compile toolchain for the ARMv7
+   (:ref:`linux-devkit`) architecture.
+
+.. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
+
+   The |__SDK_FULL_NAME__| package contains cross compile toolchains for the ARMv8
+   (:ref:`linux-devkit`) and ARMv7 (:ref:`k3r5-devkit`) architectures.
+
+These toolchains are used by the :ref:`top level makefile <top-level-makefile>` when
 compiling the binaries for the target. These also package an environment setup
 script that, when sourced, sets all the right variables to compile binaries for
 the target architecture. The toolchain installers are built through the yocto
@@ -65,13 +74,13 @@ referred to using the first column in the following sections.
         - Description
       * - CROSS_COMPILE_32
         - linux-devkit/sysroots/x86_64-arago-linux/usr/bin/arm-oe-linux-gnueabi/arm-oe-linux-gnueabi-
-        - Cross compiler toolchain for the ARMv8 architecture
+        - Cross compiler toolchain for the ARMv7 architecture
       * - SYSROOT_32
         - linux-devkit/sysroots/armv7at2hf-neon-oe-linux-gnueabi/
-        - Sysroot with the cross compiled libraries and headers for the ARMv8 architecture with Linux OS
+        - Sysroot with the cross compiled libraries and headers for the ARMv7 architecture with Linux OS
       * - ENV_SETUP_32
         - linux-devkit/environment-setup-armv7at2hf-neon-oe-linux-gnueabi
-        - Shell script that sets environment variables to compile binaries for the ARMv8 linux target
+        - Shell script that sets environment variables to compile binaries for the ARMv7 linux target
 
 .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
 
@@ -98,23 +107,35 @@ referred to using the first column in the following sections.
 The toolchain within the Linux SDK contains more than just the
 cross-compiler, it also contains pre-built libraries that can be used
 in your applications without requiring you to cross-compile them
-yourself. These libraries include packages from alsa to zlib.
-or a list of the
-libraries you can refer to the software manifest found in the **<SDK
-INSTALL DIR>/manifest** directory or look at the list of libraries
-available in the **<SYSROOT_64>/usr/lib** directory. You will
-also find the header files corresponding to these libraries in the
-**<SYSROOT_64>/usr/include** directory. As
-an example if your application wants access to the alsa asound library
-then you can now do the following command:
+yourself.
 
 .. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
+
+   These libraries include packages from alsa to zlib.
+   or a list of the
+   libraries you can refer to the software manifest found in the **<SDK
+   INSTALL DIR>/manifest** directory or look at the list of libraries
+   available in the **<SYSROOT_32>/usr/lib** directory. You will
+   also find the header files corresponding to these libraries in the
+   **<SYSROOT_32>/usr/include** directory. As
+   an example if your application wants access to the alsa asound library
+   then you can now do the following command:
 
    .. code-block:: console
 
       host# ${CROSS_COMPILE_32}gcc -lasound app.c -o app.out
 
 .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
+
+   These libraries include packages from alsa to zlib.
+   or a list of the
+   libraries you can refer to the software manifest found in the **<SDK
+   INSTALL DIR>/manifest** directory or look at the list of libraries
+   available in the **<SYSROOT_64>/usr/lib** directory. You will
+   also find the header files corresponding to these libraries in the
+   **<SYSROOT_64>/usr/include** directory. As
+   an example if your application wants access to the alsa asound library
+   then you can now do the following command:
 
    .. code-block:: console
 
@@ -194,7 +215,7 @@ libraries.
 
         .. code-block:: console
 
-           host# ${CROSS_COMPILE_32}gcc --sysroot=${SYSROOT_32} helloworld.c -o helloworld
+           host# ${CROSS_COMPILE_32}gcc -march=armv7-a -mthumb -mfpu=neon -mfloat-abi=hard --sysroot=${SYSROOT_32} helloworld.c -o helloworld
 
      .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
 
@@ -227,10 +248,19 @@ libraries.
    simple way to check this is to run the "file" command. It should
    return an output similar to below:
 
-   .. code-block:: console
+   .. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
 
-      host# file helloworld
-      helloworld: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=bb96180ad71bd44e07fc148015a55c844134f30d, for GNU/Linux 3.14.0, with debug_info, not stripped
+      .. code-block:: console
+
+         host# file helloworld
+         helloworld: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, BuildID[sha1]=f163acd736f827b9743b27d9a94e431d63990711, for GNU/Linux 3.2.0, with debug_info, not stripped
+
+   .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
+
+      .. code-block:: console
+
+         host# file helloworld
+         helloworld: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=bb96180ad71bd44e07fc148015a55c844134f30d, for GNU/Linux 3.14.0, with debug_info, not stripped
 
 |
 
@@ -299,4 +329,5 @@ commands of the Foundational Components in this document.
    host# export CROSS_COMPILE_64=$COMPILER_PATH/arm-gnu-toolchain-11.3.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-
    host# export CROSS_COMPILE_32=$COMPILER_PATH/arm-gnu-toolchain-11.3.rel1-x86_64-arm-none-linux-gnueabihf/bin/arm-none-linux-gnueabihf-
    host# export CC_64="${CROSS_COMPILE_64}gcc"
+   host# export CC_32="${CROSS_COMPILE_32}gcc"
 

--- a/source/linux/Overview/_Processor_SDK_Linux_Directory_Structure.rst
+++ b/source/linux/Overview/_Processor_SDK_Linux_Directory_Structure.rst
@@ -9,21 +9,41 @@ directories and files
 
 .. ifconfig:: CONFIG_sdk in ('SITARA')
 
-    .. code-block:: console
+   .. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
 
-        ./
-        ├── bin/
-        ├── board-support/
-        ├── example-applications/
-        ├── filesystem/
-        ├── k3r5-devkit/
-        ├── licenses/
-        ├── linux-devkit/
-        ├── Makefile
-        ├── makerules/
-        ├── manifest/
-        ├── Rules.make
-        └── setup.sh*
+      .. code-block:: console
+
+         ./
+         ├── bin/
+         ├── board-support/
+         ├── example-applications/
+         ├── external-toolchain-dir/
+         ├── filesystem/
+         ├── licenses/
+         ├── linux-devkit/
+         ├── Makefile
+         ├── makerules/
+         ├── manifest/
+         ├── Rules.make
+         └── setup.sh*
+
+   .. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
+
+      .. code-block:: console
+
+         ./
+         ├── bin/
+         ├── board-support/
+         ├── example-applications/
+         ├── filesystem/
+         ├── k3r5-devkit/
+         ├── licenses/
+         ├── linux-devkit/
+         ├── Makefile
+         ├── makerules/
+         ├── manifest/
+         ├── Rules.make
+         └── setup.sh*
 
 .. ifconfig:: CONFIG_sdk in ('JACINTO','j7_foundational')
 
@@ -61,10 +81,21 @@ Processor SDK devices.
 -  **filesystem** - Contains the reference file systems. These include
    the smaller base file system as well as the full-featured SDK file
    system.
--  **linux-devkit** - Contains the tools and libraries to speed
-   development for the target device for the ARMV8 architechture
--  **k3r5-devkit** - Contains the tools and libraries to speed
-   development for the target device for the ARMV7 architechture
+
+.. ifconfig:: CONFIG_part_variant in ('AM335X', 'AM437X', 'AM57X')
+
+   -  **linux-devkit** - Contains the tools and libraries to speed
+      development for the target device for the ARMV7 architechture
+   -  **external-toolchain-dir** - Contains the external ARM GNU toolchain
+      to speed development for the target device for the ARMV7 architechture
+
+.. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X')
+
+   -  **linux-devkit** - Contains the tools and libraries to speed
+      development for the target device for the ARMV8 architechture
+   -  **k3r5-devkit** - Contains the tools and libraries to speed
+      development for the target device for the ARMV7 architechture
+
 -  **Makefile** - Provides build targets for many of the SDK components
    from the top-level of the SDK.
 -  **makerules** - Make rules for all the topLevel Makefile build targets


### PR DESCRIPTION
Fix the invalid architectural references and update cross-compile instructions.

For final docs page view checkout: https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM335X/esd/docs/09_03_05_02/linux/Overview/GCC_ToolChain.html