### PR TITLE
fix(PRU-ICSS): Broken link to XDS Performance Comparison

### DIFF
--- a/source/common/PRU-ICSS/Overview.rst
+++ b/source/common/PRU-ICSS/Overview.rst
@@ -526,9 +526,10 @@ When using the XDS510 USB emulator, why does the PRU Program Counter not increme
 
 There is a known bug associated with PRU debug in the XDS510 USB class
 driver, and a different emulator should be used to debug the PRU. Two
-good alternatives are the XDS200 or the XDS560v2 emulators. Comparative
-benchmarks for various classes of XDS emulators are available at
-`XDS_Performance_comparison </index.php/XDS_Performance_comparison>`__.
+good alternatives are the `XDS200 <https://www.ti.com/tool/TMDSEMU200-U>`_
+or the `XDS560v2 <https://www.ti.com/tool/TMDSEMU560V2STM-U>`_ emulators.
+Comparative benchmarks for various classes of XDS emulators are available
+at `XDS_Performance_comparison <https://software-dl.ti.com/ccs/esd/documents/application_notes/appnote-debug_probe_performance_results.html>`_.
 
 Why are no MMRs outside the PRU subsystem visible from the PRU perspective memory browser window in CCS?
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""


### PR DESCRIPTION
The doc currently references a broken link to XDS_Performance_comparison file which doesn't exist anymore. Modify the doc to drop the reference to this.