### PR TITLE
feat: enable cicd builds for AM62LX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           - AM437X
           - AM57X
           - AM62AX
+          - AM62LX
           - AM62PX
           - AM62X
           - AM64X
@@ -48,6 +49,8 @@ jobs:
             device: AM62PX
           - os: android
             device: AM62X
+          - os: buildroot
+            device: AM62LX
           - os: buildroot
             device: AM62X
           - os: debian


### PR DESCRIPTION
Now that base platform support has been added, enable CICD builds for AM62LX for the linux and buildroot OS configs.