### PR TITLE
feat: temp: Disable Buildroot cicd builds for AM62LX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,6 @@ jobs:
           - os: android
             device: AM62X
           - os: buildroot
-            device: AM62LX
-          - os: buildroot
             device: AM62X
           - os: debian
             device: AM62X


### PR DESCRIPTION
Buildroot flavor of AM62LX docs are not ready yet. Disabling it from CICD flow for now.