### PR TITLE
fix: U-Boot General Info: Update host dependency list

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/UG-General-Info.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-General-Info.rst
@@ -12,7 +12,7 @@ General Information
 
       sudo apt install git xz-utils build-essential autoconf flex bison libssl-dev bc libncurses-dev \
       python3 python3-setuptools python3-dev python3-yaml python3-jsonschema python3-pyelftools \
-      swig yamllint
+      swig yamllint libgnutls28-dev
 
 .. note::
 


### PR DESCRIPTION
libgnutls28-dev provides gnutls/gnutls.h header which is required to build u-boot. Without this package, the u-boot build fails.