### PR TITLE
feat: use editorconfig to enforce formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# Shared editor configuration <https://editorconfig.org>
+
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rst]
+indent_size = 3
+indent_style = space
+
+[*.sh]
+indent_size = 8
+indent_style = tab
+
+[*.py]
+indent_size = 4
+indent_style = space
+
+[Dockerfile]
+indent_size = 8
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -79,10 +79,3 @@ You can access the latest bleeding-edge documentation at the following link:
     - [Processor SDK Documentation](https://texasinstruments.github.io/processor-sdk-doc/)
 
 Please treat GitHub Pages as the most up-to-date source of documentation.
-
-## Tips and Tricks
-
-Add the following to your `init.vim` to automatically use the standard
-whitespace values for RST files:
-
-    autocmd FileType rst set tabstop=3 shiftwidth=3 expandtab


### PR DESCRIPTION
Why recommend formatting in the readme when it can be enforced using a common editor config that's already supported and loaded by vim/nvim and other editors by default [1]? Set some sane properties [2].

[1] https://editorconfig.org/#pre-installed
[2] https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties