### PR TITLE
TF-A: Update TF-A docs for 11.00 release and AM62L APL

### DIFF
--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -42,19 +42,7 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'AM64X', 'J722S')
 
-    .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'J722S')
-
-        *With Low Power Modes enabled (default):*
-
-            .. code-block:: console
-
-                $ export TFA_DIR=<path-to-arm-trusted-firmware>
-                $ cd $TFA_DIR
-                $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 K3_PM_SYSTEM_SUSPEND=1 TARGET_BOARD=lite SPD=opteed
-
     .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'AM64X', 'J722S')
-
-        *Without Low Power Modes enabled:*
 
             .. code-block:: console
 

--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -35,8 +35,8 @@ If it is not possible to use pre-build binary, use the following:
 
 .. code-block:: console
 
-    $ git clone https://github.com/TexasInstruments/arm-trusted-firmware.git
-    $ git checkout <hash>
+   $ git clone https://github.com/TexasInstruments/arm-trusted-firmware.git
+   $ git checkout <hash>
 
 Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
@@ -56,9 +56,9 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
             .. code-block:: console
 
-                $ export TFA_DIR=<path-to-arm-trusted-firmware>
-                $ cd $TFA_DIR
-                $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=lite SPD=opteed
+               $ export TFA_DIR=<path-to-arm-trusted-firmware>
+               $ cd $TFA_DIR
+               $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=lite SPD=opteed
 
     .. ifconfig:: CONFIG_part_variant in ('AM62LX')
 
@@ -66,15 +66,15 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
             .. code-block:: console
 
-                $ export TFA_DIR=<path-to-arm-trusted-firmware>
-                $ cd $TFA_DIR
-                $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=am62l
+               $ export TFA_DIR=<path-to-arm-trusted-firmware>
+               $ cd $TFA_DIR
+               $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=am62l
 
 .. ifconfig:: CONFIG_part_variant in ('J721S2')
 
     .. code-block:: console
 
-        $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=generic SPD=opteed K3_USART=0x8
+       $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=generic SPD=opteed K3_USART=0x8
 
 .. ifconfig:: CONFIG_part_variant in ('J784S4','J742S2')
 
@@ -86,7 +86,7 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
     .. code-block:: console
 
-        $ make CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=generic SPD=opteed
+       $ make CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=generic SPD=opteed
 
 |
 
@@ -96,43 +96,43 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
     .. code-block:: text
 
-        +---------------------------+------------+
-        | ATF image                 | 0x701c0000 |
-        +---------------------------+------------+
-        | OP-TEE image              | 0x9e800000 |
-        +---------------------------+------------+
-        | U-Boot/Linux kernel image | 0x80080000 |
-        +---------------------------+------------+
-        | DTB                       | 0x82000000 |
-        +---------------------------+------------+
+       +---------------------------+------------+
+       | ATF image                 | 0x701c0000 |
+       +---------------------------+------------+
+       | OP-TEE image              | 0x9e800000 |
+       +---------------------------+------------+
+       | U-Boot/Linux kernel image | 0x80080000 |
+       +---------------------------+------------+
+       | DTB                       | 0x82000000 |
+       +---------------------------+------------+
 
 .. ifconfig:: CONFIG_part_family in ('AM62LX_family')
 
     .. code-block:: text
 
-        +---------------------------+------------+
-        | ATF image                 | 0x80000000 |
-        +---------------------------+------------+
-        | OP-TEE image              | 0x80200000 |
-        +---------------------------+------------+
-        | U-Boot/Linux kernel image | 0x80080000 |
-        +---------------------------+------------+
-        | DTB                       | 0x82000000 |
-        +---------------------------+------------+
+       +---------------------------+------------+
+       | ATF image                 | 0x80000000 |
+       +---------------------------+------------+
+       | OP-TEE image              | 0x80200000 |
+       +---------------------------+------------+
+       | U-Boot/Linux kernel image | 0x80080000 |
+       +---------------------------+------------+
+       | DTB                       | 0x82000000 |
+       +---------------------------+------------+
 
 .. ifconfig:: CONFIG_part_family not in ('AM64X_family', 'AM62LX_family')
 
     .. code-block:: text
 
-        +---------------------------+------------+
-        | ATF image                 | 0x70000000 |
-        +---------------------------+------------+
-        | OP-TEE image              | 0x9e800000 |
-        +---------------------------+------------+
-        | U-Boot/Linux kernel image | 0x80080000 |
-        +---------------------------+------------+
-        | DTB                       | 0x82000000 |
-        +---------------------------+------------+
+       +---------------------------+------------+
+       | ATF image                 | 0x70000000 |
+       +---------------------------+------------+
+       | OP-TEE image              | 0x9e800000 |
+       +---------------------------+------------+
+       | U-Boot/Linux kernel image | 0x80080000 |
+       +---------------------------+------------+
+       | DTB                       | 0x82000000 |
+       +---------------------------+------------+
 
 .. ifconfig:: CONFIG_part_variant in ('AM64X', 'AM62X', 'AM62AX', 'AM62PX', 'J722S')
 
@@ -142,26 +142,26 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
     .. code-block:: text
 
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | Source                                              | ATF              | OPTEE                 |  A53 SPL            | A53 U-Boot    | DTB               | kernel   | Comments                               |
-        +=====================================================+==================+=======================+=====================+===============+===================+==========+========================================+
-        | <atf>/plat/ti/k3/board/lite/board.mk                |                  | BL32_BASE             | PRELOADED_BL33_BASE |               | K3_HW_CONFIG_BASE |          | Change K3_HW_CONFIG_BASE for           |
-        |                                                     |                  |                       |                     |               |                   |          | u-boot a53 skip case                   |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <optee>/core/arch/arm/plat-k3/conf.mk               |                  | CFG_TZDRAM_START      |                     |               |                   |          |                                        |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <uboot>/configs/am64x_evm_r5_defconfig              | K3_ATF_LOAD_ADDR |                       |                     |               |                   |          |                                        |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <uboot>/configs/am64x_evm_a53_defconfig             |                  |                       | SPL_TEXT_BASE       | SYS_TEXT_BASE |                   |          | SYS_TEXT_BASE can be set in defconfig, |
-        |                                                     |                  |                       |                     |               |                   |          | has default value in Kconfig           |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <uboot/linux>/arch/arm/dts/k3-am642*.dts files      |                  | reserved-memory nodes |                     |               |                   |          |                                        |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <uboot>/arch/arm/dts/k3-am642-evm-binman.dtsi file  |                  | tee nodes             | uboot nodes         | uboot nodes   |                   |          |                                        |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | <uboot>/include/configs/ti_armv7_common.h           |                  |                       |                     |               | fdtaddr           | loadaddr | If not defined here, u-boot            |
-        |                                                     |                  |                       |                     |               |                   |          | will pick any adress                   |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
-        | uEnv.txt                                            |                  |                       |                     |               | fdtaddr           | loadaddr | Overwrite the u-boot environment       |
-        |                                                     |                  |                       |                     |               |                   |          | variables                              |
-        +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | Source                                              | ATF              | OPTEE                 |  A53 SPL            | A53 U-Boot    | DTB               | kernel   | Comments                               |
+       +=====================================================+==================+=======================+=====================+===============+===================+==========+========================================+
+       | <atf>/plat/ti/k3/board/lite/board.mk                |                  | BL32_BASE             | PRELOADED_BL33_BASE |               | K3_HW_CONFIG_BASE |          | Change K3_HW_CONFIG_BASE for           |
+       |                                                     |                  |                       |                     |               |                   |          | u-boot a53 skip case                   |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <optee>/core/arch/arm/plat-k3/conf.mk               |                  | CFG_TZDRAM_START      |                     |               |                   |          |                                        |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <uboot>/configs/am64x_evm_r5_defconfig              | K3_ATF_LOAD_ADDR |                       |                     |               |                   |          |                                        |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <uboot>/configs/am64x_evm_a53_defconfig             |                  |                       | SPL_TEXT_BASE       | SYS_TEXT_BASE |                   |          | SYS_TEXT_BASE can be set in defconfig, |
+       |                                                     |                  |                       |                     |               |                   |          | has default value in Kconfig           |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <uboot/linux>/arch/arm/dts/k3-am642*.dts files      |                  | reserved-memory nodes |                     |               |                   |          |                                        |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <uboot>/arch/arm/dts/k3-am642-evm-binman.dtsi file  |                  | tee nodes             | uboot nodes         | uboot nodes   |                   |          |                                        |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | <uboot>/include/configs/ti_armv7_common.h           |                  |                       |                     |               | fdtaddr           | loadaddr | If not defined here, u-boot            |
+       |                                                     |                  |                       |                     |               |                   |          | will pick any adress                   |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+
+       | uEnv.txt                                            |                  |                       |                     |               | fdtaddr           | loadaddr | Overwrite the u-boot environment       |
+       |                                                     |                  |                       |                     |               |                   |          | variables                              |
+       +-----------------------------------------------------+------------------+-----------------------+---------------------+---------------+-------------------+----------+----------------------------------------+

--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -14,6 +14,16 @@ it sets up itself as the EL3 monitor handler. Following that, it installs the se
 world software (OP-TEE) and passes execution on to either the Linux kernel or U-Boot
 in the non-secure world.
 
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. rubric:: Power and Clock Management using SCMI
+
+   The AM62Lx System-on-Chip (SoC) utilizes the System Control and Management Interface
+   (SCMI) protocol to manage clocks and power domains. SCMI is a standardized interface for
+   system control and management, providing a common way to access and control system resources.
+   The SCMI IDs used in the AM62L TF-A implementation are documented in the
+   `TF-A documentation <https://github.com/TexasInstruments/arm-trusted-firmware/blob/ti-master/docs/plat/ti-am62l.rst>`__.
+
 |
 
 .. rubric:: Getting the ATF Source Code
@@ -25,7 +35,7 @@ If it is not possible to use pre-build binary, use the following:
 
 .. code-block:: console
 
-    $ git clone https://git.trustedfirmware.org/TF-A/trusted-firmware-a.git
+    $ git clone https://github.com/TexasInstruments/arm-trusted-firmware.git
     $ git checkout <hash>
 
 Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
@@ -40,7 +50,7 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
 .. rubric:: Building ATF
 
-.. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'AM64X', 'J722S')
+.. ifconfig:: CONFIG_part_variant in ('AM62LX', 'AM62X', 'AM62AX', 'AM62PX', 'AM64X', 'J722S')
 
     .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'AM64X', 'J722S')
 
@@ -49,6 +59,16 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
                 $ export TFA_DIR=<path-to-arm-trusted-firmware>
                 $ cd $TFA_DIR
                 $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=lite SPD=opteed
+
+    .. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+        *Without OP-TEE enabled:*
+
+            .. code-block:: console
+
+                $ export TFA_DIR=<path-to-arm-trusted-firmware>
+                $ cd $TFA_DIR
+                $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=am62l
 
 .. ifconfig:: CONFIG_part_variant in ('J721S2')
 
@@ -62,7 +82,7 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
 
         $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=j784s4 SPD=opteed K3_USART=0x8
 
-.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'AM62X', 'AM62AX', 'AM62PX', 'J721S2', 'J784S4','J742S2')
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'AM62X', 'AM62LX', 'AM62AX', 'AM62PX', 'J721S2', 'J784S4','J742S2')
 
     .. code-block:: console
 
@@ -86,7 +106,21 @@ Where <hash> is the commit shown here: :ref:`tf-a-release-notes`.
         | DTB                       | 0x82000000 |
         +---------------------------+------------+
 
-.. ifconfig:: CONFIG_part_family not in ('AM64X_family')
+.. ifconfig:: CONFIG_part_family in ('AM62LX_family')
+
+    .. code-block:: text
+
+        +---------------------------+------------+
+        | ATF image                 | 0x80000000 |
+        +---------------------------+------------+
+        | OP-TEE image              | 0x80200000 |
+        +---------------------------+------------+
+        | U-Boot/Linux kernel image | 0x80080000 |
+        +---------------------------+------------+
+        | DTB                       | 0x82000000 |
+        +---------------------------+------------+
+
+.. ifconfig:: CONFIG_part_family not in ('AM64X_family', 'AM62LX_family')
 
     .. code-block:: text
 


### PR DESCRIPTION
TF-A no longer has any K3_PM_SYSTEM_SUSPEND option, hence this step is no longer relevant.
Also add AM62L relevant docs here.

---

**TI Internal Preview:** http://lcpd911.dhcp.ti.com/sharing/am62l/docs/linux/Foundational_Components_ATF.html