### PR TITLE
feat(linux): AM62LX: Remove Power Management docs from toc

### DIFF
--- a/configs/AM62LX/AM62LX_linux_toc.txt
+++ b/configs/AM62LX/AM62LX_linux_toc.txt
@@ -68,16 +68,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/USB/AM62_DWC3
 linux/Foundational_Components/Kernel/Kernel_Drivers/VTM
 linux/Foundational_Components/Kernel/Kernel_Drivers/Watchdog
 
-linux/Foundational_Components_Power_Management
-linux/Foundational_Components/Power_Management/pm_overview
-linux/Foundational_Components/Power_Management/pm_dfs
-linux/Foundational_Components/Power_Management/pm_cpuidle
-linux/Foundational_Components/Power_Management/pm_runtime_pm
-linux/Foundational_Components/Power_Management/pm_low_power_modes
-linux/Foundational_Components/Power_Management/pm_wakeup_sources
-linux/Foundational_Components/Power_Management/pm_sw_arch
-linux/Foundational_Components/Power_Management/pm_debug
-
 #linux/Foundational_Components/System_Security/SELinux
 
 linux/Foundational_Components_Kernel_Users_Guide


### PR DESCRIPTION
The current documentation for Power Management does not apply to the AM62LX. The information included is either incorrect or untested on. Therefore, remove the Power Management documentation from AM62LX documentation.