### PR TITLE
fix(component-owners): Replace team name with individuals

### DIFF
--- a/.github/component-owners.yml
+++ b/.github/component-owners.yml
@@ -19,7 +19,9 @@ components:
   source/devices/*/android: *android_list
 
   source/system: &mpu_list
-    - texasinstruments/sitara-mpu-linux-sdk
+    - jeevantelukula
+    - jsuhaas22
+    - sadik-smd
   source/buildroot: *mpu_list
   source/linux/Foundational_Components/Hypervisor: *mpu_list
   source/linux/Foundational_Components/Tools: *mpu_list
@@ -35,27 +37,26 @@ components:
 
   source/devices/AM64X/linux: *mpu_list
   source/devices/AM62X/linux:
+    - *mpu_list
     - DhruvaG2000
-    - texasinstruments/sitara-mpu-linux-sdk
 
-  source/devices/AM62AX/linux:
-    - texasinstruments/sitara-mpu-linux-sdk
+  source/devices/AM62AX/linux: *mpu_list
 
   source/devices/AM62PX/linux:
+    - *mpu_list
     - AashvijShenai
-    - texasinstruments/sitara-mpu-linux-sdk
 
   source/devices/AM62LX/linux:
-    - texasinstruments/sitara-mpu-linux-sdk
+    - *mpu_list
     - bryanbrattlof
     - r-vignesh
 
   source/linux/Overview:
-    - texasinstruments/sitara-mpu-linux-sdk
+    - *mpu_list
     - aniket-l
 
   source/linux/Release_Specific:
-    - texasinstruments/sitara-mpu-linux-sdk
+    - *mpu_list
     - aniket-l
     - praneethbajjuri
     - uditkumarti


### PR DESCRIPTION
Replace the texasinstruments/sitara-mpu-linux-sdk team name with the team individuals to fix the workflow issues observed during f9c53c3d8de74145def134f804ba10d88738fc2d