### PR TITLE
Add MMCSD boot from eMMC UDA in FS mode

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -489,7 +489,7 @@ Create software partitions in eMMC UDA
 In eMMC, the User Data Area (UDA) HW partition is the primary storage
 space generally used to flash the rootfs. To prepare the UDA, use
 the :command:`fdisk` command. For ex: :samp:`fdisk /dev/mmcblkN` in
-which **N** is 0 or 1. To find which integer is eMMC use the command
+which **N** is 0 or 1. To find which device index is eMMC use the command
 :command:`lsblk`, like so:
 
 .. code-block:: console

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -250,11 +250,11 @@ Driver Configuration
       :name: building-into-kernel-mmcsd
 
    Ensure that the following config options are set to 'y':
-	* CONFIG_MMC
-	* CONFIG_MMC_BLOCK
-	* CONFIG_MMC_SDHCI
-	* CONFIG_MMC_SDHCI_OMAP  (for DRA7XX and AM57XX devices)
-	* CONFIG_MMC_OMAP        (for AM335X and AM437X devices)
+   * CONFIG_MMC
+   * CONFIG_MMC_BLOCK
+   * CONFIG_MMC_SDHCI
+   * CONFIG_MMC_SDHCI_OMAP  (for DRA7XX and AM57XX devices)
+   * CONFIG_MMC_OMAP        (for AM335X and AM437X devices)
 
    .. rubric:: **Building as Loadable Kernel Module**
 
@@ -438,7 +438,7 @@ Driver Configuration
             pinctrl-0 = <&main_mmc1_pins_default>;
             ti,driver-strength-ohm = <50>;
             disable-wp;
-            sdhci-caps-mask = <0x00000006 0x00000000>; /* Limiting to SDR50 speed mode */
+            sdhci-caps-mask = <0x00000003 0x00000000>; /* Limiting to DDR50 speed mode */
          };
 
       Limiting to SD HS speed mode can also be done by using the property

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -78,7 +78,7 @@ Features
    - Support for both built-in and module mode
    - ext2/ext3/ext4 file system support
 
-.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62AX_family', 'AM64X_family')
+.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62AX_family', 'AM64X_family', 'AM62LX_family')
 
    The SD/MMC driver supports the following features:
 
@@ -208,7 +208,7 @@ SD: Supported High Speed Modes
 
    J721e-sk and AM68-sk does not support eMMC.
 
-.. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM64X', 'AM62PX' )
+.. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM64X', 'AM62PX' ,'AM62LX')
 
    * SD
 
@@ -220,6 +220,7 @@ SD: Supported High Speed Modes
       AM62ax, Y, Y, Y, Y, Y
       am64x, Y, Y, Y, Y, Y
       am62px, Y, Y, Y, Y, Y
+      am62lx, Y, Y, Y, Y, Y
 
    * eMMC
 
@@ -231,6 +232,7 @@ SD: Supported High Speed Modes
       AM62ax, Y, Y, N
       am64x, Y, Y, N
       am62px, Y, Y, Y
+      am62lx, Y, Y, N
 
 Driver Configuration
 ********************
@@ -278,7 +280,7 @@ Driver Configuration
    modules will be loaded and any valid filesystem will be automatically mounted
    if they exist on the card.
 
-.. ifconfig:: CONFIG_part_family in ('J7_family', 'AM62X_family', 'AM64X_family', 'AM62AX_family', 'AM62PX_family')
+.. ifconfig:: CONFIG_part_family in ('J7_family', 'AM62X_family', 'AM64X_family', 'AM62AX_family', 'AM62PX_family', 'AM62LX_family')
 
    The default kernel configuration enables support for MMC/SD driver as
    built-in to kernel. TI SDHCI driver is used. Following options need to be

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -158,7 +158,7 @@ them to the eMMC boot0 HW partition:
       => fatload mmc 1 ${loadaddr} u-boot.img
       => mmc write ${loadaddr} 0x1800 0x2000
 
-.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'J784S4','J742S2', 'J722S')
+.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
 
    .. code-block:: console
 
@@ -170,7 +170,7 @@ them to the eMMC boot0 HW partition:
       => fatload mmc 1 ${loadaddr} u-boot.img
       => mmc write ${loadaddr} 0x1400 0x2000
 
-.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'J784S4','J742S2', 'J722S')
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
 
    .. code-block:: console
 
@@ -204,7 +204,7 @@ eMMC layout
       +----------------------------------+0x3A00   +-------------------------+
             boot0 HW partition (8 MB)                     user partition
 
-.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X')
+.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
 
    .. code-block:: text
 
@@ -221,7 +221,7 @@ eMMC layout
       +----------------------------------+0x3600   +-------------------------+
             boot0 HW partition (8 MB)                     user partition
 
-.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X')
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
 
    .. code-block:: text
 

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -65,7 +65,7 @@ The general syntax is:
 Where [dev] is the MMC device index.
 
 The following lists examples and their explanation for each MMC device
-and partitions according to the example in: :ref:`uboot-listing-mmc-devices`.
+and partitions according to the example :ref:`here <uboot-listing-mmc-devices>`.
 
 .. code-block:: console
 
@@ -83,11 +83,10 @@ boot the device.
 
 .. note::
 
-   For eMMC, typically, the device ships without a partition table If there is
-   a need to create a partition in UDA (to flash the rootfs), please go to:
-   :ref:`create-partitions-in-emmc-uda-from-linux` and format the partition:
-   :ref:`formatting-mmc-partition-from-linux` before proceeding to look at the
-   eMMC partition contents.
+   For eMMC, typically, the device ships without a partition table If there is a need to
+   create a partition in UDA, please go :ref:`here <create-partitions-in-emmc-uda-from-linux>`
+   and to format the partition go :ref:`here <formatting-mmc-partition-from-linux>` before
+   proceeding.
 
 To list software created partitions for any MMC device from u-boot prompt, use the
 command: :command:`mmc part`.
@@ -345,6 +344,8 @@ set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
 
 Where <dev> is MMC device index.
 
+- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+
 .. _uboot-emmc-boot0-config:
 
 Boot from Boot0
@@ -377,11 +378,11 @@ Boot from UDA
 
 **Enable warm reset**
 
-On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
-reset input signal will be ignored. Warm reset is required to be enabled in order
-for the eMMC to be in a "clean state" on power-on reset so that ROM can do a clean
-enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute the
-following command:
+   On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
+   reset input signal will be ignored. Warm reset is required to be enabled in order
+   for the eMMC to be in a "clean state" on power-on reset so that ROM can do
+   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
+   the following command:
 
 .. code-block:: console
 
@@ -390,7 +391,7 @@ following command:
 .. warning::
 
    This is a write-once field. For more information, please refer to the u-boot
-   doc: `MMC CMD <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
 
 Boot Linux from eMMC
 ====================

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -16,9 +16,9 @@ Listing MMC devices
 ===================
 
 Usually in all the platforms there will be two MMC instances of which one
-would be SD and the other would be eMMC. The index of them can vary from
-one class of platforms to the other. For a given platform, the device
-number: **mmcdev=[0:1]** can be found in the following way:
+would be SD and the other would be eMMC. The device index of them can vary from
+one class of platforms to the other. For a given platform, the device index
+can be found in the following way:
 
 .. code-block:: console
 
@@ -26,8 +26,12 @@ number: **mmcdev=[0:1]** can be found in the following way:
    sdhci@fa10000: 0 (eMMC)
    sdhci@fa00000: 1 (SD)
 
-The device number "**0**" for eMMC will be needed when flashing to the eMMC device
-in: :ref:`flash-and-boot-to-uboot-prompt`.
+The device index "**0**" for eMMC will be used when flashing to the eMMC device
+:ref:`here <uboot-emmc-flash-and-boot-to-uboot-prompt>` using :command:`mmc dev` command.
+
+In u-boot environment, usually **mmcdev=n** is used to selct which MMC device to boot
+Linux from, where **n** is the device index.
+
 
 .. _uboot-selecting-mmc-device-and-partitions:
 
@@ -40,6 +44,8 @@ The general syntax is:
 .. code-block:: console
 
    => mmc dev [dev] [partition]
+
+Where [dev] is the MMC device index.
 
 The following lists examples and their explanation for each MMC device
 and partitions according to the example in: :ref:`uboot-listing-mmc-devices`.
@@ -250,7 +256,7 @@ set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
 
    $ mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]
 
-- For more information on these commands, please refer to: `MMC CMD <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+Where <dev> is MMC device index.
 
 **Boot from boot0 HW partition of eMMC:**
 

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -32,11 +32,28 @@ The device index "**0**" for eMMC will be used when flashing to the eMMC device
 In u-boot environment, usually **mmcdev=n** is used to selct which MMC device to boot
 Linux from, where **n** is the device index.
 
+MMC HW partitions
+=================
+
+This sections includes a summary of MMC hardware partitions.
+
+**eMMC**
+
+   Normally eMMC is divided into 4 areas (aka HW partitions):
+
+   - UDA (User Data Area): Used to store user data such as a file system. This partition can divided into several partitions
+   - Boot0/1: Used to store firmware and data needed during boot
+   - RPMB (Replay-protected memory-block area): Used to store secure data
+
+**SD**
+
+   SD card memory is not divided into sections like eMMC, but acts like UDA in eMMC where user can
+   create partitions in software allowing to logically divide the storage space into multiple sections.
 
 .. _uboot-selecting-mmc-device-and-partitions:
 
-Selecting MMC device and paritions
-==================================
+Selecting MMC device and partitions
+===================================
 
 To selct an MMC device in u-boot, the command: :command:`mmc dev` could be used.
 The general syntax is:
@@ -52,11 +69,11 @@ and partitions according to the example in: :ref:`uboot-listing-mmc-devices`.
 
 .. code-block:: console
 
-   => mmc dev 0 0 # select eMMC user HW partition (UDA)
-   => mmc dev 0 1 # select eMMC boot0 HW partition
-   => mmc dev 0 2 # select eMMC boot1 HW partition
-   => mmc dev 1 1 # select SD "boot" partition
-   => mmc dev 1 2 # select SD "root" partition
+   => mmc dev 0 0 # select eMMC UDA
+   => mmc dev 0 1 # select eMMC Boot0
+   => mmc dev 0 2 # select eMMC Boot1
+   => mmc dev 1 1 # select SD first partition (typically named 'boot')
+   => mmc dev 1 2 # select SD second partition (typically named 'root')
 
 View MMC partition contents
 ===========================
@@ -72,7 +89,7 @@ boot the device.
    :ref:`formatting-mmc-partition-from-linux` before proceeding to look at the
    eMMC partition contents.
 
-To verify partitions in any MMC device from u-boot prompt, use the
+To list software created partitions for any MMC device from u-boot prompt, use the
 command: :command:`mmc part`.
 
 .. code-block:: console
@@ -202,7 +219,7 @@ eMMC layout
       +----------------------------------+0x3900   |                         |
       |   backup environment (128 KB)    |         |                         |
       +----------------------------------+0x3A00   +-------------------------+
-            boot0 HW partition (8 MB)                     user partition
+                   Boot0 (8 MB)                              UDA
 
 .. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
 
@@ -219,7 +236,7 @@ eMMC layout
       +----------------------------------+0x3500   |                         |
       |   backup environment (128 KB)    |         |                         |
       +----------------------------------+0x3600   +-------------------------+
-            boot0 HW partition (8 MB)                     user partition
+                   Boot0 (8 MB)                              UDA
 
 .. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
 
@@ -239,7 +256,7 @@ eMMC layout
       +----------------------------------+0x3600   |                         |
       |          sysfw (1 MB)            |         |                         |
       +----------------------------------+0x3E00   +-------------------------+
-            boot0 HW partition (8 MB)                     user partition
+                   Boot0 (8 MB)                              UDA
 
 eMMC boot configuration
 -----------------------
@@ -258,26 +275,30 @@ set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
 
 Where <dev> is MMC device index.
 
-**Boot from boot0 HW partition of eMMC:**
+.. _uboot-emmc-boot0-config:
+
+Boot from Boot0
+```````````````
 
 .. code-block:: console
 
    => mmc partconf 0 1 1 1
    => mmc bootbus 0 2 0 0
 
-**Boot from boot1 HW hardware partition of eMMC:**
+.. _uboot-emmc-boot1-config:
+
+Boot from Boot1
+```````````````
 
 .. code-block:: console
 
    => mmc partconf 0 1 2 1
    => mmc bootbus 0 2 0 0
 
-.. note::
+.. _uboot-emmc-uda-config:
 
-   When booting from boot1 HW partition, make sure to flash the partition using:
-   :samp:`mmc dev 0 2`.
-
-**Boot from UDA HW partition of eMMC:**
+Boot from UDA
+`````````````
 
 .. code-block:: console
 
@@ -322,7 +343,7 @@ To boot Linux from eMMC, use the following commands after flashing rootfs to UDA
 Flashing an MMC device using USB-DFU
 ====================================
 
-To flash the eMMC device (boot0 HW partition) using USB-DFU, the device should
+To flash the eMMC device (Boot0) using USB-DFU, the device should
 be booted to u-boot prompt and a USB cable connected from the host machine
 to the device USB port configured to USB peripheral mode.
 
@@ -333,8 +354,10 @@ From u-boot prompt execute the following:
    => setenv dfu_alt_info ${dfu_alt_info_emmc}
    => dfu 0 mmc 0
 
-and on the host machine have the bootloader binaries ready to flash
-to eMMC boot0 HW partition. Execute the :command:`dfu-util` to transfer
+This comands assumes eMMC device exists and is mmc device 0.
+
+On the host machine have the bootloader binaries ready to flash
+to eMMC Boot0. Execute the :command:`dfu-util` to transfer
 files to the device. The general syntax for dfu-util command is:
 
 .. code-block:: console

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -362,11 +362,17 @@ Then transfer each desired binary from the host to the device:
    .. code-block:: console
 
       $ sudo dfu-util -R -a tiboot3.bin.raw -D tiboot3.bin
+      $ sudo dfu-util -R -a tispl.bin.raw -D tispl.bin
+      $ sudo dfu-util -R -a u-boot.img.raw -D u-boot.img
 
 - Device:
 
    .. code-block:: console
 
+      ##DOWNLOAD ... OK
+      Ctrl+C to exit ...
+      ##DOWNLOAD ... OK
+      Ctrl+C to exit ...
       ##DOWNLOAD ... OK
       Ctrl+C to exit ...
 


### PR DESCRIPTION
This  PR documents MMCSD boot from eMMC UDA in FS mode. This is necessary since we only document eMMC boot but this boot mode may not always be supported and is not supported for am62l, see details in errata: https://www.ti.com/lit/pdf/sprz582.