### PR TITLE
Bugfix/u boot syntax

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/ADC.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/ADC.rst
@@ -229,7 +229,7 @@ You can find the source code for ADC in the kernel sources at
 ``drivers/iio/adc/ti_am335x_adc.c``.
 
 .. rubric:: **Usage**
-   :name: usage
+   :name: adc-usage
 
 To test ADC, Connect a DC voltage supply to each of the AIN0 through
 AIN7 pins (based on your channel configuration), and vary voltage

--- a/source/linux/How_to_Guides/Host/How_to_Flash_Linux_System_from_U-boot.rst
+++ b/source/linux/How_to_Guides/Host/How_to_Flash_Linux_System_from_U-boot.rst
@@ -108,7 +108,7 @@ How to Flash from U-boot Shell
 
     All of the following commands are performed at the u-boot prompt.
 
-      These commands are actually a series of u-boot commands that are
+    These commands are actually a series of u-boot commands that are
     connected together with semicolons.  The individual commands can be
     entered separately or simple pasted from here.
 
@@ -135,7 +135,7 @@ How to Flash from U-boot Shell
     .. rubric:: Put the EVM in NAND boot mode
        :name: put-the-evm-in-nandboot-mode
 
-     With the EVM in NAND boot mode and the images flashed in NAND as
+    With the EVM in NAND boot mode and the images flashed in NAND as
     detailed above, the SD card does not need to be in the EVM at boot up.
     X-loader and u-boot will run from NAND.  In order to also pull the Linux
     kernel (uImage) from NAND it will be necessary to halt the boot process

--- a/source/linux/Overview/GCC_ToolChain.rst
+++ b/source/linux/Overview/GCC_ToolChain.rst
@@ -185,7 +185,7 @@ is as simple as:
 
 
 .. rubric:: Example usage
-   :name: usage
+   :name: linux-devkit-usage
 
 In the simplest case the cross-compiler can be used to compile simple
 applications that just need access to standard libraries. The


### PR DESCRIPTION
- fix: use verbose explicit names

  Explicit names don't help anyone if the name is simply "usage".

  Signed-off-by: Randolph Sapp <rs@ti.com>

- fix(u-boot-flash): resolve 2 syntax errors

  ERROR: Error in "rubric" directive WARNING: Block quote ends without a blank
  line; unexpected unindent.

  Signed-off-by: Randolph Sapp <rs@ti.com>