### PR TITLE
feat(linux): document errata i2458 for eMMC HS400

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -215,14 +215,14 @@ SD: Supported High Speed Modes
    * SD
 
    .. csv-table::
-      :header: "Platform", "SDR104", "DDR50", "SDR50", "SDR25", "SDR12"
+      :header: "Platform", "SDR12", "SDR25", "SDR50", "DDR50", "SDR104"
       :widths: auto
 
       AM62*, Y, Y, Y, Y, Y
       AM62ax, Y, Y, Y, Y, Y
       am64x, Y, Y, Y, Y, Y
       am62px, Y, Y, Y, Y, Y
-      am62lx, Y, Y, Y, Y, Y
+      am62lx, N, N, N, N, N
 
    * eMMC
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -69,7 +69,7 @@ Features
    -  SD cards including SD High Speed and SDHC cards
    -  Uses block bounce buffer to aggregate scattered blocks
 
-.. ifconfig:: CONFIG_part_family in ('J7_family', 'AM62PX_family')
+.. ifconfig:: CONFIG_part_family in ('J7_family')
 
    The SD/MMC driver supports the following features:
 
@@ -78,7 +78,7 @@ Features
    - Support for both built-in and module mode
    - ext2/ext3/ext4 file system support
 
-.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62AX_family', 'AM64X_family', 'AM62LX_family')
+.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62AX_family', 'AM64X_family', 'AM62LX_family', 'AM62PX_family')
 
    The SD/MMC driver supports the following features:
 
@@ -86,6 +86,8 @@ Features
    - HS200 speed mode
    - Support for both built-in and module mode
    - ext2/ext3/ext4 file system support
+
+.. _mmc-sd-supported-hs-modes:
 
 SD: Supported High Speed Modes
 ******************************
@@ -231,7 +233,7 @@ SD: Supported High Speed Modes
       AM62*, Y, Y, N
       AM62ax, Y, Y, N
       am64x, Y, Y, N
-      am62px, Y, Y, Y
+      am62px, Y, Y, N
       am62lx, Y, Y, N
 
 Driver Configuration
@@ -480,6 +482,43 @@ Driver Configuration
          };
 
          sdhci2: mmc@fa20000 {
+
+eMMC HS400 support in Linux
+===========================
+
+.. ifconfig:: CONFIG_part_family in ('AM62PX_family')
+
+   For 11.0 SDK, am62px device does not support eMMC HS400 mode due to errata i2458.
+   If support for HS400 is anyways required, please add the following DT attributes to sdhci0 node:
+
+   .. code-block:: diff
+
+      diff --git a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      index 3e5ca8a3eb86..a05b22a6e5a2 100644
+      --- a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      +++ b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      @@ -593,12 +593,16 @@ sdhci0: mmc@fa10000 {
+                      bus-width = <8>;
+                      mmc-ddr-1_8v;
+                      mmc-hs200-1_8v;
+      +               mmc-hs400-1_8v;
+                      ti,clkbuf-sel = <0x7>;
+                      ti,trm-icp = <0x8>;
+      +               ti,strobe-sel = <0x55>;
+                      ti,otap-del-sel-legacy = <0x1>;
+                      ti,otap-del-sel-mmc-hs = <0x1>;
+                      ti,otap-del-sel-ddr52 = <0x6>;
+                      ti,otap-del-sel-hs200 = <0x8>;
+      +               ti,otap-del-sel-hs400 = <0x5>; // at 0.85V VDD_CORE
+      +               //ti,otap-del-sel-hs400 = <0x7>; // at 0.75V VDD_CORE
+                      ti,itap-del-sel-legacy = <0x10>;
+                      ti,itap-del-sel-mmc-hs = <0xa>;
+                      ti,itap-del-sel-ddr52 = <0x3>;
+
+.. ifconfig:: CONFIG_part_family not in ('AM62PX_family')
+
+	eMMC HS400 is not suppported, refer to :ref:`this <mmc-sd-supported-hs-modes>` table for the list of modes supported in Linux
+	for |__PART_FAMILY_NAME__| SoC.
 
 |
 

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -1010,3 +1010,60 @@ increasing order of reducing performance.
       };
 
       sdhci2: mmc@fa20000 {
+
+eMMC HS400 support in u-boot
+============================
+
+.. ifconfig:: CONFIG_part_family in ('AM62PX_family')
+
+   For 11.0 SDK, am62px device does not support eMMC HS400 mode due to errata i2458.
+   If support for HS400 is anyways required, please add the following DT attributes to sdhci0 node:
+
+   .. code-block:: diff
+
+      diff --git a/dts/upstream/src/arm64/ti/k3-am62p-j722s-common-main.dtsi b/dts/upstream/src/arm64/ti/k3-am62p-j722s-common-main.dtsi
+      index 8bfc6539b2a..8a536b081e1 100644
+      --- a/dts/upstream/src/arm64/ti/k3-am62p-j722s-common-main.dtsi
+      +++ b/dts/upstream/src/arm64/ti/k3-am62p-j722s-common-main.dtsi
+      @@ -593,12 +593,16 @@
+                      bus-width = <8>;
+                      mmc-ddr-1_8v;
+                      mmc-hs200-1_8v;
+      +               mmc-hs400-1_8v;
+                      ti,clkbuf-sel = <0x7>;
+      +               ti,strobe-sel = <0x55>;
+                      ti,trm-icp = <0x8>;
+                      ti,otap-del-sel-legacy = <0x1>;
+                      ti,otap-del-sel-mmc-hs = <0x1>;
+                      ti,otap-del-sel-ddr52 = <0x6>;
+                      ti,otap-del-sel-hs200 = <0x8>;
+      +               ti,otap-del-sel-hs400 = <0x5>; // at 0.85V VDD_CORE
+      +               //ti,otap-del-sel-hs400 = <0x7>; // at 0.75V VDD_CORE
+                      ti,itap-del-sel-legacy = <0x10>;
+                      ti,itap-del-sel-mmc-hs = <0xa>;
+                      ti,itap-del-sel-ddr52 = <0x3>;
+
+   and enable the following config options:
+
+   .. code-block:: diff
+
+      diff --git a/configs/am62px_evm_a53_defconfig b/configs/am62px_evm_a53_defconfig
+      index 09a91248ce6..f95879f41c9 100644
+      --- a/configs/am62px_evm_a53_defconfig
+      +++ b/configs/am62px_evm_a53_defconfig
+      @@ -114,8 +114,8 @@ CONFIG_MMC_IO_VOLTAGE=y
+       CONFIG_SPL_MMC_IO_VOLTAGE=y
+       CONFIG_MMC_UHS_SUPPORT=y
+       CONFIG_SPL_MMC_UHS_SUPPORT=y
+      -CONFIG_MMC_HS200_SUPPORT=y
+      -CONFIG_SPL_MMC_HS200_SUPPORT=y
+      +CONFIG_MMC_HS400_SUPPORT=y
+      +CONFIG_SPL_MMC_HS400_SUPPORT=y
+       CONFIG_MMC_SDHCI=y
+       CONFIG_MMC_SDHCI_ADMA=y
+       CONFIG_SPL_MMC_SDHCI_ADMA=y
+
+.. ifconfig:: CONFIG_part_family not in ('AM62PX_family')
+
+	eMMC HS400 is not suppported, refer to :ref:`this <mmc-sd-supported-hs-modes>` table for the list of modes supported in u-boot
+	for |__PART_FAMILY_NAME__| SoC.


### PR DESCRIPTION
Document errata i2458 for eMMC HS400 bus mode. If support for eMMC HS400 is still required, provide instructions for enabling eMMC HS400 mode.