### PR TITLE
Boot from eMMC update

### DIFF
--- a/configs/AM62AX/AM62AX_linux_toc.txt
+++ b/configs/AM62AX/AM62AX_linux_toc.txt
@@ -115,6 +115,8 @@ linux/How_to_Guides/Host/K3_Resource_Partitioning_Tool
 linux/How_to_Guides/Host/SYSFW_Trace_Parser
 linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customization
 linux/How_to_Guides/Target/How_to_boot_quickly
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_test_MCAN_on_AM62x
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux

--- a/configs/AM62LX/AM62LX_linux_toc.txt
+++ b/configs/AM62LX/AM62LX_linux_toc.txt
@@ -102,6 +102,8 @@ linux/How_to_Guides/Host/SYSFW_Trace_Parser
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_playback_audio_over_HDMI
 #linux/How_to_Guides/Target/How_to_boot_quickly
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux
 linux/How_to_Guides/Target/Runtime_debug_unlock_on_secure_device
 linux/How_to_Guides/FAQ/How_to_Check_Device_Tree_Info

--- a/configs/AM62PX/AM62PX_linux_toc.txt
+++ b/configs/AM62PX/AM62PX_linux_toc.txt
@@ -140,7 +140,8 @@ linux/How_to_Guides/Host/How_to_Setup_and_Debug_using_Lauterbach
 linux/How_to_Guides/Host/SYSFW_Trace_Parser
 #linux/How_to_Guides/Host/Minimal_Platform_Development
 linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customization
-#linux/How_to_Guides/Target/How_to_manually_flash_emmc_device   # We do not support this for now
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 #linux/How_to_Guides/Target/How_to_suspend_to_ram_on_AM62x
 linux/How_to_Guides/Target/How_to_test_MCAN_on_AM62x
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux

--- a/configs/AM62X/AM62X_linux_toc.txt
+++ b/configs/AM62X/AM62X_linux_toc.txt
@@ -146,7 +146,8 @@ linux/How_to_Guides/Host/SYSFW_Trace_Parser
 linux/How_to_Guides/Host/Minimal_Platform_Development
 linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customization
 linux/How_to_Guides/Target/How_to_boot_quickly
-#linux/How_to_Guides/Target/How_to_manually_flash_emmc_device   # We do not support this for now
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_suspend_to_ram_on_AM62x
 linux/How_to_Guides/Target/How_to_test_MCAN_on_AM62x
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux

--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -128,6 +128,8 @@ linux/How_to_Guides/Host/K3_Resource_Partitioning_Tool
 linux/How_to_Guides/Host/How_to_Setup_and_Debug_using_Lauterbach
 linux/How_to_Guides/Host/SYSFW_Trace_Parser
 linux/How_to_Guides/Host/Program_MMC_boot_media
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Hardware_Setup_with_CCS/AM64x_EVM_Hardware_Setup
 linux/How_to_Guides/FAQ/How_to_Verify_Ipc_Linux_R5
 linux/How_to_Guides/FAQ/How_to_Check_Device_Tree_Info

--- a/configs/AM67/AM67_linux_toc.txt
+++ b/configs/AM67/AM67_linux_toc.txt
@@ -113,6 +113,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/AM67A/AM67A_linux_toc.txt
+++ b/configs/AM67A/AM67A_linux_toc.txt
@@ -114,6 +114,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/AM69/AM69_linux_toc.txt
+++ b/configs/AM69/AM69_linux_toc.txt
@@ -118,6 +118,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/AM69A/AM69A_linux_toc.txt
+++ b/configs/AM69A/AM69A_linux_toc.txt
@@ -119,6 +119,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/FAQ/How_to_Verify_Ipc_Linux_R5

--- a/configs/J7200/J7200_linux_toc.txt
+++ b/configs/J7200/J7200_linux_toc.txt
@@ -100,6 +100,8 @@ linux/How_to_Guides/Host/K3_Resource_Partitioning_Tool
 linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customization
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/J721E/J721E_linux_toc.txt
+++ b/configs/J721E/J721E_linux_toc.txt
@@ -123,6 +123,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/J721S2/J721S2_linux_toc.txt
+++ b/configs/J721S2/J721S2_linux_toc.txt
@@ -122,6 +122,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/J722S/J722S_linux_toc.txt
+++ b/configs/J722S/J722S_linux_toc.txt
@@ -117,6 +117,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/J742S2/J742S2_linux_toc.txt
+++ b/configs/J742S2/J742S2_linux_toc.txt
@@ -121,6 +121,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/configs/J784S4/J784S4_linux_toc.txt
+++ b/configs/J784S4/J784S4_linux_toc.txt
@@ -121,6 +121,8 @@ linux/How_to_Guides/Target/Processor_SDK_Linux_File_System_Optimization_Customiz
 linux/How_to_Guides/Target/How_to_Change_dtb_File
 linux/How_to_Guides/Target/How_to_enable_DT_overlays_in_linux
 linux/How_to_Guides/Target/How_to_manually_flash_emmc_device
+linux/How_to_Guides/Target/How_to_emmc_boot
+linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
 linux/How_to_Guides/Target/How_to_visualize_statistics_data
 linux/How_to_Guides/Target/How_to_Use_K3Conf_Tool
 linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -483,6 +483,8 @@ Driver Configuration
 
 |
 
+.. _mmc-listing-mmc-devices-linux:
+
 Listing MMC devices from Linux
 ******************************
 eMMC and SD cards are registered to the MMC subsystem and availiable as a block device
@@ -520,10 +522,10 @@ command :command:`lsblk`, like so:
 Use the :command:`umount` and :command:`mount` commands to mount and unmount software partitions
 if they are formated, usally to vfat or ext4 types.
 
-.. _create-partitions-in-emmc-uda-from-linux:
+.. _mmc-create-partitions-in-emmc-linux:
 
-Create software partitions in eMMC UDA
-**************************************
+Create partitions in eMMC UDA
+*****************************
 
 In eMMC, the User Data Area (UDA) HW partition is the primary storage space generally used
 to flash the rootfs. To create logical paritions in UDA, use the :command:`fdisk` command.
@@ -532,7 +534,7 @@ eMMC is :samp:`fdisk /dev/mmcblk0`.
 
 For documentation on using fdisk, please go to: `fdisk how-to <https://tldp.org/HOWTO/Partition/fdisk_partitioning.html>`__.
 
-.. _create-boot-partition-in-emmc-uda-from-linux:
+.. _mmc-create-boot-partition-emmc-linux:
 
 Create "boot" partition
 =======================
@@ -542,6 +544,8 @@ and will store the bootloader binaries.
 
 .. code-block:: console
 
+   root@<machine>:~# umount /dev/mmcblk0*
+   root@<machine>:~# dd if=/dev/zero of=/dev/mmcblk0 bs=1024 count=1024
    root@<machine>:~# fdisk /dev/mmcblk0
 
    Welcome to fdisk (util-linux 2.39.3).
@@ -585,7 +589,7 @@ and will store the bootloader binaries.
 Make sure bootable flag is set for "boot" partition, ROM may not boot from this patitition
 if bootable flag is not set.
 
-.. _create-root-partition-in-emmc-uda-from-linux:
+.. _mmc-create-root-partition-emmc-linux:
 
 Create "root" partition
 =======================
@@ -595,6 +599,8 @@ Linux kernel Image, DTB, and the rootfs.
 
 .. code-block:: console
 
+   root@<machine>:~# umount /dev/mmcblk0*
+   root@<machine>:~# dd if=/dev/zero of=/dev/mmcblk0 bs=1024 count=1024
    root@<machine>:~# fdisk /dev/mmcblk0
 
    Welcome to fdisk (util-linux 2.39.3).
@@ -647,7 +653,7 @@ Linux kernel Image, DTB, and the rootfs.
       |-mmcblk1p1  /run/media/boot-mmcblk1p1 boot   128M 681F-55DD
       `-mmcblk1p2  /                         root   8.7G ead4c8bb-fa37-4c4d-9ba3-47a1f3824764
 
-.. _formatting-mmc-partition-from-linux:
+.. _mmc-format-partition-linux:
 
 Formatting eMMC partitions from Linux
 *************************************
@@ -660,32 +666,32 @@ software partitions to format. The general syntax for formatting disk partitions
 
    mkfs [options] [-t type fs-options] device [size]
 
-.. _format-partition-vfat:
+.. _mmc-format-partition-vfat:
 
 Format to vfat
 ==============
 
-In this example, format the first created partition to type vfat.
+In this example, format the first partition to type vfat.
 
 .. code-block:: console
 
-   root@<machine>:~# mkfs -t vfat /dev/mmcblk0p1
+   root@<machine>:~# mkfs.vfat -F 32 -n "boot" /dev/mmcblk0p1
 
-.. _format-partition-ext4:
+.. _mmc-format-partition-ext4:
 
 Format to ext4
 ==============
 
-In this example, format the first created partition to type ext4.
+In this example, format the second partition to type ext4.
 
 .. code-block:: console
 
-   root@<machine>:~# mkfs -t ext4 /dev/mmcblk0p2
+   root@<machine>:~# mkfs.ext4 -L "root" /dev/mmcblk0p2
 
-.. _flash-emmc-mmcsd-boot-uda-fs:
+.. _mmc-flash-emmc-uda:
 
-Flash eMMC for MMCSD boot from eMMC UDA in FS mode
-**************************************************
+Flash eMMC for MMCSD boot
+*************************
 
 In this example, we show one simple method for flashing to eMMC for MMCSD boot from
 eMMC UDA in FS mode. Please know this is not the only method for flashing the eMMC
@@ -693,14 +699,17 @@ for this bootmode.
 
 This example assumes the current bootmode is MMCSD boot from SD (FS mode)
 
-Flash to eMMC "boot" software partition
-=======================================
+.. _mmc-flash-emmc-uda-boot:
+
+Flash to eMMC "boot" partition
+==============================
 
 .. code-block:: console
 
-   root@<machine>:~# mkdir eboot sdboot
-   root@<machine>:~# mount /dev/mmcblk0p1 eboot
-   root@<machine>:~# mount /dev/mmcblk1p1 sdboot
+   root@<machine>:~# umount /run/media/*
+   root@<machine>:~# mkdir /mnt/eboot /mnt/sdboot
+   root@<machine>:~# mount /dev/mmcblk0p1 /mnt/eboot
+   root@<machine>:~# mount /dev/mmcblk1p1 /mnt/sdboot
 
 Verify the partitions are mounted to the correct folders using :command:`lsblk` command in the
 column labeled :file:`MOUNTPOINTS`.
@@ -710,36 +719,35 @@ column labeled :file:`MOUNTPOINTS`.
    root@<machine>:~# lsblk
    NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
    mmcblk0      179:0    0 14.8G  0 disk
-   |-mmcblk0p1  179:1    0  400M  0 part /root/eboot
+   |-mmcblk0p1  179:1    0  400M  0 part /mnt/eboot
    `-mmcblk0p2  179:2    0 14.4G  0 part
    mmcblk0boot0 179:32   0 31.5M  1 disk
    mmcblk0boot1 179:64   0 31.5M  1 disk
    mmcblk1      179:96   0 29.7G  0 disk
-   |-mmcblk1p1  179:97   0  128M  0 part /root/sdboot
-   |                                     /run/media/boot-mmcblk1p1
+   |-mmcblk1p1  179:97   0  128M  0 part /mnt/sdboot
    `-mmcblk1p2  179:98   0  8.7G  0 part /
 
 Now we can copy bootloader binaries to eMMC and umount the partitions when writes finish.
 
 .. code-block:: console
 
-   root@<machine>:~# cd sdboot/
-   root@<machine>:~# ls
+   root@<machine>:~# ls /mnt/sdboot/
    tiboot3.bin  tispl.bin	u-boot.img  uEnv.txt
-   root@<machine>:~# cp tiboot3.bin tispl.bin u-boot.img ../eboot/
-   root@<machine>:~# cd ../ && umount sd* && umount e*
+   root@<machine>:~# cp /mnt/sdboot/* /mnt/eboot/
+   root@<machine>:~# sync && umount /mnt/*
 
-.. _flash-emmc-mmcsd-boot-uda-fs-root:
+.. _mmc-flash-emmc-uda-root:
 
-Flash to eMMC "root" software partition
-=======================================
+Flash to eMMC "root" partition
+==============================
 
 .. code-block:: console
 
-   root@<machine>:~# mkdir eroot sdroot
-   root@<machine>:~# mount /dev/mmcblk0p2 eroot
+   root@<machine>:~# umount /run/media/*
+   root@<machine>:~# mkdir /mnt/eroot /mnt/sdroot
+   root@<machine>:~# mount /dev/mmcblk0p2 /mnt/eroot
    [69229.982452] EXT4-fs (mmcblk0p2): mounted filesystem 74d40075-07e4-4bce-9401-6fccef68e934 r/w with ordered data mode. Quota mode: none.
-   root@<machine>:~# mount /dev/mmcblk1p2 sdroot
+   root@<machine>:~# mount /dev/mmcblk1p2 /mnt/sdroot
 
 Verify the partitions are mounted to the correct folders using :command:`lsblk` command in the
 column labeled :file:`MOUNTPOINTS`.
@@ -750,23 +758,38 @@ column labeled :file:`MOUNTPOINTS`.
    NAME         MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
    mmcblk0      179:0    0 14.8G  0 disk
    |-mmcblk0p1  179:1    0  400M  0 part
-   `-mmcblk0p2  179:2    0 14.4G  0 part /root/eroot
+   `-mmcblk0p2  179:2    0 14.4G  0 part /mnt/eroot
    mmcblk0boot0 179:32   0 31.5M  1 disk
    mmcblk0boot1 179:64   0 31.5M  1 disk
    mmcblk1      179:96   0 29.7G  0 disk
    |-mmcblk1p1  179:97   0  128M  0 part
-   |                                     /run/media/boot-mmcblk1p1
-   `-mmcblk1p2  179:98   0  8.7G  0 part /root/sdroot
+   `-mmcblk1p2  179:98   0  8.7G  0 part /mnt/sdroot
                                          /
 
-Now we can copy rootfs to eMMC and umount the partitions when writes finish.
+Now we can copy rootfs to eMMC (either from SD rootfs or from tarball) and umount the partitions
+when writes finish.
+
+**From SD**
 
 .. code-block:: console
 
-   root@<machine>:~# cd sdroot
-   root@<machine>:~# ls
+   root@<machine>:~# ls /mnt/sdroot
    bin   dev  home  lost+found  mnt  proc	run   srv  tmp	var
    boot  etc  lib	 media	     opt  root	sbin  sys  usr
-   root@<machine>:~# cp -r ./* ../eroot/
-   root@<machine>:~# cd ../ && umount sd* && umount e*
+   root@<machine>:~# cp -r -a /mnt/sdroot/* /mnt/eroot
+   root@<machine>:~# sync
+   root@<machine>:~# umount /mnt/*
    [70154.205154] EXT4-fs (mmcblk0p2): unmounting filesystem 74d40075-07e4-4bce-9401-6fccef68e934.
+
+**From tarball**
+
+This sections requires for tisdk-base-image-<soc>evm.rootfs.tar.xz to have been previously copied
+to the SD card rootfs.
+
+.. code-block:: console
+
+   root@<machine>:~# ls
+   tisdk-base-image-<soc>-evm.rootfs.tar.xz
+   root@<machine>:~# tar -xfp tisdk-base-image-<soc>-evm.rootfs.tar.xz -C /mnt/eroot
+   root@<machine>:~# sync
+   root@<machine>:~# umount /mnt/*

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -27,7 +27,7 @@ can be found in the following way:
    sdhci@fa00000: 1 (SD)
 
 The device index "**0**" for eMMC will be used when flashing to the eMMC device
-:ref:`here <uboot-emmc-flash-and-boot-to-uboot-prompt>` using :command:`mmc dev` command.
+:ref:`here <how-to-emmc-boot>` using :command:`mmc dev` command.
 
 In u-boot environment, usually **mmcdev=n** is used to selct which MMC device to boot
 Linux from, where **n** is the device index.
@@ -84,8 +84,8 @@ boot the device.
 .. note::
 
    For eMMC, typically, the device ships without a partition table If there is a need to
-   create a partition in UDA, please go :ref:`here <create-partitions-in-emmc-uda-from-linux>`
-   and to format the partition go :ref:`here <formatting-mmc-partition-from-linux>` before
+   create a partition in UDA, please go :ref:`here <mmc-create-partitions-in-emmc-uda-from-linux>`
+   and to format the partition go :ref:`here <mmc-formatting-mmc-partition-from-linux>` before
    proceeding.
 
 To list software created partitions for any MMC device from u-boot prompt, use the
@@ -143,15 +143,14 @@ Where the general syntax is:
 MMC supported bootmodes
 ========================
 
-For complete information on the MMC bootmodes supported by ROM, please refer to the device
-specific TRM, under: :file:`Initialization/Boot Mode Pins`.
-
-The ROM supports the following two MMC bootmodes:
+The K3 based processors support and recommends using *eMMC boot* from Boot0/1. For complete
+information on the MMC bootmodes supported by ROM, please refer to the device specific TRM,
+under: :file:`Initialization/Boot Mode Pins`. ROM supports the following two MMC bootmodes:
 
 **eMMC boot**
 
    This bootmode is a special bootmode specific to eMMC device. In this bootmode, ROM cannot
-   boot from SD and can only boot from Boot0 or Boot1 in eMMC. Please go :ref:`here <uboot-emmc-boot>`
+   boot from SD and can only boot from Boot0 or Boot1 in eMMC. Please go :ref:`here <how-to-emmc-boot>`
    for a step-by-step guide to boot with this bootmode.
 
 **MMCSD boot**
@@ -160,257 +159,7 @@ The ROM supports the following two MMC bootmodes:
    only boot from SD card or UDA in eMMC. ROM allows to boot in RAW or FS mode, FS mode being
    the recommended option and hence will have a subsequent guide to boot using this mode. Configuration
    for selecting MMC device and RAW/FS mode, is done with bootmode pins, please refer to TRM for this
-   setup. To boot from eMMC UDA in FS mode, please go :ref:`here <uboot-mmcsd-boot-uda-fs-mode>`.
-
-.. _uboot-emmc-flash-and-boot-to-uboot-prompt:
-
-EMMC: Flash and boot to uboot prompt
-====================================
-
-eMMC layout
------------
-
-.. ifconfig:: CONFIG_part_variant in ('AM64X', 'J7200')
-
-   .. code-block:: text
-
-      +----------------------------------+0x0      +-------------------------+0x0
-      |      tiboot3.bin (1 MB)          |         |                         |
-      +----------------------------------+0x800    |                         |
-      |       tispl.bin (2 MB)           |         |                         |
-      +----------------------------------+0x1800   |                         |
-      |       u-boot.img (4 MB)          |         |                         |
-      +----------------------------------+0x3800   |                         |
-      |      environment (128 KB)        |         |                         |
-      +----------------------------------+0x3900   |                         |
-      |   backup environment (128 KB)    |         |                         |
-      +----------------------------------+0x3A00   +-------------------------+
-                   Boot0 (8 MB)                              UDA
-
-.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
-
-   .. code-block:: text
-
-      +----------------------------------+0x0      +-------------------------+0x0
-      |      tiboot3.bin (1 MB)          |         |                         |
-      +----------------------------------+0x400    |                         |
-      |       tispl.bin (2 MB)           |         |                         |
-      +----------------------------------+0x1400   |                         |
-      |       u-boot.img (4 MB)          |         |                         |
-      +----------------------------------+0x3400   |                         |
-      |      environment (128 KB)        |         |                         |
-      +----------------------------------+0x3500   |                         |
-      |   backup environment (128 KB)    |         |                         |
-      +----------------------------------+0x3600   +-------------------------+
-                   Boot0 (8 MB)                              UDA
-
-.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
-
-   .. code-block:: text
-
-
-      +----------------------------------+0x0      +-------------------------+0x0
-      |      tiboot3.bin (512 KB)        |         |                         |
-      +----------------------------------+0x400    |                         |
-      |       tispl.bin (2 MB)           |         |                         |
-      +----------------------------------+0x1400   |                         |
-      |       u-boot.img (4 MB)          |         |                         |
-      +----------------------------------+0x3400   |                         |
-      |      environment (128 KB)        |         |                         |
-      +----------------------------------+0x3500   |                         |
-      |   backup environment (128 KB)    |         |                         |
-      +----------------------------------+0x3600   |                         |
-      |          sysfw (1 MB)            |         |                         |
-      +----------------------------------+0x3E00   +-------------------------+
-                   Boot0 (8 MB)                              UDA
-
-.. _uboot-emmc-boot:
-
-eMMC boot
----------
-
-The K3 based processors support and recommends using *eMMC boot* from Boot0/1.
-To boot with *eMMC boot* the eMMC needs to be prepared before hand. The recommended process
-is to flash an SD card with TI SDK image and boot the board in *MMCSD boot* from SD
-(FS mode) and boot to u-boot prompt, then proceed to flash eMMC:
-
-In the following example, we use the :command:`fatload` and :command:`mmc write` commands
-to load binaries from an SD card and flash them to eMMC Boot0. Note, to flash Boot1 instead,
-replace :command:`mmc dev 0 1` with :command:`mmc dev 0 2`.
-
-.. ifconfig:: CONFIG_part_variant in ('AM62LX')
-
-   .. note::
-
-      For am62lx device there is an errata for booting with *eMMC boot* `here <https://www.ti.com/lit/pdf/sprz582//>`__,
-      hence it is recommended to boot with *MMCSD boot*, as shown :ref:`here <uboot-mmcsd-boot-uda-fs-mode>`.
-
-.. ifconfig:: CONFIG_part_variant in ('AM64X')
-
-   .. code-block:: console
-
-      => mmc dev 0 1
-      => fatload mmc 1 ${loadaddr} tiboot3.bin
-      => mmc write ${loadaddr} 0x0 0x800
-      => fatload mmc 1 ${loadaddr} tispl.bin
-      => mmc write ${loadaddr} 0x800 0x1000
-      => fatload mmc 1 ${loadaddr} u-boot.img
-      => mmc write ${loadaddr} 0x1800 0x2000
-
-.. ifconfig:: CONFIG_part_variant in ('J7200')
-
-   .. code-block:: console
-
-      => mmc dev 0 1
-      => fatload mmc 1 ${loadaddr} tiboot3.bin
-      => mmc write ${loadaddr} 0x0 0x800
-      => fatload mmc 1 ${loadaddr} tispl.bin
-      => mmc write ${loadaddr} 0x800 0x1000
-      => fatload mmc 1 ${loadaddr} u-boot.img
-      => mmc write ${loadaddr} 0x1800 0x2000
-
-.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
-
-   .. code-block:: console
-
-      => mmc dev 0 1
-      => fatload mmc 1 ${loadaddr} tiboot3.bin
-      => mmc write ${loadaddr} 0x0 0x400
-      => fatload mmc 1 ${loadaddr} tispl.bin
-      => mmc write ${loadaddr} 0x400 0x1000
-      => fatload mmc 1 ${loadaddr} u-boot.img
-      => mmc write ${loadaddr} 0x1400 0x2000
-
-.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
-
-   .. code-block:: console
-
-      => mmc dev 0 1
-      => fatload mmc 1 ${loadaddr} tiboot3.bin
-      => mmc write ${loadaddr} 0x0 0x400
-      => fatload mmc 1 ${loadaddr} tispl.bin
-      => mmc write ${loadaddr} 0x400 0x1000
-      => fatload mmc 1 ${loadaddr} u-boot.img
-      => mmc write ${loadaddr} 0x1400 0x2000
-      => fatload mmc 1 ${loadaddr} sysfw.itb
-      => mmc write ${loadaddr} 0x3600 0x800
-
-**eMMC boot configuration**
-
-   After flashing bootloader binaries to eMMC flash, the eMMC device Extended CSD register fields:
-   BUS_WIDTH and PARTITION_CONFIG must be configured. These bits can be configured as shown
-   :ref:`here <uboot-emmc-boot0-config>` if using Boot0 and :ref:`here <uboot-emmc-boot1-config>` if
-   using Boot1. This is required in order for ROM to use the correct configuration when using
-   *eMMC boot*. Lastly, proceed to change boot pins to *eMMC boot* and power cycle the board.
-
-.. _uboot-mmcsd-boot-uda-fs-mode:
-
-MMCSD boot from UDA in FS mode
-------------------------------
-
-The K3 based processors supports booting from the eMMC UDA in FS mode. To boot with *MMCSD boot*
-from eMMC UDA (fs mode), the eMMC needs to be prepared before hand. The recommended
-process is to flash an SD card with TI SDK image and boot the board in *MMCSD boot* from
-SD (FS mode) and boot to Linux prompt. In Linux, create a "boot" partition as shown
-:ref:`here <create-boot-partition-in-emmc-uda-from-linux>`, format the new partition as shown
-:ref:`here <format-partition-vfat>`, mount the new partition and copy the bootloader binaries
-to the new partition as shown :ref:`here <flash-emmc-mmcsd-boot-uda-fs>`. Finally reboot the board
-to configure booting from eMMC UDA from u-boot prompt.
-
-**MMCSD boot configuration from UDA in FS mode**
-
-   After flashing bootloader binaries to eMMC flash, the eMMC device Extended CSD register fields:
-   BUS_WIDTH and PARTITION_CONFIG must be configured. These bits can be configured as shown
-   :ref:`here <uboot-emmc-uda-config>`. This is required in order for ROM to use the correct
-   configuration when using *MMCSD boot*. Lastly, proceed to change boot pins to *MMCSD boot*
-   [Select configuration for eMMC (port 0) and FS mode] and power cycle the board.
-
-.. _uboot-boot-emmc-config:
-
-Boot eMMC configuration
-------------------------
-
-To boot from an eMMC, the ROM will require some configuration which can be
-set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
-
-- The :command:`mmc bootbus` command sets the BOOT_BUS_WIDTH field where :command:`mmc bootbus 0 2 0 0`
-  selects **x8 (sdr/ddr) buswidth in boot operation mode**.
-- The :command:`mmc partconf` command can be used to configure what hardware partition
-  to boot from. The general syntax is:
-
-.. code-block:: console
-
-   $ mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]
-
-Where <dev> is MMC device index.
-
-- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
-
-.. _uboot-emmc-boot0-config:
-
-Boot from Boot0
-```````````````
-
-.. code-block:: console
-
-   => mmc partconf 0 1 1 1
-   => mmc bootbus 0 2 0 0
-
-.. _uboot-emmc-boot1-config:
-
-Boot from Boot1
-```````````````
-
-.. code-block:: console
-
-   => mmc partconf 0 1 2 1
-   => mmc bootbus 0 2 0 0
-
-.. _uboot-emmc-uda-config:
-
-Boot from UDA
-`````````````
-
-.. code-block:: console
-
-   => mmc partconf 0 1 7 1
-   => mmc bootbus 0 2 0 0
-
-**Enable warm reset**
-
-   On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
-   reset input signal will be ignored. Warm reset is required to be enabled in order
-   for the eMMC to be in a "clean state" on power-on reset so that ROM can do
-   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
-   the following command:
-
-.. code-block:: console
-
-   => mmc rst-function 0 1
-
-.. warning::
-
-   This is a write-once field. For more information, please refer to the u-boot
-   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
-
-Boot Linux from eMMC
-====================
-
-To flash & boot the rootfs from eMMC UDA, first create a partition to flash the rootfs:
-as shown :ref:`here <create-root-partition-in-emmc-uda-from-linux>`. The new software
-partition should be formatted as ext4 type as shown :ref:`here <format-partition-ext4>`,
-mount the new partition and flash the rootfs as shown  :ref:`here <flash-emmc-mmcsd-boot-uda-fs-root>`.
-It is not possible to format a partition to ext4 in U-Boot. The Linux kernel Image and DT are
-expected to be present in the /boot folder of the "root" partition in order for u-boot to find
-and load these. Reboot the board to configure u-boot environment to boot Linux from eMMC UDA.
-
-At u-boot prompt, run the following commands to boot Linux from eMMC UDA:
-
-.. code-block:: console
-
-   => setenv mmcdev 0
-   => setenv bootpart 0
-   => boot
+   setup. To boot from eMMC UDA in FS mode, please go :ref:`here <how-to-mmcsd-boot-from-emmc-uda>`.
 
 Flashing an MMC device using USB-DFU
 ====================================

--- a/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
+++ b/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
@@ -1,0 +1,288 @@
+.. _how-to-emmc-boot:
+
+#########################################
+How to flash eMMC and boot with eMMC Boot
+#########################################
+
+Overview
+========
+
+This how to guide allows to prepare and flash the eMMC device to boot using *eMMC boot*,
+that is, to boot from Boot0 or Boot1 eMMC hardware partitions and boot the rootfs from
+eMMC UDA.
+
+.. note::
+
+   This process will require a working SD card that can boot the device to Linux kernel.
+
+.. _how-to-emmc-layout:
+
+eMMC layout
+===========
+
+.. ifconfig:: CONFIG_part_variant in ('AM64X', 'J7200')
+
+   .. code-block:: text
+
+      +----------------------------------+0x0      +-------------------------+0x0
+      |      tiboot3.bin (1 MB)          |         |                         |
+      +----------------------------------+0x800    |                         |
+      |       tispl.bin (2 MB)           |         |                         |
+      +----------------------------------+0x1800   |                         |
+      |       u-boot.img (4 MB)          |         |                         |
+      +----------------------------------+0x3800   |                         |
+      |      environment (128 KB)        |         |                         |
+      +----------------------------------+0x3900   |                         |
+      |   backup environment (128 KB)    |         |                         |
+      +----------------------------------+0x3A00   +-------------------------+
+                   Boot0 (8 MB)                              UDA
+
+.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
+
+   .. code-block:: text
+
+      +----------------------------------+0x0      +-------------------------+0x0
+      |      tiboot3.bin (1 MB)          |         |                         |
+      +----------------------------------+0x400    |                         |
+      |       tispl.bin (2 MB)           |         |                         |
+      +----------------------------------+0x1400   |                         |
+      |       u-boot.img (4 MB)          |         |                         |
+      +----------------------------------+0x3400   |                         |
+      |      environment (128 KB)        |         |                         |
+      +----------------------------------+0x3500   |                         |
+      |   backup environment (128 KB)    |         |                         |
+      +----------------------------------+0x3600   +-------------------------+
+                   Boot0 (8 MB)                              UDA
+
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'AM62PX', 'AM62AX', 'AM62LX')
+
+   .. code-block:: text
+
+
+      +----------------------------------+0x0      +-------------------------+0x0
+      |      tiboot3.bin (512 KB)        |         |                         |
+      +----------------------------------+0x400    |                         |
+      |       tispl.bin (2 MB)           |         |                         |
+      +----------------------------------+0x1400   |                         |
+      |       u-boot.img (4 MB)          |         |                         |
+      +----------------------------------+0x3400   |                         |
+      |      environment (128 KB)        |         |                         |
+      +----------------------------------+0x3500   |                         |
+      |   backup environment (128 KB)    |         |                         |
+      +----------------------------------+0x3600   |                         |
+      |          sysfw (1 MB)            |         |                         |
+      +----------------------------------+0x3E00   +-------------------------+
+                   Boot0 (8 MB)                              UDA
+
+Flash bootloader binaries to eMMC
+=================================
+
+To boot with *eMMC boot* the eMMC needs to be prepared before hand. The recommended process
+is to flash an SD card with TI SDK image, copy the bootlader binaries that will be flashed to
+eMMC in the SD card "boot" partition in emmc/ folder, boot the board with *MMCSD boot* from SD
+(FS mode), and proceed to flash the eMMC from either u-boot or linux.
+
+**Flash from u-boot**
+
+Stop at u-boot prompt and flash eMMC using :command:`fatload` and :command:`mmc write` commands
+to load binaries from SD card and flash them to eMMC Boot0.
+
+In this example, eMMC device is :command:`dev 0`, to find which device is eMMC, refer to
+:ref:`this <uboot-listing-mmc-devices>`. section. To flash to eMMC Boot1 instead, replace
+:command:`mmc dev 0 1` with :command:`mmc dev 0 2`.
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. note::
+
+      For am62lx device there is an errata for booting with *eMMC boot* `here <https://www.ti.com/lit/pdf/sprz582//>`__,
+      hence it is recommended to boot with *MMCSD boot*, as shown :ref:`here <>`.
+
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+   .. code-block:: console
+
+      => mmc dev 0 1
+      => fatload mmc 1 ${loadaddr} emmc/tiboot3.bin
+      => mmc write ${loadaddr} 0x0 0x800
+      => fatload mmc 1 ${loadaddr} emmc/tispl.bin
+      => mmc write ${loadaddr} 0x800 0x1000
+      => fatload mmc 1 ${loadaddr} emmc/u-boot.img
+      => mmc write ${loadaddr} 0x1800 0x2000
+
+.. ifconfig:: CONFIG_part_variant in ('J7200')
+
+   .. code-block:: console
+
+      => mmc dev 0 1
+      => fatload mmc 1 ${loadaddr} emmc/tiboot3.bin
+      => mmc write ${loadaddr} 0x0 0x800
+      => fatload mmc 1 ${loadaddr} emmc/tispl.bin
+      => mmc write ${loadaddr} 0x800 0x1000
+      => fatload mmc 1 ${loadaddr} emmc/u-boot.img
+      => mmc write ${loadaddr} 0x1800 0x2000
+
+.. ifconfig:: CONFIG_part_variant in ('J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
+
+   .. code-block:: console
+
+      => mmc dev 0 1
+      => fatload mmc 1 ${loadaddr} emmc/tiboot3.bin
+      => mmc write ${loadaddr} 0x0 0x400
+      => fatload mmc 1 ${loadaddr} emmc/tispl.bin
+      => mmc write ${loadaddr} 0x400 0x1000
+      => fatload mmc 1 ${loadaddr} emmc/u-boot.img
+      => mmc write ${loadaddr} 0x1400 0x2000
+
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'J7200', 'J721S2', 'AM62X', 'J784S4','J742S2', 'J722S', 'AM62PX', 'AM62AX', 'AM62LX')
+
+   .. code-block:: console
+
+      => mmc dev 0 1
+      => fatload mmc 1 ${loadaddr} emmc/tiboot3.bin
+      => mmc write ${loadaddr} 0x0 0x400
+      => fatload mmc 1 ${loadaddr} emmc/tispl.bin
+      => mmc write ${loadaddr} 0x400 0x1000
+      => fatload mmc 1 ${loadaddr} emmc/u-boot.img
+      => mmc write ${loadaddr} 0x1400 0x2000
+      => fatload mmc 1 ${loadaddr} emmc/sysfw.itb
+      => mmc write ${loadaddr} 0x3600 0x800
+
+**Flash from linux**
+
+At linux prompt, flash eMMC using :command:`cp` and :command:`dd` commands to load binaries
+from SD card and flash them to eMMC Boot0.
+
+In this example, eMMC is :command:`/dev/mmcblk0*` and SD :command:`/dev/mmcblk1*` to find which
+device is eMMC, refer to :ref:`this <mmc-listing-mmc-devices-linux>`. section. To flash to
+eMMC Boot1 instead, replace :command:`mmcblk0boot0` with :command:`mmcblk0boot1`.
+
+.. code-block:: console
+
+   # Enable write access to the Boot0 partition
+   root@<machine>:~# echo 0 > /sys/block/mmcblk0boot0/force_ro
+   root@<machine>:~# mkdir /mnt/sdboot && mount /dev/mmcblk1p1 /mnt/sdboot && cd /mnt/sdboot
+   root@<machine>:~# dd if=emmc/tiboot3.bin of=/dev/mmcblk0boot0 seek=0 bs=512
+   root@<machine>:~# dd if=emmc/tispl.bin of=/dev/mmcblk0boot0 seek=1024 bs=512
+   root@<machine>:~# dd if=emmc/u-boot.img of=/dev/mmcblk0boot0 seek=5120 bs=512
+
+Where seek is the eMMC offset converted to decimal type. For example, for seek=1024, we are
+flashing to offset 0x400. Please refer :ref:`here <how-to-emmc-layout>` for the offsets in eMMC
+when flashing bootloader files.
+
+Flash rootfs to eMMC
+====================
+
+To boot the rootfs from eMMC UDA, the eMMC needs to be prepared before hand. It is not
+possible to format a partition to ext4 in U-Boot, so the recommended process is to flash
+an SD card with TI SDK image, boot the device with SD card boot to linux kernel prompt,
+and prepre eMMC UDA from Linux.
+
+First create a "root" partition to flash the rootfs as shown :ref:`here <mmc-create-root-partition-emmc-linux>`.
+The new partition should be formatted as ext4 type as shown :ref:`here <mmc-format-partition-ext4>`.
+Mount the new partition and flash the rootfs as shown  :ref:`here <mmc-flash-emmc-uda-root>`.
+The Linux kernel :file:`Image` and DT file are expected to be in the /boot folder of the
+"root" partition in order for u-boot to find and load them.
+
+eMMC boot configuration
+=======================
+
+Now that we have flashed the eMMC device, reboot the board and stop at u-boot prompt to
+set configuration for *eMMC boot*.
+
+**Enable boot from HW partition**
+
+After flashing binaries to eMMC flash, the eMMC device Extended CSD register fields:
+BUS_WIDTH and PARTITION_CONFIG must be set so ROM will use the correct configuration
+for *eMMC boot*. Set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
+Go to `Boot from Boot0` if booting for eMMC boot0. Alternatively, `Boot from Boot0` if
+booting from eMMC boot1.
+
+- The :command:`mmc bootbus` command sets the BOOT_BUS_WIDTH field where :command:`mmc bootbus 0 2 0 0`
+  selects **x8 (sdr/ddr) buswidth in boot operation mode**.
+- The :command:`mmc partconf` command can be used to configure what hardware partition
+  to boot from. The general syntax is:
+
+.. code-block:: console
+
+   $ mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]
+
+Where <dev> is MMC device index.
+
+- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+
+*Boot from Boot0*
+
+.. code-block:: console
+
+   => mmc partconf 0 1 1 1
+   => mmc bootbus 0 2 0 0
+
+*Boot from Boot1*
+
+.. code-block:: console
+
+   => mmc partconf 0 1 2 1
+   => mmc bootbus 0 2 0 0
+
+**Enable warm reset**
+
+   On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
+   reset input signal will be ignored. Warm reset is required to be enabled in order
+   for the eMMC to be in a "clean state" on power-on reset so that ROM can do
+   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
+   the following command:
+
+.. code-block:: console
+
+   => mmc rst-function 0 1
+
+.. warning::
+
+   This is a write-once field. For more information, please refer to the u-boot
+   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+
+**u-boot environment**
+
+The command :command:`saveenv` is no longer used in TI SDK, thus, the following
+environment workarounds must be implemented to boot from eMMC.
+
+At u-boot prompt, run the following commands to boot Linux from eMMC UDA:
+
+.. code-block:: console
+
+   => setenv mmcdev 0
+   => setenv bootpart 0
+   => boot
+
+Or change the u-boot environment for *eMMC boot* to boot completely from eMMC.
+
+First apply the following diff to u-boot. In this example we use am62x, but the
+same can be done for any other SoC.
+
+.. code-block:: diff
+
+   diff --git a/board/ti/am62x/am62x.env b/board/ti/am62x/am62x.env
+   index 82b9f0741bb..73d59ac425c 100644
+   --- a/board/ti/am62x/am62x.env
+   +++ b/board/ti/am62x/am62x.env
+   @@ -17,8 +17,8 @@ run_kern=booti ${loadaddr} ${rd_spec} ${fdtaddr}
+
+    boot_targets=mmc1 mmc0 usb pxe dhcp
+    boot=mmc
+   -mmcdev=1
+   -bootpart=1:2
+   +mmcdev=0
+   +bootpart=0:1
+    bootdir=/boot
+    rd_spec=-
+
+Re-build bootloader binaries and copy build outputs to the SD card "boot" partition
+and :file:`emmc/` folder. Proceed to flash eMMC with these binaries as shown in this
+step-by-step guide.
+
+Boot from eMMC boot partition
+=============================
+
+Finally we can proceed to change boot mode pins to *eMMC boot* as per specific TRM, under:
+:file:`Initialization/Boot Mode Pins` and power cycle the board.

--- a/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
+++ b/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
@@ -1,0 +1,164 @@
+.. _how-to-mmcsd-boot-from-emmc-uda:
+
+########################################
+How to flash eMMC and boot from eMMC UDA
+########################################
+
+Overview
+========
+
+This how to guide allows to prepare and flash the eMMC device to boot using *MMCSD boot*,
+from eMMC UDA in fs mode.
+
+.. note::
+
+   This process will require a working SD card that can boot the device to Linux kernel.
+
+- To flash eMMC using a partitioned wic image from the SDK, go :ref:`here <how-to-flash-emmc-wic>`
+- To flash eMMC manually, go :ref:`here <how-to-flash-emmc-manual>`
+
+.. _how-to-flash-emmc-wic:
+
+Flash eMMC with disk image
+==========================
+
+Copy the .wic formatted disk image from the SDK installer to target filesystem, boot the
+device via SD card boot and at linux prompt, find the eMMC block device as shown
+:ref:`here <mmc-listing-mmc-devices-linux` and flash the eMMC as shown below:
+
+.. code-block:: console
+
+   root@<machine>:~# ls
+   tisdk-base-image-<soc>-evm.rootfs.wic.xz
+   root@<machine>:~# xz -d -k tisdk-base-image-<soc>-evm.rootfs.wic.xz
+   root@<machine>:~# ls
+   tisdk-base-image-<soc>-evm.rootfs.wic tisdk-base-image-<soc>-evm.rootfs.wic.xz
+   root@<machine>:~# umount /dev/mmcblk0*
+   root@<machine>:~# dd if=tisdk-base-image-<soc>-evm.rootfs.wic of=/dev/mmcblk0
+
+.. _how-to-flash-emmc-manual:
+
+Manually flash eMMC device
+==========================
+
+To boot with *MMCSD boot* from eMMC UDA in fs mode, the eMMC needs to be prepared before hand.
+The recommended process is to flash an SD card with TI SDK image, copy the bootlader binaries
+that will be flashed to eMMC in the SD card "boot" partition in :file:`emmc/` folder, boot the
+board with *MMCSD boot* from SD (FS mode), and proceed to create partitions and flash the eMMC
+from linux.
+
+**Create partitions**
+
+In Linux, create a "boot" partition to store bootloader binaries as shown
+:ref:`here <mmc-create-boot-partition-emmc-linux>` and
+a "root" partition partition for the rootfs: as shown
+:ref:`here <mmc-create-root-partition-emmc-linux>`.
+
+**Format partitions**
+
+For the "boot" partition, format as *vfat* type as shown :ref:`here <mmc-format-partition-vfat>`
+and for the "root" partition, format as *ext4* type as shown :ref:`here <mmc-format-partition-ext4>`.
+
+**Flash eMMC UDA**
+
+Mount the new "boot" partition and copy the bootloader binaries to the new partition
+as shown :ref:`here <mmc-flash-emmc-uda-boot>`. Mount the new "root" partition
+and copy the rootfs to the parititon as shown :ref:`here <mmc-flash-emmc-uda-root>`
+
+MMCSD boot configuration from eMMC UDA
+======================================
+
+Now that we have flashed the eMMC device, reboot the board and stop at u-boot prompt to
+set configuration for *MMCSD boot* from UDA.
+
+**Enable boot from eMMC UDA**
+
+After flashing binaries to eMMC flash, the eMMC device Extended CSD register fields:
+BUS_WIDTH and PARTITION_CONFIG must be set so ROM will use the correct configuration
+for *MMCSD boot* from UDA.
+
+Set using the :command:`mmc bootbus` and :command:`mmc partconf` commands. Go to
+`Boot from UDA`.
+
+- The :command:`mmc bootbus` command sets the BOOT_BUS_WIDTH field where :command:`mmc bootbus 0 2 0 0`
+  selects **x8 (sdr/ddr) buswidth in boot operation mode**.
+- The :command:`mmc partconf` command can be used to configure what hardware partition
+  to boot from. The general syntax is:
+
+.. code-block:: console
+
+   $ mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]
+
+Where <dev> is MMC device index.
+
+- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+
+*Boot from UDA*
+
+.. code-block:: console
+
+   => mmc partconf 0 1 7 1
+   => mmc bootbus 0 2 0 0
+
+**Enable warm reset**
+
+   On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
+   reset input signal will be ignored. Warm reset is required to be enabled in order
+   for the eMMC to be in a "clean state" on power-on reset so that ROM can do
+   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
+   the following command:
+
+.. code-block:: console
+
+   => mmc rst-function 0 1
+
+.. warning::
+
+   This is a write-once field. For more information, please refer to the u-boot
+   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+
+**u-boot environment**
+
+The command :command:`saveenv` is no longer used in TI SDK, thus, the following
+environment workarounds must be implemented to boot from eMMC UDA.
+
+At u-boot prompt, run the following commands to boot Linux from UDA:
+
+.. code-block:: console
+
+   => setenv mmcdev 0
+   => setenv bootpart 0:2
+   => boot
+
+Or change the u-boot environment for *MMCSD boot* to boot completely from eMMC.
+
+First apply the following diff to u-boot. In this example we use am62x, but the
+same can be done for any other SoC.
+
+.. code-block:: diff
+
+   diff --git a/board/ti/am62x/am62x.env b/board/ti/am62x/am62x.env
+   index 82b9f0741bb..73d59ac425c 100644
+   --- a/board/ti/am62x/am62x.env
+   +++ b/board/ti/am62x/am62x.env
+   @@ -17,8 +17,8 @@ run_kern=booti ${loadaddr} ${rd_spec} ${fdtaddr}
+
+    boot_targets=mmc1 mmc0 usb pxe dhcp
+    boot=mmc
+   -mmcdev=1
+   -bootpart=1:2
+   +mmcdev=0
+   +bootpart=0:2
+    bootdir=/boot
+    rd_spec=-
+
+Re-build bootloader binaries and copy build outputs to the SD card "boot" partition
+and :file:`emmc/` folder. Proceed to flash eMMC with these binaries as shown in this
+step-by-step guide.
+
+Boot from eMMC UDA
+==================
+
+Finally we can proceed to change boot mode pins to *MMCSD boot* from eMMC (port 0) in fs
+mode as per specific TRM, under: :file:`Initialization/Boot Mode Pins` and power cycle the
+board.

--- a/source/linux/How_to_Guides_Developer_Notes.rst
+++ b/source/linux/How_to_Guides_Developer_Notes.rst
@@ -26,6 +26,8 @@ Developer Notes
    How_to_Guides/Target/How_to_Boot_Beagle_Bone_Black_with_Processor_SDK_Linux
    How_to_Guides/Target/How_to_flash_emmc_device
    How_to_Guides/Target/How_to_manually_flash_emmc_device
+   How_to_Guides/Target/How_to_emmc_boot
+   How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
    How_to_Guides/Target/How_to_suspend_to_ram_on_AM62x
    How_to_Guides/Target/How_to_test_MCAN_on_AM62x
    How_to_Guides/Target/How_to_enable_DT_overlays_in_linux


### PR DESCRIPTION
This PR updates boot from eMMC documentation by moving all of eMMC boot and MMCSD boot from eMMC UDA documentation to how-to-guides in an effort to clean up u-boot MMC doc, fill in missing sections, and organize according to each boot mode as much as possible.