### PR TITLE
feat(android): AM62X/AM62PX: update manifests to version 10.01.01

### DIFF
--- a/source/android/Foundational_Components_Bootloaders.rst
+++ b/source/android/Foundational_Components_Bootloaders.rst
@@ -31,7 +31,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-bootloader-aosp/ && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_Bootloader.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_01_Bootloader.xml
    $ repo sync
 
 For more information about ``repo``, visit `Android's official

--- a/source/android/Foundational_Components_Kernel.rst
+++ b/source/android/Foundational_Components_Kernel.rst
@@ -23,7 +23,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-kernel-aosp/ && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_Kernel-6.6.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_01_Kernel.xml
    $ repo sync
 
 .. tip::
@@ -32,7 +32,7 @@ Fetch the code using ``repo``:
 
    .. code-block:: console
 
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_Kernel-6.6.xml --depth=1
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_01_Kernel.xml --depth=1
 
 .. _android-build-kernel:
 

--- a/source/android/Overview_Building_the_SDK.rst
+++ b/source/android/Overview_Building_the_SDK.rst
@@ -40,7 +40,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-aosp-15 && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android15-release -m releases/RLS_10_01_01.xml
    $ repo sync
 
 .. tip::


### PR DESCRIPTION
Update manifests names for TI SDK, Kernel and Bootloader.

Update the commands given to fetch the code with the new manifests names for 
the TI SDK, Kernel and Bootloader.

cc @vishalmti @glaroque 
