### PR TITLE
11.0 Performance updates

### DIFF
--- a/source/devices/AM62AX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62AX/linux/Linux_Performance_Guide.rst
@@ -1,6 +1,6 @@
 
 ======================================
- Linux 10.01 Performance Guide
+ Linux 11.00 Performance Guide
 ======================================
 
 .. rubric::  **Read This First**
@@ -63,76 +63,76 @@ Execute the LMBench with the following:
 .. csv-table:: LMBench Benchmarks
     :header: "Benchmarks","am62axx_sk-fs: perf"
 
-    "af_unix_sock_stream_latency (microsec)","26.81"
-    "af_unix_socket_stream_bandwidth (MBs)","1190.21"
-    "bw_file_rd-io-1mb (MB/s)","1283.23"
-    "bw_file_rd-o2c-1mb (MB/s)","729.93"
-    "bw_mem-bcopy-16mb (MB/s)","1832.13"
-    "bw_mem-bcopy-1mb (MB/s)","1941.75"
-    "bw_mem-bcopy-2mb (MB/s)","1719.10"
-    "bw_mem-bcopy-4mb (MB/s)","1632.65"
-    "bw_mem-bcopy-8mb (MB/s)","1822.53"
-    "bw_mem-bzero-16mb (MB/s)","7901.23"
-    "bw_mem-bzero-1mb (MB/s)","4929.85 (min 1941.75, max 7917.94)"
-    "bw_mem-bzero-2mb (MB/s)","4792.34 (min 1719.10, max 7865.57)"
-    "bw_mem-bzero-4mb (MB/s)","4768.90 (min 1632.65, max 7905.14)"
-    "bw_mem-bzero-8mb (MB/s)","4858.64 (min 1822.53, max 7894.74)"
-    "bw_mem-cp-16mb (MB/s)","920.97"
-    "bw_mem-cp-1mb (MB/s)","4536.64 (min 922.68, max 8150.59)"
-    "bw_mem-cp-2mb (MB/s)","4463.19 (min 924.93, max 8001.45)"
-    "bw_mem-cp-4mb (MB/s)","4444.81 (min 935.89, max 7953.72)"
-    "bw_mem-cp-8mb (MB/s)","4451.94 (min 962.12, max 7941.76)"
-    "bw_mem-fcp-16mb (MB/s)","1648.46"
-    "bw_mem-fcp-1mb (MB/s)","4836.17 (min 1754.39, max 7917.94)"
-    "bw_mem-fcp-2mb (MB/s)","4722.80 (min 1580.03, max 7865.57)"
-    "bw_mem-fcp-4mb (MB/s)","4790.91 (min 1676.68, max 7905.14)"
-    "bw_mem-fcp-8mb (MB/s)","4785.51 (min 1676.27, max 7894.74)"
-    "bw_mem-frd-16mb (MB/s)","1886.35"
-    "bw_mem-frd-1mb (MB/s)","1882.31 (min 1754.39, max 2010.23)"
-    "bw_mem-frd-2mb (MB/s)","1641.81 (min 1580.03, max 1703.58)"
-    "bw_mem-frd-4mb (MB/s)","1664.45 (min 1652.21, max 1676.68)"
-    "bw_mem-frd-8mb (MB/s)","1780.42 (min 1676.27, max 1884.57)"
-    "bw_mem-fwr-16mb (MB/s)","7944.39"
-    "bw_mem-fwr-1mb (MB/s)","5080.41 (min 2010.23, max 8150.59)"
-    "bw_mem-fwr-2mb (MB/s)","4852.52 (min 1703.58, max 8001.45)"
-    "bw_mem-fwr-4mb (MB/s)","4802.97 (min 1652.21, max 7953.72)"
-    "bw_mem-fwr-8mb (MB/s)","4913.17 (min 1884.57, max 7941.76)"
-    "bw_mem-rd-16mb (MB/s)","1935.64"
-    "bw_mem-rd-1mb (MB/s)","1939.10 (min 1680.39, max 2197.80)"
-    "bw_mem-rd-2mb (MB/s)","1768.02 (min 1633.99, max 1902.04)"
-    "bw_mem-rd-4mb (MB/s)","1818.85 (min 1722.90, max 1914.79)"
-    "bw_mem-rd-8mb (MB/s)","1845.93 (min 1772.46, max 1919.39)"
-    "bw_mem-rdwr-16mb (MB/s)","1814.26"
-    "bw_mem-rdwr-1mb (MB/s)","1313.13 (min 922.68, max 1703.58)"
-    "bw_mem-rdwr-2mb (MB/s)","1270.22 (min 924.93, max 1615.51)"
-    "bw_mem-rdwr-4mb (MB/s)","1302.32 (min 935.89, max 1668.75)"
-    "bw_mem-rdwr-8mb (MB/s)","1361.54 (min 962.12, max 1760.95)"
-    "bw_mem-wr-16mb (MB/s)","1822.32"
-    "bw_mem-wr-1mb (MB/s)","1691.99 (min 1680.39, max 1703.58)"
-    "bw_mem-wr-2mb (MB/s)","1624.75 (min 1615.51, max 1633.99)"
-    "bw_mem-wr-4mb (MB/s)","1695.83 (min 1668.75, max 1722.90)"
-    "bw_mem-wr-8mb (MB/s)","1766.71 (min 1760.95, max 1772.46)"
-    "bw_mmap_rd-mo-1mb (MB/s)","2134.85"
-    "bw_mmap_rd-o2c-1mb (MB/s)","680.04"
-    "bw_pipe (MB/s)","805.00"
-    "bw_unix (MB/s)","1190.21"
-    "lat_connect (us)","56.95"
-    "lat_ctx-2-128k (us)","5.99"
-    "lat_ctx-2-256k (us)","6.45"
-    "lat_ctx-4-128k (us)","5.85"
-    "lat_ctx-4-256k (us)","4.51"
-    "lat_fs-0k (num_files)","248.00"
-    "lat_fs-10k (num_files)","125.00"
-    "lat_fs-1k (num_files)","172.00"
-    "lat_fs-4k (num_files)","144.00"
-    "lat_mem_rd-stride128-sz1000k (ns)","30.75"
-    "lat_mem_rd-stride128-sz125k (ns)","5.53"
-    "lat_mem_rd-stride128-sz250k (ns)","5.83"
-    "lat_mem_rd-stride128-sz31k (ns)","3.65"
+    "af_unix_sock_stream_latency (microsec)","28.80"
+    "af_unix_socket_stream_bandwidth (MBs)","1158.39"
+    "bw_file_rd-io-1mb (MB/s)","1367.99"
+    "bw_file_rd-o2c-1mb (MB/s)","771.72"
+    "bw_mem-bcopy-16mb (MB/s)","1805.05"
+    "bw_mem-bcopy-1mb (MB/s)","1992.39"
+    "bw_mem-bcopy-2mb (MB/s)","1734.30"
+    "bw_mem-bcopy-4mb (MB/s)","1786.78"
+    "bw_mem-bcopy-8mb (MB/s)","1796.74"
+    "bw_mem-bzero-16mb (MB/s)","7947.02"
+    "bw_mem-bzero-1mb (MB/s)","4970.90 (min 1992.39, max 7949.41)"
+    "bw_mem-bzero-2mb (MB/s)","4832.55 (min 1734.30, max 7930.79)"
+    "bw_mem-bzero-4mb (MB/s)","4864.51 (min 1786.78, max 7942.24)"
+    "bw_mem-bzero-8mb (MB/s)","4867.28 (min 1796.74, max 7937.82)"
+    "bw_mem-cp-16mb (MB/s)","930.29"
+    "bw_mem-cp-1mb (MB/s)","4563.39 (min 916.59, max 8210.18)"
+    "bw_mem-cp-2mb (MB/s)","4473.88 (min 893.12, max 8054.63)"
+    "bw_mem-cp-4mb (MB/s)","4472.48 (min 943.51, max 8001.45)"
+    "bw_mem-cp-8mb (MB/s)","4465.06 (min 959.35, max 7970.77)"
+    "bw_mem-fcp-16mb (MB/s)","1724.32"
+    "bw_mem-fcp-1mb (MB/s)","4842.31 (min 1735.21, max 7949.41)"
+    "bw_mem-fcp-2mb (MB/s)","4754.04 (min 1577.29, max 7930.79)"
+    "bw_mem-fcp-4mb (MB/s)","4822.07 (min 1701.89, max 7942.24)"
+    "bw_mem-fcp-8mb (MB/s)","4749.32 (min 1560.82, max 7937.82)"
+    "bw_mem-frd-16mb (MB/s)","1904.31"
+    "bw_mem-frd-1mb (MB/s)","1886.69 (min 1735.21, max 2038.17)"
+    "bw_mem-frd-2mb (MB/s)","1663.69 (min 1577.29, max 1750.09)"
+    "bw_mem-frd-4mb (MB/s)","1642.30 (min 1582.70, max 1701.89)"
+    "bw_mem-frd-8mb (MB/s)","1637.86 (min 1560.82, max 1714.90)"
+    "bw_mem-fwr-16mb (MB/s)","7964.16"
+    "bw_mem-fwr-1mb (MB/s)","5124.18 (min 2038.17, max 8210.18)"
+    "bw_mem-fwr-2mb (MB/s)","4902.36 (min 1750.09, max 8054.63)"
+    "bw_mem-fwr-4mb (MB/s)","4792.08 (min 1582.70, max 8001.45)"
+    "bw_mem-fwr-8mb (MB/s)","4842.84 (min 1714.90, max 7970.77)"
+    "bw_mem-rd-16mb (MB/s)","1951.93"
+    "bw_mem-rd-1mb (MB/s)","1994.86 (min 1764.60, max 2225.11)"
+    "bw_mem-rd-2mb (MB/s)","1756.29 (min 1568.63, max 1943.95)"
+    "bw_mem-rd-4mb (MB/s)","1841.36 (min 1734.35, max 1948.37)"
+    "bw_mem-rd-8mb (MB/s)","1892.72 (min 1830.87, max 1954.56)"
+    "bw_mem-rdwr-16mb (MB/s)","1863.50"
+    "bw_mem-rdwr-1mb (MB/s)","1331.97 (min 916.59, max 1747.34)"
+    "bw_mem-rdwr-2mb (MB/s)","1205.75 (min 893.12, max 1518.37)"
+    "bw_mem-rdwr-4mb (MB/s)","1310.86 (min 943.51, max 1678.20)"
+    "bw_mem-rdwr-8mb (MB/s)","1371.14 (min 959.35, max 1782.93)"
+    "bw_mem-wr-16mb (MB/s)","1805.67"
+    "bw_mem-wr-1mb (MB/s)","1755.97 (min 1747.34, max 1764.60)"
+    "bw_mem-wr-2mb (MB/s)","1543.50 (min 1518.37, max 1568.63)"
+    "bw_mem-wr-4mb (MB/s)","1706.28 (min 1678.20, max 1734.35)"
+    "bw_mem-wr-8mb (MB/s)","1806.90 (min 1782.93, max 1830.87)"
+    "bw_mmap_rd-mo-1mb (MB/s)","2130.68"
+    "bw_mmap_rd-o2c-1mb (MB/s)","731.93"
+    "bw_pipe (MB/s)","791.41"
+    "bw_unix (MB/s)","1158.39"
+    "lat_connect (us)","56.82"
+    "lat_ctx-2-128k (us)","7.87"
+    "lat_ctx-2-256k (us)","8.59"
+    "lat_ctx-4-128k (us)","6.76"
+    "lat_ctx-4-256k (us)","9.67"
+    "lat_fs-0k (num_files)","249.00"
+    "lat_fs-10k (num_files)","119.00"
+    "lat_fs-1k (num_files)","153.00"
+    "lat_fs-4k (num_files)","146.00"
+    "lat_mem_rd-stride128-sz1000k (ns)","30.87"
+    "lat_mem_rd-stride128-sz125k (ns)","5.59"
+    "lat_mem_rd-stride128-sz250k (ns)","5.84"
+    "lat_mem_rd-stride128-sz31k (ns)","4.19"
     "lat_mem_rd-stride128-sz50 (ns)","2.15"
-    "lat_mem_rd-stride128-sz500k (ns)","11.61"
-    "lat_mem_rd-stride128-sz62k (ns)","5.26"
-    "lat_mmap-1m (us)","58.00"
+    "lat_mem_rd-stride128-sz500k (ns)","11.18"
+    "lat_mem_rd-stride128-sz62k (ns)","4.53"
+    "lat_mmap-1m (us)","50.00"
     "lat_ops-double-add (ns)","2.86"
     "lat_ops-double-div (ns)","15.74"
     "lat_ops-double-mul (ns)","2.86"
@@ -143,41 +143,41 @@ Execute the LMBench with the following:
     "lat_ops-int-bit (ns)","0.48"
     "lat_ops-int-div (ns)","4.29"
     "lat_ops-int-mod (ns)","4.53"
-    "lat_ops-int-mul (ns)","3.07"
+    "lat_ops-int-mul (ns)","3.08"
     "lat_ops-int64-add (ns)","0.72"
     "lat_ops-int64-bit (ns)","0.48"
-    "lat_ops-int64-div (ns)","6.80"
+    "lat_ops-int64-div (ns)","6.81"
     "lat_ops-int64-mod (ns)","5.25"
     "lat_ops-int64-mul (ns)","3.55"
-    "lat_pagefault (us)","1.36"
-    "lat_pipe (us)","23.35"
-    "lat_proc-exec (us)","842.71"
-    "lat_proc-fork (us)","651.13"
+    "lat_pagefault (us)","1.06"
+    "lat_pipe (us)","25.31"
+    "lat_proc-exec (us)","693.38"
+    "lat_proc-fork (us)","585.00"
     "lat_proc-proccall (us)","0.01"
-    "lat_select (us)","35.07"
-    "lat_sem (us)","2.15"
-    "lat_sig-catch (us)","5.77"
-    "lat_sig-install (us)","0.66"
-    "lat_sig-prot (us)","1.21"
-    "lat_syscall-fstat (us)","2.00"
+    "lat_select (us)","34.04"
+    "lat_sem (us)","2.90"
+    "lat_sig-catch (us)","5.55"
+    "lat_sig-install (us)","0.68"
+    "lat_sig-prot (us)","0.85"
+    "lat_syscall-fstat (us)","1.96"
     "lat_syscall-null (us)","0.46"
-    "lat_syscall-open (us)","169.97"
-    "lat_syscall-read (us)","0.83"
-    "lat_syscall-stat (us)","4.97"
-    "lat_syscall-write (us)","0.74"
-    "lat_tcp (us)","0.94"
-    "lat_unix (us)","26.81"
-    "latency_for_0.50_mb_block_size (nanosec)","11.61"
-    "latency_for_1.00_mb_block_size (nanosec)","15.38 (min 0.00, max 30.75)"
-    "pipe_bandwidth (MBs)","805.00"
-    "pipe_latency (microsec)","23.35"
+    "lat_syscall-open (us)","212.00"
+    "lat_syscall-read (us)","0.80"
+    "lat_syscall-stat (us)","4.80"
+    "lat_syscall-write (us)","0.76"
+    "lat_tcp (us)","0.91"
+    "lat_unix (us)","28.80"
+    "latency_for_0.50_mb_block_size (nanosec)","11.18"
+    "latency_for_1.00_mb_block_size (nanosec)","15.44 (min 0.00, max 30.87)"
+    "pipe_bandwidth (MBs)","791.41"
+    "pipe_latency (microsec)","25.31"
     "procedure_call (microsec)","0.01"
-    "select_on_200_tcp_fds (microsec)","35.07"
-    "semaphore_latency (microsec)","2.15"
-    "signal_handler_latency (microsec)","0.66"
-    "signal_handler_overhead (microsec)","5.77"
-    "tcp_ip_connection_cost_to_localhost (microsec)","56.95"
-    "tcp_latency_using_localhost (microsec)","0.94"
+    "select_on_200_tcp_fds (microsec)","34.04"
+    "semaphore_latency (microsec)","2.90"
+    "signal_handler_latency (microsec)","0.68"
+    "signal_handler_overhead (microsec)","5.55"
+    "tcp_ip_connection_cost_to_localhost (microsec)","56.82"
+    "tcp_latency_using_localhost (microsec)","0.91"
 
 Dhrystone
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -224,7 +224,7 @@ solving a dense linear system.
 .. csv-table:: Linpack Benchmarks
     :header: "Benchmarks","am62axx_sk-fs: perf"
 
-    "linpack (Kflops)","578294.00"
+    "linpack (Kflops)","577662.00"
 
 Stream
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -247,10 +247,10 @@ Execute the benchmark with the following:
 .. csv-table:: Stream Benchmarks
     :header: "Benchmarks","am62axx_sk-fs: perf"
 
-    "add (MB/s)","2609.30"
-    "copy (MB/s)","3771.70"
-    "scale (MB/s)","3491.20"
-    "triad (MB/s)","2399.70"
+    "add (MB/s)","2638.50"
+    "copy (MB/s)","3791.10"
+    "scale (MB/s)","3538.50"
+    "triad (MB/s)","2426.20"
 
 CoreMarkPro
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -263,16 +263,30 @@ and floating-point workloads, and data sets for utilizing larger memory subsyste
 .. csv-table:: CoreMarkPro Benchmarks
     :header: "Benchmarks","am62axx_sk-fs: perf"
 
-    "cjpeg-rose7-preset (workloads/)","42.19"
+    "cjpeg-rose7-preset (workloads/)","41.67"
     "core (workloads/)","0.30"
-    "coremark-pro ()","938.54"
+    "coremark-pro ()","940.71"
     "linear_alg-mid-100x100-sp (workloads/)","14.68"
     "loops-all-mid-10k-sp (workloads/)","0.71"
     "nnet_test (workloads/)","1.09"
-    "parser-125k (workloads/)","8.85"
-    "radix2-big-64k (workloads/)","69.60"
+    "parser-125k (workloads/)","8.77"
+    "radix2-big-64k (workloads/)","72.61"
     "sha-test (workloads/)","81.30"
     "zip-test (workloads/)","22.22"
+
+.. csv-table:: CoreMarkProFourCore Benchmarks
+    :header: "Benchmarks","am62axx_sk-fs: perf"
+
+    "cjpeg-rose7-preset (workloads/)","161.29"
+    "core (workloads/)","1.20"
+    "coremark-pro ()","2630.14"
+    "linear_alg-mid-100x100-sp (workloads/)","56.37"
+    "loops-all-mid-10k-sp (workloads/)","2.07"
+    "nnet_test (workloads/)","3.62"
+    "parser-125k (workloads/)","9.76"
+    "radix2-big-64k (workloads/)","100.84"
+    "sha-test (workloads/)","270.27"
+    "zip-test (workloads/)","78.43"
 
 MultiBench
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -294,32 +308,31 @@ thread-enabled workloads to be tested.
 .. csv-table:: Multibench Benchmarks
     :header: "Benchmarks","am62axx_sk-fs: perf"
 
-    "4m-check (workloads/)","426.04"
-    "4m-check-reassembly (workloads/)","124.69"
-    "4m-check-reassembly-tcp (workloads/)","60.10"
-    "4m-check-reassembly-tcp-cmykw2-rotatew2 (workloads/)","33.69"
-    "4m-check-reassembly-tcp-x264w2 (workloads/)","1.93"
-    "4m-cmykw2 (workloads/)","246.31"
-    "4m-cmykw2-rotatew2 (workloads/)","50.51"
-    "4m-reassembly (workloads/)","83.47"
-    "4m-rotatew2 (workloads/)","54.73"
-    "4m-tcp-mixed (workloads/)","119.40"
-    "4m-x264w2 (workloads/)","1.98"
-    "empty-wld (workloads/)","1.00"
-    "idct-4m (workloads/)","19.27"
-    "idct-4mw1 (workloads/)","19.27"
-    "ippktcheck-4m (workloads/)","424.45"
-    "ippktcheck-4mw1 (workloads/)","424.09"
-    "ipres-4m (workloads/)","112.87"
-    "ipres-4mw1 (workloads/)","113.46"
-    "md5-4m (workloads/)","29.29"
-    "md5-4mw1 (workloads/)","29.03"
-    "rgbcmyk-4m (workloads/)","65.75"
-    "rgbcmyk-4mw1 (workloads/)","65.77"
-    "rotate-4ms1 (workloads/)","23.66"
-    "rotate-4ms1w1 (workloads/)","23.67"
-    "rotate-4ms64 (workloads/)","23.92"
-    "rotate-4ms64w1 (workloads/)","25.60"
+    "4m-check (workloads/)","418.20"
+    "4m-check-reassembly (workloads/)","124.07"
+    "4m-check-reassembly-tcp (workloads/)","60.24"
+    "4m-check-reassembly-tcp-cmykw2-rotatew2 (workloads/)","34.25"
+    "4m-check-reassembly-tcp-x264w2 (workloads/)","1.89"
+    "4m-cmykw2 (workloads/)","248.76"
+    "4m-cmykw2-rotatew2 (workloads/)","50.76"
+    "4m-reassembly (workloads/)","83.19"
+    "4m-rotatew2 (workloads/)","56.50"
+    "4m-tcp-mixed (workloads/)","117.65"
+    "4m-x264w2 (workloads/)","1.97"
+    "idct-4m (workloads/)","19.25"
+    "idct-4mw1 (workloads/)","19.25"
+    "ippktcheck-4m (workloads/)","423.44"
+    "ippktcheck-4mw1 (workloads/)","421.30"
+    "ipres-4m (workloads/)","112.02"
+    "ipres-4mw1 (workloads/)","113.12"
+    "md5-4m (workloads/)","28.39"
+    "md5-4mw1 (workloads/)","28.29"
+    "rgbcmyk-4m (workloads/)","65.66"
+    "rgbcmyk-4mw1 (workloads/)","65.66"
+    "rotate-4ms1 (workloads/)","23.60"
+    "rotate-4ms1w1 (workloads/)","23.54"
+    "rotate-4ms64 (workloads/)","23.80"
+    "rotate-4ms64w1 (workloads/)","23.84"
     "x264-4mq (workloads/)","0.58"
     "x264-4mqw1 (workloads/)","0.58"
 
@@ -332,7 +345,7 @@ Boot media: MMCSD
 .. csv-table:: Linux boot time MMCSD
     :header: "Boot Configuration","am62axx_sk-fs: Boot time in seconds: avg(min,max)"
 
-    "Linux boot time from SD with default rootfs (20 boot cycles)","16.57 (min 15.67, max 17.24)"
+    "Linux boot time from SD with default rootfs (20 boot cycles)","13.68 (min 13.50, max 13.97)"
 
 Boot time numbers [avg, min, max] are measured from "Starting kernel" to Linux prompt across 20 boot cycles.
 
@@ -416,7 +429,7 @@ CPSW/CPSW2g/CPSW3g Ethernet Driver
 .. csv-table:: CPSW2g TCP Bidirectional Throughput
     :header: "Command Used","am62axx_sk-fs: THROUGHPUT (Mbits/sec)","am62axx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1856.34","63.35"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1855.56","65.98"
 
 .. rubric::  TCP Bidirectional Throughput Interrupt Pacing
    :name: CPSW2g-tcp-bidirectional-throughput-interrupt-pacing
@@ -424,7 +437,7 @@ CPSW/CPSW2g/CPSW3g Ethernet Driver
 .. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am62axx_sk-fs: THROUGHPUT (Mbits/sec)","am62axx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1877.64","36.58"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1876.44","38.25"
 
 .. rubric::  UDP Throughput
    :name: CPSW2g-udp-throughput-0-loss
@@ -432,29 +445,29 @@ CPSW/CPSW2g/CPSW3g Ethernet Driver
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am62axx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62axx_sk-fs: THROUGHPUT (Mbits/sec)","am62axx_sk-fs: Packets Per Second (kPPS)","am62axx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","18.00","16.42","114.00","40.70"
-    "128","82.00","73.46","112.00","40.31"
-    "256","210.00","186.80","111.00","40.33"
-    "1024","978.00","839.17","107.00","40.21"
-    "1518","1472.00","955.68","81.00","33.86"
+    "64","18.00","15.73","109.00","40.72"
+    "128","82.00","69.74","106.00","40.24"
+    "256","210.00","177.12","105.00","40.18"
+    "1024","978.00","800.79","102.00","39.91"
+    "1518","1472.00","955.95","81.00","35.45"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am62axx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62axx_sk-fs: THROUGHPUT (Mbits/sec)","am62axx_sk-fs: Packets Per Second (kPPS)","am62axx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","18.00","1.02","7.00","2.44"
-    "128","82.00","4.85","7.00","5.70"
-    "256","210.00","12.89","8.00","1.48"
-    "1024","978.00","65.72","8.00","3.86"
-    "1518","1472.00","98.92","8.00","5.28"
+    "64","18.00","1.02","7.00","1.11"
+    "128","82.00","5.25","8.00","3.50"
+    "256","210.00","13.10","8.00","2.10"
+    "1024","978.00","102.49","13.00","7.14"
+    "1518","1472.00","100.09","8.00","3.16"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am62axx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62axx_sk-fs: THROUGHPUT (Mbits/sec)","am62axx_sk-fs: Packets Per Second (kPPS)","am62axx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62axx_sk-fs: Packet Loss %"
 
-    "64","18.00","32.83","228.00","41.27","43.93"
-    "128","82.00","98.72","150.00","40.41","0.28"
-    "256","210.00","337.70","201.00","42.58","46.54"
-    "1024","978.00","933.59","119.00","42.42","0.21"
-    "1518","1472.00","947.84","80.00","41.41","0.15"
+    "64","18.00","33.07","230.00","42.67","50.74"
+    "128","82.00","134.23","205.00","45.22","52.22"
+    "256","210.00","337.01","201.00","44.35","47.91"
+    "1024","978.00","898.26","115.00","41.05","0.26"
+    "1518","1472.00","931.76","79.00","40.01","2.10"
 
 EMMC Driver
 -----------
@@ -472,10 +485,21 @@ EMMC EXT4 FIO 1G
 .. csv-table:: EMMC EXT4 FIO 1G
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Write EXT4 CPU Load (%)","am62axx_sk-fs: Read EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Read EXT4 CPU Load (%)"
 
-    "1m","90.40","1.46","172.00","1.86"
-    "4m","95.90","1.14","172.00","1.42"
-    "4k","63.80","20.08","94.20","23.04"
-    "256k","90.10","1.67","171.00","2.39"
+    "1m","91.70","1.48","172.00","1.54"
+    "4m","97.50","1.07","171.00","1.38"
+    "4k","64.00","21.81","93.00","22.36"
+    "256k","92.20","1.68","171.00","2.20"
+
+EMMC RAW FIO 1G
+^^^^^^^^^^^^^^^
+
+.. csv-table:: EMMC RAW FIO 1G
+    :header: "Buffer size (bytes)","am62axx_sk-fs: Write Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Write Raw CPU Load (%)","am62axx_sk-fs: Read Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Read Raw CPU Load (%)"
+
+    "1m","91.00","1.42","174.00","1.83"
+    "4m","97.60","1.02","174.00","1.35"
+    "4k","64.10","16.11","92.70","20.72"
+    "256k","90.90","1.77","173.00","2.43"
 
 EMMC EXT4
 ^^^^^^^^^
@@ -483,11 +507,11 @@ EMMC EXT4
 .. csv-table:: EMMC EXT4
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Write EXT4 CPU Load (%)","am62axx_sk-fs: Read EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Read EXT4 CPU Load (%)"
 
-    "102400","84.31 (min 81.57, max 85.86)","6.26 (min 5.61, max 8.19)","179.01","8.19"
-    "262144","80.39 (min 53.59, max 90.44)","6.08 (min 3.70, max 8.56)","179.87","9.52"
-    "524288","72.34 (min 49.21, max 89.48)","5.31 (min 3.06, max 8.43)","180.99","9.48"
-    "1048576","72.06 (min 47.11, max 89.92)","5.19 (min 2.92, max 7.94)","181.20","8.66"
-    "5242880","79.37 (min 55.35, max 88.16)","5.97 (min 4.47, max 8.33)","181.25","9.48"
+    "102400","82.79 (min 80.86, max 84.20)","5.89 (min 5.33, max 7.53)","178.87","8.62"
+    "262144","79.25 (min 56.62, max 88.47)","5.91 (min 3.91, max 8.43)","180.55","9.13"
+    "524288","79.95 (min 57.79, max 88.21)","5.89 (min 3.99, max 8.38)","181.15","8.70"
+    "1048576","74.08 (min 52.01, max 88.83)","5.40 (min 3.35, max 8.03)","181.22","8.26"
+    "5242880","75.34 (min 53.85, max 87.76)","5.38 (min 3.47, max 8.02)","181.47","9.48"
 
 EMMC VFAT
 ^^^^^^^^^
@@ -495,11 +519,11 @@ EMMC VFAT
 .. csv-table:: EMMC VFAT
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write VFAT Throughput (Mbytes/sec)","am62axx_sk-fs: Write VFAT CPU Load (%)","am62axx_sk-fs: Read VFAT Throughput (Mbytes/sec)","am62axx_sk-fs: Read VFAT CPU Load (%)"
 
-    "102400","51.02 (min 45.02, max 52.67)","5.10 (min 4.15, max 7.76)","172.99","10.20"
-    "262144","52.91 (min 45.76, max 54.80)","5.17 (min 4.32, max 7.96)","171.43","10.33"
-    "524288","53.43 (min 46.13, max 55.33)","5.31 (min 4.35, max 8.23)","170.89","9.43"
-    "1048576","53.11 (min 45.89, max 55.06)","5.06 (min 4.20, max 7.88)","170.78","10.84"
-    "5242880","53.39 (min 45.78, max 55.49)","5.21 (min 4.35, max 7.89)","171.34","9.05"
+    "102400","28.13 (min 3.67, max 34.37)","3.45 (min 2.27, max 3.95)","171.77","10.20"
+    "262144","43.39 (min 11.54, max 60.99)","5.67 (min 4.16, max 6.97)","175.90","9.70"
+    "524288","41.35 (min 3.90, max 51.60)","4.24 (min 2.41, max 4.93)","171.23","9.35"
+    "1048576","42.74 (min 3.97, max 53.26)","4.21 (min 2.26, max 4.84)","171.45","9.47"
+    "5242880","42.69 (min 4.00, max 52.77)","3.86 (min 2.30, max 4.35)","171.53","9.02"
 
 UBoot EMMC Driver
 -----------------
@@ -507,8 +531,8 @@ UBoot EMMC Driver
 .. csv-table:: UBOOT EMMC RAW
     :header: "File size (bytes in hex)","am62axx_sk-fs: Write Throughput (Kbytes/sec)","am62axx_sk-fs: Read Throughput (Kbytes/sec)"
 
-    "2000000","96376.47","171560.21"
-    "4000000","98996.98","175229.95"
+    "2000000","59362.32","168907.22"
+    "4000000","59850.23","172918.21"
 
 MMCSD
 -----
@@ -527,10 +551,10 @@ MMC EXT4 FIO 1G
 .. csv-table:: MMC EXT4 FIO 1G
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Write EXT4 CPU Load (%)","am62axx_sk-fs: Read EXT4 Throughput (Mbytes/sec)","am62axx_sk-fs: Read EXT4 CPU Load (%)"
 
-    "1m","41.20","1.00","85.50","1.27"
-    "4m","40.90","0.68","84.20","1.07"
-    "4k","2.81","1.45","13.00","4.13"
-    "256k","38.20","1.17","84.40","1.51"
+    "1m","42.20","1.02","87.40","1.26"
+    "4m","43.20","0.75","87.20","1.06"
+    "4k","2.84","1.67","12.90","4.27"
+    "256k","39.20","1.31","83.60","1.57"
 
 MMC RAW FIO 1G
 ^^^^^^^^^^^^^^
@@ -538,10 +562,10 @@ MMC RAW FIO 1G
 .. csv-table:: MMC RAW FIO 1G
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Write Raw CPU Load (%)","am62axx_sk-fs: Read Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Read Raw CPU Load (%)"
 
-    "1m","44.80","1.00","88.30","1.27"
-    "4m","44.60","0.74","88.30","0.85"
-    "4k","4.16","1.36","17.00","5.00"
-    "256k","42.90","1.07","86.30","1.40"
+    "1m","43.00","0.84","88.10","1.14"
+    "4m","43.00","0.64","88.00","0.89"
+    "4k","2.81","1.40","13.00","3.90"
+    "256k","36.80","0.94","84.20","1.38"
 
 MMC EXT4
 ^^^^^^^^
@@ -549,11 +573,11 @@ MMC EXT4
 .. csv-table:: MMC EXT4
     :header: "Buffer size (bytes)","am62axx_sk-fs: Write Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Write Raw CPU Load (%)","am62axx_sk-fs: Read Raw Throughput (Mbytes/sec)","am62axx_sk-fs: Read Raw CPU Load (%)"
 
-    "102400","10.54 (min 10.31, max 10.94)","0.86 (min 0.72, max 1.21)","10.84","0.65"
-    "262144","10.25 (min 10.03, max 10.50)","0.89 (min 0.69, max 1.37)","10.96","0.84"
-    "524288","10.29 (min 10.19, max 10.42)","0.83 (min 0.63, max 1.20)","11.02","0.63"
-    "1048576","10.31 (min 10.18, max 10.39)","0.89 (min 0.76, max 1.16)","12.01","0.72"
-    "5242880","11.04 (min 10.91, max 11.11)","0.87 (min 0.72, max 1.20)","12.02","0.63"
+    "102400","10.40 (min 10.24, max 10.69)","0.83 (min 0.72, max 1.12)","10.80","0.67"
+    "262144","10.37 (min 10.24, max 10.50)","0.91 (min 0.64, max 1.48)","10.99","0.79"
+    "524288","10.47 (min 10.29, max 10.56)","0.81 (min 0.71, max 1.13)","11.05","0.66"
+    "1048576","10.38 (min 10.26, max 10.59)","0.92 (min 0.76, max 1.19)","10.79","0.77"
+    "5242880","10.79 (min 10.66, max 10.92)","0.83 (min 0.73, max 1.04)","12.03","0.75"
 
 The performance numbers were captured using the following:
 
@@ -569,9 +593,9 @@ UBOOT MMCSD FAT
 .. csv-table:: UBOOT MMCSD FAT
     :header: "File size (bytes in hex)","am62axx_sk-fs: Write Throughput (Kbytes/sec)","am62axx_sk-fs: Read Throughput (Kbytes/sec)"
 
-    "400000","39009.52","50567.90"
-    "800000","45765.36","65536.00"
-    "1000000","46678.06","76560.75"
+    "400000","38641.51","81920.00"
+    "800000","45765.36","87148.94"
+    "1000000","48046.92","90021.98"
 
 The performance numbers were captured using the following:
 
@@ -588,12 +612,12 @@ USB Device Controller
 .. csv-table:: USBDEVICE HIGHSPEED SLAVE_READ_THROUGHPUT
     :header: "Number of Blocks","am62axx_sk-fs: Throughput (MB/sec)"
 
-    "150","44.50"
+    "150","43.80"
 
 .. csv-table:: USBDEVICE HIGHSPEED SLAVE_WRITE_THROUGHPUT
     :header: "Number of Blocks","am62axx_sk-fs: Throughput (MB/sec)"
 
-    "150","38.70"
+    "150","36.10"
 
 |
 
@@ -606,66 +630,66 @@ OpenSSL Performance
 .. csv-table:: OpenSSL Performance
     :header: "Algorithm","Buffer Size (in bytes)","am62axx_sk-fs: throughput (KBytes/Sec)"
 
-    "aes-128-cbc","1024","24957.27"
-    "aes-128-cbc","16","455.88"
-    "aes-128-cbc","16384","86857.05"
-    "aes-128-cbc","256","7483.90"
-    "aes-128-cbc","64","1996.46"
-    "aes-128-cbc","8192","73760.77"
-    "aes-128-ecb","1024","25503.40"
-    "aes-128-ecb","16","465.99"
-    "aes-128-ecb","16384","89822.55"
-    "aes-128-ecb","256","7670.44"
-    "aes-128-ecb","64","2051.39"
-    "aes-128-ecb","8192","76229.29"
-    "aes-192-cbc","1024","24464.38"
-    "aes-192-cbc","16","457.74"
-    "aes-192-cbc","16384","78528.51"
-    "aes-192-cbc","256","7427.24"
-    "aes-192-cbc","64","1993.73"
-    "aes-192-cbc","8192","67876.18"
-    "aes-192-ecb","1024","25041.24"
-    "aes-192-ecb","16","464.68"
-    "aes-192-ecb","16384","80909.65"
-    "aes-192-ecb","256","7619.07"
-    "aes-192-ecb","64","2042.90"
-    "aes-192-ecb","8192","69348.01"
-    "aes-256-cbc","1024","23916.20"
-    "aes-256-cbc","16","455.50"
-    "aes-256-cbc","16384","71647.23"
-    "aes-256-cbc","256","7336.79"
-    "aes-256-cbc","64","1995.58"
-    "aes-256-cbc","8192","62608.73"
-    "aes-256-ecb","1024","24311.81"
-    "aes-256-ecb","16","467.63"
-    "aes-256-ecb","16384","73449.47"
-    "aes-256-ecb","256","7513.60"
-    "aes-256-ecb","64","2043.61"
-    "aes-256-ecb","8192","64208.90"
-    "sha256","1024","32988.84"
-    "sha256","16","554.30"
-    "sha256","16384","273929.56"
-    "sha256","256","8643.50"
-    "sha256","64","2191.15"
-    "sha256","8192","183552.68"
-    "sha512","1024","23909.72"
-    "sha512","16","539.73"
-    "sha512","16384","67605.85"
-    "sha512","256","7746.73"
-    "sha512","64","2160.13"
-    "sha512","8192","60159.32"
+    "aes-128-cbc","1024","22690.82"
+    "aes-128-cbc","16","407.87"
+    "aes-128-cbc","16384","83771.39"
+    "aes-128-cbc","256","6693.03"
+    "aes-128-cbc","64","1769.71"
+    "aes-128-cbc","8192","70991.87"
+    "aes-128-ecb","1024","23238.66"
+    "aes-128-ecb","16","415.95"
+    "aes-128-ecb","16384","87064.58"
+    "aes-128-ecb","256","6831.70"
+    "aes-128-ecb","64","1811.97"
+    "aes-128-ecb","8192","72884.22"
+    "aes-192-cbc","1024","22330.03"
+    "aes-192-cbc","16","412.24"
+    "aes-192-cbc","16384","76540.59"
+    "aes-192-cbc","256","6668.46"
+    "aes-192-cbc","64","1779.07"
+    "aes-192-cbc","8192","65191.94"
+    "aes-192-ecb","1024","22708.57"
+    "aes-192-ecb","16","415.37"
+    "aes-192-ecb","16384","78255.45"
+    "aes-192-ecb","256","6798.68"
+    "aes-192-ecb","64","1813.08"
+    "aes-192-ecb","8192","67029.67"
+    "aes-256-cbc","1024","21670.23"
+    "aes-256-cbc","16","405.98"
+    "aes-256-cbc","16384","70068.91"
+    "aes-256-cbc","256","6556.16"
+    "aes-256-cbc","64","1761.22"
+    "aes-256-cbc","8192","60661.76"
+    "aes-256-ecb","1024","22268.25"
+    "aes-256-ecb","16","415.66"
+    "aes-256-ecb","16384","71734.61"
+    "aes-256-ecb","256","6744.66"
+    "aes-256-ecb","64","1808.04"
+    "aes-256-ecb","8192","60866.56"
+    "sha256","1024","34747.73"
+    "sha256","16","571.94"
+    "sha256","16384","286829.23"
+    "sha256","256","9044.22"
+    "sha256","64","2270.38"
+    "sha256","8192","193448.62"
+    "sha512","1024","24330.24"
+    "sha512","16","566.06"
+    "sha512","16384","67687.77"
+    "sha512","256","8116.39"
+    "sha512","64","2266.01"
+    "sha512","8192","60424.19"
 
 .. csv-table:: OpenSSL CPU Load
     :header: "Algorithm","am62axx_sk-fs: CPU Load"
 
-    "aes-128-cbc","34.00"
-    "aes-128-ecb","35.00"
-    "aes-192-cbc","33.00"
-    "aes-192-ecb","34.00"
-    "aes-256-cbc","33.00"
-    "aes-256-ecb","33.00"
-    "sha256","98.00"
-    "sha512","98.00"
+    "aes-128-cbc","30.00"
+    "aes-128-ecb","32.00"
+    "aes-192-cbc","30.00"
+    "aes-192-ecb","31.00"
+    "aes-256-cbc","30.00"
+    "aes-256-ecb","30.00"
+    "sha256","96.00"
+    "sha512","96.00"
 
 Listed for each algorithm are the code snippets used to run each benchmark test.
 

--- a/source/devices/AM62AX/linux/RT_Linux_Performance_Guide.rst
+++ b/source/devices/AM62AX/linux/RT_Linux_Performance_Guide.rst
@@ -1,8 +1,9 @@
 ======================================
- RT-linux 10.01 Performance Guide
+ RT-linux 11.00 Performance Guide
 ======================================
 
 .. rubric::  **Read This First**
+   :name: read-this-first-kernel-perf-guide
 
 **All performance numbers provided in this document are gathered using
 following Evaluation Modules unless otherwise specified.**
@@ -10,22 +11,22 @@ following Evaluation Modules unless otherwise specified.**
 +----------------+----------------------------------------------------------------------------------------------------------------+
 | Name           | Description                                                                                                    |
 +================+================================================================================================================+
-| AM62A SK       | AM62A Starter Kit rev E2 with ARM running at 1200MHz, LPDDR4 data rate is 3733 MT/s                            |
+| AM62Ax SK      | AM62Ax Starter Kit with ARM running at 1.2GHz, DDR data rate 3733 MT/S                                         |
 +----------------+----------------------------------------------------------------------------------------------------------------+
 
 Table:  Evaluation Modules
 
-|
-
 .. rubric::  About This Manual
+   :name: about-this-manual-rt-kernel-perf-guide
 
 This document provides performance data for each of the device drivers
-which are part of the Process SDK Linux package. This document should be
+which are part of the Processor SDK Linux package. This document should be
 used in conjunction with release notes and user guides provided with the
-Process SDK Linux package for information on specific issues present
+Processor SDK Linux package for information on specific issues present
 with drivers included in a particular release.
 
 .. rubric::  If You Need Assistance
+   :name: if-you-need-assistance-rt-kernel-perf-guide
 
 For further information or to report any problems, contact
 https://e2e.ti.com/ or https://support.ti.com/

--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -676,9 +676,9 @@ UBOOT MMCSD FAT
 .. csv-table:: UBOOT MMCSD FAT
     :header: "File size (bytes in hex)","am62pxx_sk-fs: Write Throughput (Kbytes/sec)","am62pxx_sk-fs: Read Throughput (Kbytes/sec)"
 
-    "400000","37236.36","71859.65"
-    "800000","46022.47","81108.91"
-    "1000000","47216.14","86231.58"
+    "400000","40156.86","81920.00"
+    "800000","45765.36","87148.94"
+    "1000000","47627.91","90021.98"
 
 The performance numbers were captured using the following:
 

--- a/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
+++ b/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
@@ -261,10 +261,10 @@ resulting in a score that is double the bandwidth LMBench will show.
 .. csv-table:: Stream Benchmarks
     :header: "Benchmarks","am64xx-hsevm: perf"
 
-    "add (MB/s)","1626.90"
-    "copy (MB/s)","2112.60"
-    "scale (MB/s)","2263.80"
-    "triad (MB/s)","1625.90"
+    "add (MB/s)","1619.70"
+    "copy (MB/s)","2019.30"
+    "scale (MB/s)","2250.40"
+    "triad (MB/s)","1615.70"
 
 CoreMarkPro
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -475,36 +475,6 @@ ICSSG Ethernet Driver
 
 |
 
-PCIe Driver
--------------------------
-
-PCIe-ETH
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table:: PCIe Ethernet performance
-    :header: "TCP Window Size(Kbytes)","am64xx-hsevm: Bandwidth (Mbits/sec)"
-
-    "8","0.00"
-    "16","0.00"
-
-PCIe-NVMe-SSD
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table:: PCIE SSD EXT4 FIO 10G
-    :header: "Buffer size (bytes)","am64xx-hsevm: Write EXT4 Throughput (Mbytes/sec)","am64xx-hsevm: Write EXT4 CPU Load (%)","am64xx-hsevm: Read EXT4 Throughput (Mbytes/sec)","am64xx-hsevm: Read EXT4 CPU Load (%)"
-
-    "1m","373.00","19.47","398.00","13.84"
-    "4m","364.00","16.00","398.00","12.77"
-    "4k","78.30","51.37","90.40","46.75"
-    "256k","375.00","21.93","397.00","15.57"
-
-- Filesize used is: 10G
-- FIO command options: --ioengine=libaio --iodepth=4 --numjobs=1 --direct=1 --runtime=60 --time_based 
-- Platform: Speed 5GT/s, Width x1
-- SSD being used: Lite-On Technology Corporation M8Pe Series NVMe SSD [14a4:22f1] (rev 01)
-
-|
-
 OSPI Flash Driver
 -------------------------
 
@@ -686,12 +656,3 @@ Listed for each algorithm are the code snippets used to run each benchmark test.
 ::
 
     time -v openssl speed -elapsed -evp aes-128-cbc
-
-IPSec Software Performance
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table:: IPSec Software Performance
-    :header: "Algorithm","am64xx-hsevm: Throughput (Mbps)","am64xx-hsevm: Packets/Sec","am64xx-hsevm: CPU Load"
-
-    "3des","52.80","4.00","52.54"
-    "aes128","0.00","0.00","51.14"


### PR DESCRIPTION
This PR is a follow-up update for performance data on the following:

am62px:
- update UBOOT MMCSD FAT

am64x:
- update ARM bench STREAM
- remove Crypto IPSEC
- remove PCIE

am62ax:
- update Linux performance numbers for all sections except lowpower & cyclic tests

