### PR TITLE
fix(linux): add Real-Time Linux Tuning to the AM64x build

### DIFF
--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -130,6 +130,7 @@ linux/How_to_Guides/Host/SYSFW_Trace_Parser
 linux/How_to_Guides/Host/Program_MMC_boot_media
 linux/How_to_Guides/Target/How_to_emmc_boot
 linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda
+linux/How_to_Guides/Target/How_to_Tune_Real_Time_Linux
 linux/How_to_Guides/Hardware_Setup_with_CCS/AM64x_EVM_Hardware_Setup
 linux/How_to_Guides/FAQ/How_to_Verify_Ipc_Linux_R5
 linux/How_to_Guides/FAQ/How_to_Check_Device_Tree_Info


### PR DESCRIPTION
When the documentation for tuning the SoC for the real-time linux kernel was added the AM64x family was missed. Add the 'How to Tune Real Time Linux' to the build list for the AM64x family.