### PR TITLE
docs(linux): AM64X/AM62X/AM62AX/AM62PX: Add SYSFW release note info

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -63,7 +63,7 @@ What's new
   - ATF 2.12+
   - OPTEE 4.5.0
   - Graphics DDK 24.2
-  - TIFS Firmware v11.00.07
+  - TIFS Firmware / SYSFW `v11.00.07 <https://software-dl.ti.com/tisci/esd/11_00_07/release_notes/release_notes.html>`__ (Click on the link for more information)
   - DM Firmware 11.00.00.06
   - Yocto scarthgap 5.0
 

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -69,7 +69,7 @@ What's new
   - ATF 2.12+
   - OPTEE 4.5.0
   - Graphics DDK 24.2
-  - TIFS Firmware v11.00.07
+  - TIFS Firmware / SYSFW `v11.00.07 <https://software-dl.ti.com/tisci/esd/11_00_07/release_notes/release_notes.html>`__ (Click on the link for more information)
   - DM Firmware 11.00.00.06
   - Yocto scarthgap 5.0
 

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -65,7 +65,7 @@ What's new
   - ATF 2.12+
   - OPTEE 4.5.0
   - Graphics DDK 24.2
-  - TIFS Firmware v11.00.07
+  - TIFS Firmware / SYSFW `v11.00.07 <https://software-dl.ti.com/tisci/esd/11_00_07/release_notes/release_notes.html>`__ (Click on the link for more information)
   - DM Firmware 11.00.00.06
   - Yocto scarthgap 5.0
 

--- a/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
@@ -62,7 +62,7 @@ What's new
   - Toolchain GCC 13.3
   - ATF 2.12+
   - OPTEE 4.5.0
-  - TIFS Firmware v11.00.07
+  - TIFS Firmware `v11.00.07 <https://software-dl.ti.com/tisci/esd/11_00_07/release_notes/release_notes.html>`__ (Click on the link for more information)
   - Yocto scarthgap 5.0
 
 


### PR DESCRIPTION
Add link for TIFS/SYSFW release notes for version used in SDK 11.0.