### PR TITLE
Documentation updates for LPM

### DIFF
--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -326,11 +326,11 @@ The benefits of using MCU Only mode:
    or a network communication task.
 #. Respond to interrupts: This allows the system to still respond to external events, while it is in a low-power state.
 
-To enter MCU Only mode, set :code:`100 usec` resume latency for CPU0 in linux:
+To enter MCU Only mode, set :code:`100000 usec` resume latency for CPU0 in linux:
 
 .. code-block:: console
 
-   root@<machine>:~# echo 100 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
+   root@<machine>:~# echo 100000 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
 
 .. important::
 

--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -54,7 +54,7 @@ sources is found to be enabled, Partial I/O is entered instead of poweroff.
 
 The following wakeup sources have been configured for Partial I/O:
 mcu_uart0, mcu_mcan0, and mcu_mcan1. Partial I/O mode can only be tested
-when `k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+when `k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=11.00.09>`__
 overlay is loaded. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>` for more details.
 
 After Linux boots, the MCAN wakeup for Partial I/O is enabled.
@@ -132,7 +132,7 @@ I/O Only Plus DDR
    The wakeup sources that can be used to wake the system from I/O Only Plus
    DDR are mcu_uart0, mcu_mcan0, mcu_mcan1 and wkup_uart0. To use the mcu_mcan0
    and mcu_mcan1 wakeup sources, apply the
-   `k3-am62x-sk-lpm-io-ddr-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+   `k3-am62x-sk-lpm-io-ddr-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-io-ddr-wkup-sources.dtso?h=11.00.09>`__
    overlay. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>`
    for more details. To use the mcu_uart0 and wkup_uart0 wakeup sources, direct
    register writes can be used to enable wakeup after Linux boots.

--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -57,19 +57,7 @@ mcu_uart0, mcu_mcan0, and mcu_mcan1. Partial I/O mode can only be tested
 when `k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
 overlay is loaded. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>` for more details.
 
-After Linux boots, the MCAN wakeup for Partial I/O is enabled using the
-wake on PHY activity option of ethtool. For example, the following
-command enables mcu_mcan0 wakeup:
-
-.. code-block:: console
-
-   root@<machine>:~# ethtool -s mcu_mcan0 wol p
-
-.. rubric:: To enable mcu_mcan1 wakeup:
-
-.. code-block:: console
-
-   root@<machine>:~# ethtool -s mcu_mcan1 wol p
+After Linux boots, the MCAN wakeup for Partial I/O is enabled.
 
 .. rubric:: To enable UART wakeup:
 
@@ -141,22 +129,25 @@ I/O Only Plus DDR
 
       .. important:: Jumper J12 should be connected on SK to enable system to enter I/O Only plus DDR mode.
 
-   The wakeup sources that can be used to wake the system from I/O Only Plus DDR are
-   mcu_uart0, mcu_mcan0, mcu_mcan1 and wkup_uart0. After Linux boots, direct register
-   writes can be used to enable wakeup.
+   The wakeup sources that can be used to wake the system from I/O Only Plus
+   DDR are mcu_uart0, mcu_mcan0, mcu_mcan1 and wkup_uart0. To use the mcu_mcan0
+   and mcu_mcan1 wakeup sources, apply the
+   `k3-am62x-sk-lpm-io-ddr-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+   overlay. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>`
+   for more details. To use the mcu_uart0 and wkup_uart0 wakeup sources, direct
+   register writes can be used to enable wakeup after Linux boots.
 
    .. rubric:: Following commands set the wakeup EN bit, enable receive for pad in PADCONFIG register and can
-               be used to enable wakeup from mcu_mcan0, mcu_mcan1, mcu_uart0 and wkup_uart0 pins respectively.
+               be used to enable wakeup from mcu_uart0 and wkup_uart0 pins respectively.
 
    .. important::
 
-      The steps mentioned below are a workaround to enable wakeup as there are more driver level changes
-      required to enable the wakeup support.
+      The steps mentioned below are a workaround to enable wakeup for mcu_uart0
+      and wkup_uart0 as there are more driver level changes required to enable
+      the wakeup support.
 
    .. code-block:: console
 
-      root@<machine>:~# devmem2 0x4084038 0x20050000  # MCU_PADCONFIG14 for mcu_mcan0
-      root@<machine>:~# devmem2 0x4084040 0x20050000  # MCU_PADCONFIG16 for mcu_mcan1
       root@<machine>:~# devmem2 0x4084014 0x20050000  # MCU_PADCONFIG5 for mcu_uart0
       root@<machine>:~# devmem2 0x4084024 0x20050000  # MCU_PADCONFIG9 for wkup_uart0
 

--- a/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
@@ -151,8 +151,8 @@ Specifically, checking of constraints is done at two levels:
 
 The code enabling the constraints framework can be found in:
 
-#. TISCI PM Domain driver: https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/pmdomain/ti/ti_sci_pm_domains.c?h=10.01.10
-#. TISCI driver: https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/firmware/ti_sci.c?h=10.01.10
+#. TISCI PM Domain driver: https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/pmdomain/ti/ti_sci_pm_domains.c?h=11.00.09
+#. TISCI driver: https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/firmware/ti_sci.c?h=11.00.09
 
 Examples of adding constraints from the remote core side are being implemented and will
 be enabled in future release.
@@ -198,7 +198,7 @@ The various modes and their latencies are documented here: https://downloads.ti.
 If a device wants to put a constraint to not be powered-off, it can use the Linux
 QoS framework and set the ``DEV_PM_QOS_RESUME_LATENCY`` equal to 0.
 An example is shown in the following RemoteProc driver:
-https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/remoteproc/ti_k3_r5_remoteproc.c?h=10.01.10#n523
+https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/remoteproc/ti_k3_r5_remoteproc.c?h=11.00.09#n549
 
 .. note::
 

--- a/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
@@ -180,11 +180,11 @@ Resume Latency Constraint
 This constraint is exposed to the user-level through the existing sysfs PM QoS interface for CPU Cores.
 Default constraint is "no constraint", but it can be changed as shown in the examples below:
 
-   a. To set 100 usec resume latency for the SoC, a constraint can be placed for CPU0 (or any other CPU core):
+   a. To set 100000 usec resume latency for the SoC, a constraint can be placed for CPU0 (or any other CPU core):
 
    .. code:: console
 
-      root@evm:~# echo 100 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
+      root@evm:~# echo 100000 > /sys/devices/system/cpu/cpu0/power/pm_qos_resume_latency_us
 
    b. To clear the constraint, 0 has to be written to the same parameter:
 

--- a/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
@@ -271,7 +271,7 @@ by configuring the MCU GPIO controller as a wakeup source.
 In ideal scenarios, the firmware running on MCU core is responsible for configuring MCU GPIO's as a wakeup source.
 However, if the application design doesn't rely too much on the MCU firmware then
 Linux can be used to configure the MCU GPIOs as a wakeup source. You can refer to the mcu_gpio_key node in
-`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=11.00.09>`__
 and use it as a template to configure the MCU GPIO of your choice as a wakeup capable GPIO.
 
 A brief guide to configuring an MCU GPIO as wakeup:
@@ -330,7 +330,7 @@ source and send a wakeup interrupt to the Device Manager. To understand the role
 please refer to :ref:`S/W Architecture of System Suspend<pm_sw_arch>`
 
 MCU GPIO wakeup can only be tested when
-`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=11.00.09>`__
 overlay is loaded. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>` for more details.
 
 Once the system has entered Deep Sleep or MCU Only mode as shown in the
@@ -373,7 +373,7 @@ Main UART
 =========
 
 The way to configure UART as an I/O daisy chain wakeup, refer to the
-main_uart0 node in `k3-am62x-sk-common.dtsi <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-common.dtsi?h=10.01.10>`_
+main_uart0 node in `k3-am62x-sk-common.dtsi <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-common.dtsi?h=11.00.09>`_
 
 .. code-block:: dts
 
@@ -436,10 +436,10 @@ configuration and working of these frameworks have been covered under
 the MCU GPIO and Main UART sections.
 
 The reference configuration for Main GPIO wakeup can be found under
-gpio_key node in `k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10#n21>`__
+gpio_key node in `k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=11.00.09#n21>`__
 
 Main GPIO wakeup can only be tested when
-`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=10.01.10>`__
+`k3-am62x-sk-lpm-wkup-sources.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62x-sk-lpm-wkup-sources.dtso?h=11.00.09>`__
 overlay is loaded. Please refer to :ref:`How to enable DT overlays<howto_dt_overlays>` for more details.
 
 To use main_gpio as a wakeup source, ensure gpio is a wake-irq in /proc/interrupts:
@@ -463,7 +463,7 @@ Sleep and MCU Only modes.
 In order to use WKUP UART as a wakeup source, it needs to be configured
 in a generic way using the ti-sysc interconnect target module driver.
 The reference configuration can be found under target-module in
-`k3-am62-wakeup.dtsi <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62-wakeup.dtsi?h=10.01.10#n36>`__
+`k3-am62-wakeup.dtsi <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62-wakeup.dtsi?h=11.00.09#n36>`__
 
 WKUP UART is generally available on the third serial port
 (/dev/ttyUSB2) and by default it only shows output from DM R5.


### PR DESCRIPTION
Updates include:
- Update how to enable CAN UART wakeup for every LPM. Remove references to enabling via ethtools or setting the register manually
- Update the units used for CPU resume latency. They were previously ms and are now us
- Change any URL that references SDK 10.1 to 11.00.09 