### PR TITLE
feat(perf): update am62/am62p glmark2 scores for 11.0

### DIFF
--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -420,8 +420,8 @@ Run Glmark2 and capture performance reported (Score). All display outputs (HDMI,
 .. csv-table:: Glmark2 Performance
     :header: "Benchmark","am62pxx_sk-fs: Score"
 
-    "Glmark2-DRM","309.00"
-    "Glmark2-Wayland","782.00"
+    "Glmark2-DRM","355.00"
+    "Glmark2-Wayland","737.00"
 
 |
 

--- a/source/devices/AM62X/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62X/linux/Linux_Performance_Guide.rst
@@ -427,11 +427,11 @@ Glmark2
 Run Glmark2 and capture performance reported (Score). All display outputs (HDMI, Displayport and/or LCD) are connected when running these tests
 
 .. csv-table:: Glmark2 Performance
-    :header: "Benchmark","am62xx_lp_sk-fs: Score","am62xx_sk-fs: Score","am62xxsip_sk-fs: Score"
+    :header: "Benchmark","am62xx_lp_sk-fs: Score","am62xx_sk-fs: Score"
 
     "Glmark2-DRM","51.00","61.00"
-    "Glmark2-Wayland","200.00","218.00","209.00"
-    "Glmark2-Wayland 1920x1080","62.00","67.00"
+    "Glmark2-Wayland","203.00","216.00"
+    "Glmark2-Wayland 1920x1080","63.00","67.00"
 
 |
 


### PR DESCRIPTION
Manually the GLMark2 scores in this section for AM62X/AM62PX while we're working on fixing the automation.