### PR TITLE
docs(linux): AM62PX, AM62X: Release Notes: Add ti-apps-launcher with Qt6

### DIFF
--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -56,7 +56,7 @@ What's new
   - Support for streaming from multiple 0V5640 cameras with `Arducam V3Link (Fusion Mini) <https://www.arducam.com/product/arducam-v3link-camera-kit-for-ti-development-boards/>`_
   - TISCI: A53 hosts default priv_id value updated to 1 from 4 (to match all other SOCs)
   - Power Management: :ref:`I/O Only Plus DDR <pm_io_only_plus_ddr>` mode
-  - TI Apps Launcher: New Wi-Fi and Terminal Demo - :ref:`TI Apps Launcher <TI-Apps-Launcher-User-Guide-label>`
+  - Out-of-Box TI Apps Launcher Application with Qt6 Framework - :ref:`TI Apps Launcher <TI-Apps-Launcher-User-Guide-label>`
   - Snagfactory Support - :ref:`Snagfactory Tool <Flash-via-Fastboot>`
   - Support for M2 CC33xx cards on Debian - `How to Enable M.2-CC33x1 in Linux <https://software-dl.ti.com/processor-sdk-linux/esd/AM62PX/10_01_10_04_Debian/exports/docs/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.html>`__
 

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -52,7 +52,7 @@ What's new
 **Key Release References:**
 
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here - :ref:`RT Interrupt Latencies <RT-linux-performance>`
-  - TI Apps Launcher: New Wi-Fi and Terminal Demo - :ref:`TI Apps Launcher <TI-Apps-Launcher-User-Guide-label>`
+  - Out-of-Box TI Apps Launcher Application with Qt6 Framework - :ref:`TI Apps Launcher <TI-Apps-Launcher-User-Guide-label>`
   - Snagfactory Support - :ref:`Snagfactory Tool <Flash-via-Fastboot>`
   - Support for M2 CC33xx cards on Debian - `How to Enable M.2-CC33x1 in Linux <https://software-dl.ti.com/processor-sdk-linux/esd/AM62X/10_01_10_04_Debian/exports/docs/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.html>`__
   - How to Enable PRU RPMsg - `Read FAQ <https://e2e.ti.com/support/processors-group/processors/f/791/t/1494495>`__


### PR DESCRIPTION
In 11.0, the OOB TI Apps Launcher uses Qt6 Framework. In earlier releases, it used Qt5. Highlight this change in release notes for 11.0.