### PR TITLE
Additional LPM documentation updates

### DIFF
--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -317,7 +317,7 @@ The benefits of using MCU Only mode:
    or a network communication task.
 #. Respond to interrupts: This allows the system to still respond to external events, while it is in a low-power state.
 
-To enter MCU Only mode, set :code:`100000 usec` resume latency for CPU0 in linux:
+To enter MCU Only mode, set :code:`100 msec` resume latency for CPU0 in Linux:
 
 .. code-block:: console
 

--- a/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
@@ -196,11 +196,6 @@ Default constraint is "no constraint", but it can be changed as shown in the exa
 Setting a resume latency constraint impacts the deepest low power mode system can enter.
 The various modes and their latencies are documented here: https://downloads.ti.com/tisci/esd/latest/2_tisci_msgs/pm/lpm.html#tisci-msg-lpm-set-latency-constraint
 
-If a device wants to put a constraint to not be powered-off, it can use the Linux
-QoS framework and set the ``DEV_PM_QOS_RESUME_LATENCY`` equal to 0.
-An example is shown in the following RemoteProc driver:
-https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/drivers/remoteproc/ti_k3_r5_remoteproc.c?h=11.00.09#n549
-
 .. note::
 
    The constraints need to be set before each system suspend as DM firmware clears all

--- a/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_sw_arch.rst
@@ -180,7 +180,8 @@ Resume Latency Constraint
 This constraint is exposed to the user-level through the existing sysfs PM QoS interface for CPU Cores.
 Default constraint is "no constraint", but it can be changed as shown in the examples below:
 
-   a. To set 100000 usec resume latency for the SoC, a constraint can be placed for CPU0 (or any other CPU core):
+   a. To set 100 msec resume latency for the SoC, a constraint can be placed for
+   CPU0 (or any other CPU core):
 
    .. code:: console
 

--- a/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
@@ -677,14 +677,20 @@ triggered by grounding Pin 11 or Pin 22 on J8 MCU Header, respectively.
 Confirming the Wakeup event type
 ********************************
 
-When the SoC wakes up from any Low Power Mode, the Device Manager logs the wake reason.
-This wake reason can be queried by Linux using the `TISCI LPM API <https://downloads.ti.com/tisci/esd/latest/2_tisci_msgs/pm/lpm.html>`__.
+When the SoC wakes up from any Low Power Mode, the Device Manager logs the wake
+reason, the pin number that triggered the wakeup, and the last low power mode
+entered. This wake reason and low power mode can be queried by Linux using the
+`TISCI LPM API <https://downloads.ti.com/tisci/esd/latest/2_tisci_msgs/pm/lpm.html>`__.
+The wakeup pin can be found in the datasheet by converting the pin number from
+hex to decimal and finding the corresponding PADCONFIG register.
 
 This wake reason is printed as part of the Linux suspend/resume log:
 
 .. code-block:: console
 
-   [   37.357109] CPU3 is up
-   [   37.357710] ti-sci 44043000.system-controller: ti_sci_resume: wakeup source: 0x50
+   [  249.471725] CPU3 is up
+   [  249.472314] ti-sci 44043000.system-controller: ti_sci: wakeup source:0x80, pin:0x72, mode:0x1
 
-In the above example, 0x50 means that WKUP_RTC0 is the wakeup source.
+In the above example, the wakeup source of 0x80 is MAIN_IO. The 0x72 pin refers
+to PADCONFIG114. This means the cause of the wakeup event is UART0_RXD. The
+mode of 0x1 is the last low power mode entered which was MCU_ONLY.


### PR DESCRIPTION
Documentation updates to address comments from Akash's comments from this PR https://github.com/TexasInstruments/processor-sdk-doc/pull/245

Updates include:
- Updating the confirmation of wakeup events to include the pin that caused the wakeup and the last entered low power mode.
- Increasing readability for setting CPU resume constraints where the resume latency is referenced in ms and not us