### PR TITLE
fix(rename): relative paths should be from dir

### DIFF
--- a/bin/rename.py
+++ b/bin/rename.py
@@ -162,7 +162,7 @@ def register_rst_filters(source, destination):
         """Replace old include and image/figure statements"""
         ref_destination = (
             ' '
-            + destination.relative_to(kwargs["file"], walk_up=True).as_posix()
+            + destination.relative_to(kwargs["file"].parent, walk_up=True).as_posix()
             + "\n"
         )
 
@@ -182,7 +182,7 @@ def register_rst_filters(source, destination):
         ref_destination = (
             "`"
             + destination.with_suffix("")
-            .relative_to(kwargs["file"], walk_up=True)
+            .relative_to(kwargs["file"].parent, walk_up=True)
             .as_posix()
             + "`"
         )


### PR DESCRIPTION
Relative paths should be from the directory of the current file, not from the file itself. This was done correctly for 1 out of the 3 inline replacement filters.