### PR TITLE
ci(previews): fix index identifier function

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,7 @@ jobs:
           EOF
 
           for path in build/*/; do
-            root_index=$(find "$path" -name index.html | sort -u | tail -1)
+            root_index=$(find "$path" -name index.html -print -quit)
             if [ -n "$root_index" ]; then
               text=$(basename "$path")
               relative_path=$(realpath "$root_index" --relative-to=build)


### PR DESCRIPTION
Find operates in breadth-first by default. There can only be one index per directory. Might as well shorten this find expression to print and bail out after the first match.

Also resolves the issue where other non-root index files will be picked as the root index due to sorting precedence.