### PR TITLE
chore(platforms-and-version): fix linking and toc tree

### DIFF
--- a/source/devices/AM57X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM57X/linux/Release_Specific_Release_Notes.rst
@@ -95,7 +95,7 @@ Released June 2022
 
 Supported Platforms
 =====================================
-See `here <Release_Specific_Supported_Platforms_and_Versions.html>`__ for a list of supported platforms and links to more information.
+See :ref:`release-specific-supported-platforms-and-versions` for a list of supported platforms and links to more information.
 
 |
 

--- a/source/devices/AM62LX/linux/Release_Specific.rst
+++ b/source/devices/AM62LX/linux/Release_Specific.rst
@@ -10,3 +10,4 @@ Release Specific
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide
    Release_Specific_Workarounds
+   Release_Specific_Supported_Platforms_and_Versions

--- a/source/devices/AM62PX/linux/Release_Specific.rst
+++ b/source/devices/AM62PX/linux/Release_Specific.rst
@@ -10,3 +10,4 @@ Release Specific
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide
    Release_Specific_Workarounds
+   Release_Specific_Supported_Platforms_and_Versions

--- a/source/devices/AM62X/linux/Release_Specific.rst
+++ b/source/devices/AM62X/linux/Release_Specific.rst
@@ -10,3 +10,4 @@ Release Specific
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide
    Release_Specific_Workarounds
+   Release_Specific_Supported_Platforms_and_Versions

--- a/source/devices/AM64X/linux/Release_Specific.rst
+++ b/source/devices/AM64X/linux/Release_Specific.rst
@@ -9,3 +9,4 @@ Release Specific
    Release_Specific_Yocto_layer_Configuration
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide
+   Release_Specific_Supported_Platforms_and_Versions

--- a/source/linux/Foundational_Components/_OpenCV.rst
+++ b/source/linux/Foundational_Components/_OpenCV.rst
@@ -519,7 +519,7 @@ OpenCL extensions (intrinsics and EDMAmgr).
 Supported Platforms
 --------------------
 
-See `here <Release_Specific_Supported_Platforms_and_Versions.html>`__ for a list
+See :ref:`release-specific-supported-platforms-and-versions` for a list
 of supported platforms and links to more information.
 OpenCL dispatch is available only on platforms with DSP C66 core, like
 AM5728 (2 C66 cores).

--- a/source/linux/Release_Specific_PLSDK_Release_Notes.rst
+++ b/source/linux/Release_Specific_PLSDK_Release_Notes.rst
@@ -103,7 +103,7 @@ Processor SDK 6.3 Release has following new features:
 
 Supported Platforms
 =====================================
-See `here <Release_Specific_Supported_Platforms_and_Versions.html>`__ for a list of supported platforms and links to more information.
+See :ref:`release-specific-supported-platforms-and-versions` for a list of supported platforms and links to more information.
 
 |
 


### PR DESCRIPTION
Fix links to Release_Specific_Release_Notes in common documentation and make sure it's actually included in the toc tree for all platforms. This disconnect from toc tree and toc.txt files is part of the motivation for the proposed index file structure.