### PR TITLE
chore: move to exclude only logic

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -260,9 +260,6 @@ suppress_warnings = ['toc.excluded']
 
 # -- Tag file loader ------------------------------------------------------
 
-# Defaults
-exclude_patterns = []
-
 FAMILY = os.environ.get("DEVFAMILY", "")
 OS = os.environ.get("OS", "")
 try:
@@ -276,6 +273,9 @@ except ModuleNotFoundError as exc:
 family_tocfiles = [f"{FAMILY}/{FAMILY}_{OS}_toc.txt"]
 # Family Configuration file to use
 family_config_inputfile = f"{FAMILY}/{FAMILY}_{OS}_config.txt"
+
+# Set document exclusion list from the tocfiles
+exclude_patterns = sectinc.generate_exclude_patterns(family_tocfiles)
 
 # Hash table for Replacement Variables and Config Values
 family_replacevars, family_configvals = interpretvalues.read_familyvals(family_config_inputfile)
@@ -298,16 +298,6 @@ def setup(app):
     print(family_replacevars)
     print("family_configvals = ")
     print(family_configvals)
-
-    # Determine which sections need to be excluded
-    sectinc.find_all_rst_files(app, exclude_patterns)
-    sectinc.fill_docs_to_keep(app, family_tocfiles, 0)
-    sectinc.set_excluded_docs(app, exclude_patterns)
-    print(FAMILY + " exclude_patterns is:")
-    print('[')
-    for elem in exclude_patterns:
-        print(elem)
-    print(']')
 
     # Load family config values into application context
     for key, value in family_configvals.items():

--- a/configs/AM335X/AM335X_linux_tags.py
+++ b/configs/AM335X/AM335X_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM335X Documentation'
 # The master toctree document.
 master_doc = 'devices/AM335X/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X/rtos', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM437X/AM437X_linux_tags.py
+++ b/configs/AM437X/AM437X_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM437X Documentation'
 # The master toctree document.
 master_doc = 'devices/AM437X/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM437X/rtos', 'devices/AM335X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM57X/AM57X_linux_tags.py
+++ b/configs/AM57X/AM57X_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM57X Documentation'
 # The master toctree document.
 master_doc = 'devices/AM57X/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM57X/rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM62AX/AM62AX_linux_tags.py
+++ b/configs/AM62AX/AM62AX_linux_tags.py
@@ -10,12 +10,5 @@ html_title = 'Processor SDK AM62Ax Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62AX/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62Ax RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM62LX/AM62LX_buildroot_tags.py
+++ b/configs/AM62LX/AM62LX_buildroot_tags.py
@@ -10,13 +10,6 @@ html_title = 'Buildroot AM62L Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62LX/buildroot/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'linux', 'debian']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'buildroot'
 

--- a/configs/AM62LX/AM62LX_debian_tags.py
+++ b/configs/AM62LX/AM62LX_debian_tags.py
@@ -10,13 +10,6 @@ html_title = 'Debian AM62LX Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62LX/debian/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'
 

--- a/configs/AM62LX/AM62LX_linux_tags.py
+++ b/configs/AM62LX/AM62LX_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Linux SDK for AM62L Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62LX/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62AX','devices/AM62PX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/AM62PX/AM62PX_android_tags.py
+++ b/configs/AM62PX/AM62PX_android_tags.py
@@ -10,14 +10,6 @@ html_title = 'Processor SDK AM62Px Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62PX/android/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/DRA821A']
-#exclude_patterns = ['devices/AM62X']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'android'
 

--- a/configs/AM62PX/AM62PX_debian_tags.py
+++ b/configs/AM62PX/AM62PX_debian_tags.py
@@ -10,13 +10,6 @@ html_title = 'Debian AM62Px Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62PX/debian/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'
 

--- a/configs/AM62PX/AM62PX_linux_tags.py
+++ b/configs/AM62PX/AM62PX_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Processor SDK AM62Px Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62PX/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/AM62X/AM62X_android_tags.py
+++ b/configs/AM62X/AM62X_android_tags.py
@@ -10,14 +10,6 @@ html_title = 'Processor SDK AM62x Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62X/android/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/DRA821A']
-#exclude_patterns = ['devices/AM62X']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'android'
 

--- a/configs/AM62X/AM62X_buildroot_tags.py
+++ b/configs/AM62X/AM62X_buildroot_tags.py
@@ -10,13 +10,6 @@ html_title = 'Buildroot AM62x Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62X/buildroot/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX' , 'devices/AM62LX','linux', 'debian']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'buildroot'
 

--- a/configs/AM62X/AM62X_debian_tags.py
+++ b/configs/AM62X/AM62X_debian_tags.py
@@ -10,13 +10,6 @@ html_title = 'Debian AM62x Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62X/debian/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'
 

--- a/configs/AM62X/AM62X_linux_tags.py
+++ b/configs/AM62X/AM62X_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Processor SDK AM62x Documentation'
 # The master toctree document.
 master_doc = 'devices/AM62X/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM62x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/AM64X/AM64X_debian_tags.py
+++ b/configs/AM64X/AM64X_debian_tags.py
@@ -10,13 +10,6 @@ html_title = 'Debian AM64x Documentation'
 # The master toctree document.
 master_doc = 'devices/AM64X/debian/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM64x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM62X', 'devices/AM62PX', 'devices/AM65X', 'devices/J7_Family', 'devices/J721E', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62LX', 'linux']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'debian'
 

--- a/configs/AM64X/AM64X_linux_tags.py
+++ b/configs/AM64X/AM64X_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Processor SDK AM64X Documentation'
 # The master toctree document.
 master_doc = 'devices/AM64X/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# AM64x RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM65X', 'devices/J7_Family', 'devices/DRA821A' , 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/AM65X/AM65X_linux_tags.py
+++ b/configs/AM65X/AM65X_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM65X Documentation'
 # The master toctree document.
 master_doc = 'devices/AM65X/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/J7_Family', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM67/AM67_linux_tags.py
+++ b/configs/AM67/AM67_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM67 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM67A/AM67A_linux_tags.py
+++ b/configs/AM67A/AM67A_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Processor SDK Linux for AM67A Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# J722S RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7200', 'devices/J721E', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/AM68/AM68_linux_tags.py
+++ b/configs/AM68/AM68_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM68 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM68A/AM68A_linux_tags.py
+++ b/configs/AM68A/AM68A_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM68A Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7200', 'devices/J721E', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM69/AM69_linux_tags.py
+++ b/configs/AM69/AM69_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM69 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/AM69A/AM69A_linux_tags.py
+++ b/configs/AM69A/AM69A_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for AM69A Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7200', 'devices/J721S2', 'devices/J721E', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/CORESDK/CORESDK_linux_tags.py
+++ b/configs/CORESDK/CORESDK_linux_tags.py
@@ -9,10 +9,6 @@ sdk_product = 'general'
 # The master toctree document.
 master_doc = 'linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'devices']
-
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ProcessorSDKLinuxdoc'
 

--- a/configs/DRA821A/DRA821A_linux_tags.py
+++ b/configs/DRA821A/DRA821A_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for DRA821A Documentation'
 # The master toctree document.
 master_doc = 'devices/DRA821A/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7_Family', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/GEN/GEN_android_tags.py
+++ b/configs/GEN/GEN_android_tags.py
@@ -7,10 +7,6 @@ sdk_product = 'general'
 # The master toctree document.
 master_doc = 'android/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'linux', 'devices']
-
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ProcessorSDKAndroiddoc'
 

--- a/configs/GEN/GEN_linux_tags.py
+++ b/configs/GEN/GEN_linux_tags.py
@@ -7,10 +7,6 @@ sdk_product = 'general'
 # The master toctree document.
 master_doc = 'linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'devices']
-
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ProcessorSDKLinuxdoc'
 

--- a/configs/J7200/J7200_linux_tags.py
+++ b/configs/J7200/J7200_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for J7200 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/J721E/J721E_linux_tags.py
+++ b/configs/J721E/J721E_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for J721e Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/J721S2/J721S2_linux_tags.py
+++ b/configs/J721S2/J721S2_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for J721s2 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/J722S/J722S_linux_tags.py
+++ b/configs/J722S/J722S_linux_tags.py
@@ -10,13 +10,6 @@ html_title = 'Processor SDK J722S Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-
-# J722S RTOS docs are not in this project, rather referenced externally,
-# so exclude 'rtos' folder along with others.
-exclude_patterns = ['android', 'files', 'rtos', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'
 

--- a/configs/J742S2/J742S2_linux_tags.py
+++ b/configs/J742S2/J742S2_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for J742s2 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/J784S4/J784S4_linux_tags.py
+++ b/configs/J784S4/J784S4_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for J784s4 Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62PX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/configs/TDA4VM/TDA4VM_linux_tags.py
+++ b/configs/TDA4VM/TDA4VM_linux_tags.py
@@ -9,9 +9,5 @@ html_title = 'Processor SDK Linux for TDA4VM Documentation'
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
 
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-exclude_patterns = ['rtos', 'android', 'linux/index.rst', 'devices/AM335X', 'devices/AM437X', 'devices/AM64X', 'devices/AM65X', 'devices/J7200', 'devices/J721S2', 'devices/J784S4', 'devices/DRA821A', 'devices/AM62X', 'devices/AM62AX', 'devices/AM62LX']
-
 # OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
 sdk_os = 'linux'

--- a/scripts/sectinc.py
+++ b/scripts/sectinc.py
@@ -1,184 +1,34 @@
-import os, re
+"""Scripts to prepare config values for Sphinx
 
-# This script handles section inclusion/exclusion for the device family
+SPDX-License-Identifier: MIT
+Copyright (C) 2025 Texas Instruments Incorporated - https://www.ti.com
+"""
 
-toctreefiles    = []
-toctreesections = []
-docs_to_keep    = []
-all_rst_files   = []
+import re
+from pathlib import Path
 
-# fill_docs_to_keep
-# -----------------
-#
-# Description: Opens the device family Table-of-Contents file and reads each of the lines
-#              into the docs_to_keep[] array
-#
-# Parameters: app               - Application calling this Python function
-#             family_configlist - Device family Table-of-Contents file input
-#             verbosity         - Flag to determine if function will print names for all
-#                                 documents that are to be included
 
-def fill_docs_to_keep(app, family_configlist, verbosity):
+def generate_exclude_patterns(family_configlist):
+    """Read the toc.txt file and generate an exclude_patterns list for Sphinx. We use
+    exclude_patterns instead of include_patterns so toc.not_readable errors are specifically about
+    paths used with the RST toctree directive in the source directory.
+
+    :param family_configlist: List of String paths to the toc.txt files
+    """
+    comment = re.compile(r"#.*")
+    include_files = set()
     for config in family_configlist:
-        with open("configs" + os.sep + config, 'r') as docconfigfile:
-            for line in docconfigfile:
-                if line.strip():
-                    # Only add line to docs_to_keep[] if it is not a blank line
-                    docs_to_keep.append(re.sub(r"[\n\t\s]*", "", line))
-    if verbosity == 1:
-        print("The following .rst files will be included in the build:")
-        print('[')
-        for elem in docs_to_keep:
-            print(elem)
-        print(']')
-
-# set_excluded_docs
-# -----------------
-#
-# Description:  For each file in all_rst_files, searches the docs_to_keep[] array
-#               for its explicit inclusion in the device family build.  If the file
-#               is not found, it is placed in the exclusion_list so that Sphinx does not build it.
-#
-# Parameters: app            - Application calling this Python function
-#             exclusion_list - Section (.rst file) exclusion list used by Sphinx build
-
-def set_excluded_docs(app, exclusion_list):
-    for entry in all_rst_files:
-        #print("Checking " + entry)
-        if entry[:-4] not in docs_to_keep: # use [:-4] to remove ".rst" at the end
-            #print("Removing " + entry)
-            exclusion_list.append(entry)
-
-# find_toctree_files
-# ------------------
-#
-# Description:  Recursively searches for all files in the source folder (except those in excluded_patters)
-# that contain "toctree" directives, and places the names of these files in toctreefiles[].
-#
-# Parameters: app             - Application calling this Python function
-#             exclude_in_conf - excluded_patterns from <device>_tags.py
-
-def find_toctree_files(app, exclude_in_conf):
-    directory=os.getcwd() + os.sep + "source"
-    #print("Running find_toctree_files: directory = " + directory)
-    for root, dirs, files in os.walk(directory):
-        # exclude directories specified by excluded_patters in <device>_tags.py
-        dirs[:] = [d for d in dirs if (os.path.join(root, d).replace(directory+"/", "")) not in exclude_in_conf]
-        for filename in files:
-            if filename.endswith(".rst") and os.path.join(root, filename).replace(directory+"/", "") not in exclude_in_conf:
-                #print("Checking " + filename)
-                path = os.path.join(root, filename)
-                f = open(path, 'r')
-
-                if "toctree" in f.read():
-                    #print('found string in file %s' % filename)
-                    toctreefiles.append(path)
-                f.close()
-    #print("Finished toctree file search")
-    #print(toctreefiles)
-
-# find_all_rst_files
-# ------------------
-#
-# Description: Recursively finds all .rst files in the source directory, excluding those
-#              defined in excluded_patterns from <device>_tags.py
-#
-# Parameters: app             - Application calling this Python function
-#             exclude_in_conf - excluded_patterns from <device>_tags.py
-
-def find_all_rst_files(app, exclude_in_conf):
-    extension = '.rst'
-    directory = "source"
-    for dirpath, dirnames, files in os.walk(directory):
-        # exclude directories specified by excluded_patters in <device>_tags.py
-        dirnames[:] = [d for d in dirnames if (os.path.join(dirpath, d)).replace("source/", "") not in exclude_in_conf]
-        for name in files:
-            if extension and name.lower().endswith(extension) and os.path.join(dirpath, name).replace("source/", "") not in exclude_in_conf :
-                rst_path = os.path.join(dirpath, name)
-                all_rst_files.append(rst_path.replace("source/",""))
-    #print("Finished .rst file search")
-    #print(all_rst_files)
-
-# get_toctree_entries
-# -------------------
-#
-# Description:  This function opens a toctreenodefile that contains a "toctree" directive within it.
-# It searches for the "toctree" directive. After finding the toctree directive, it searches
-# for the next blank line (since this blank line is required for toctree's to work
-# in restructured text).  It then reads each line into toctreesections[] until it encounters
-# another blank line.
-#
-# Limitations:  In the current implementation, the assumption is that only a single toctree directive
-# is in each file.  This code would need to be updated if more than one toctree directive
-# is found in a single file.
-#
-# Parameters: app             - Application calling this Python function
-#             toctreenodefile - An .rst file that contains a toctree directive
-
-def get_toctree_entries(app, toctreenodefile):
-    with open(toctreenodefile, 'r') as tocfile:
-        line = 1
-        cnt = 0
-        while line:
-            line = tocfile.readline()
-            cnt += 1
-            # Searching for "toctree" line
-            toctreeline = re.match(r'^\.\. toctree::', line)
-            if toctreeline:
-                break
-        while line:
-            # Searching for next blank line
-            line = tocfile.readline()
-            cnt += 1
-            if not line.strip():
-                #print("Found blank line at line " + "{}".format(cnt))
-                break
-        while line:
-            # Reading lines and filling section array until next blank line
-            line = tocfile.readline()
-            cnt += 1
-            if line.strip() == '':
-                #print("Found last blank line")
-                break
-            # First, search for location of this .rst
-            rstfilename = "/" + re.sub(r"[\n\t\s]*", "", line) + ".rst"
-            rstfilelocation = [s for s in all_rst_files if rstfilename in s]
-            if len(rstfilelocation) > 1:
-                print("Error - More than one .rst file has been found for this TOC entry: ")
-                for i, value in enumerate(rstfilelocation):
-                    print(rstfilelocation[i])
-            elif len(rstfilelocation) == 0:
-                print("Error - .RST file has not been found for " + rstfilename + " section used in toctree.")
-                raise Exception('.RST file missing for section used in toctree.')
-            else:
-                # Only 1 string has been found in the .rst array
-                rststring = rstfilelocation[0]
-                if rststring:
-                    # Append the found .rst file to the toctreesections list
-                    toctreesections.append(re.sub(r'\.rst$', '', rststring))
-                else:
-                    print("TOC Tree Entry is not a defined .rst file in current directory")
-
-
-# create_master_rst_list
-# ----------------------
-#
-# Description:  This function first recursively searches for all files in source/{op_os} folder
-# that contain "toctree" directives, and places the names of these files in toctreefiles[].
-# Second, it recursively searches in this same directory for all .rst files and places the
-# names of these files in all_rst_files[].
-# Lastly, it gathers the toctreesections[] across all the toctreefiles[].
-# The result of this function is a master list (in toctreesections[]) of all .rst files
-# that the Table of Contents stage of the Sphinx build could utilize.
-#
-# Parameters: app             - Application calling this Python function
-#             exclude_in_conf - excluded_patterns from <device>_tags.py
-
-def create_master_rst_list(app, exclude_in_conf):
-    find_toctree_files(app, exclude_in_conf)
-    find_all_rst_files(app, exclude_in_conf)
-    #print(toctreefiles)
-    for files in toctreefiles:
-        get_toctree_entries(app, files)
-    #for section in toctreesections:
-    #    print(section)
+        config_path = Path("configs").joinpath(config)
+        with config_path.open("r", encoding="utf-8") as config_file:
+            for line in config_file:
+                clean_line = comment.sub("", line).strip()
+                if clean_line:
+                    clean_line = clean_line + ".rst"
+                    include_files.add(clean_line)
+    if not include_files:
+        raise ValueError("Expected at least one entry in the toc.txt file")
+    all_rst_files = set(
+        x.relative_to("source/").as_posix() for x in Path("source/").glob("**/*.rst")
+    )
+    exclude_files = all_rst_files.difference(include_files)
+    return list(exclude_files)


### PR DESCRIPTION
- chore: move to exclude only logic based on toc.txt

  Exclude all documents with an rst suffix not explicitly listed in the toc.txt.
  This removes a lot of dead logic and unnecessary config values.

  For a while this project mixed including and excluding document logic, where
  the include list was provided as an exhaustive description of everything
  through the toc.txt and a basic exclude list was provided as a sparse array
  populated manually in the OS tags.py file.

  This sparse array was supposed to change the way we searched for index files
  (previously referred to as toctreefiles), but ultimately any index files we
  needed were already listed in the main toc.txt.

  Signed-off-by: Randolph Sapp <rs@ti.com>

Closes #167