### PR TITLE
chore: add vale config for prose and spell checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.pyc
 build/
+.vale/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,6 @@
+MinAlertLevel = suggestion
+
+Packages = RedHat
+
+[*.{md,rst}]
+BasedOnStyles = RedHat


### PR DESCRIPTION
Red Hat has a pretty good template for this thing [1] and it already understands RST. Might as well pick it up here. Fair warning, it's much more picky than I am. I'm not entirely sure if we should add it to the PR checker right now, as even my stuff was flagged to hell and back.

[1] https://github.com/redhat-documentation/vale-at-red-hat

May be good enough to address #19 in the future though.