### PR TITLE
feat(U-Boot): J722S: Update config fragments for DFU and MSC boot

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/UG-DFU.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-DFU.rst
@@ -183,11 +183,11 @@ platform that support USB Peripheral boot mode.
 
 .. ifconfig:: CONFIG_part_variant in ('J722S')
 
-  #. Build the bootloader images using default "j722s_evm_r5_defconfig"
-     and the config fragment j722s_evm_r5_usbdfu.config
-     and "j722s_evm_a53_defconfig" config files. The configs required for
-     DFU boot as well as DFU in U-Boot are already enabled. For instructions
-     to build the bootloader images please refer to :ref:`Build-U-Boot-label`.
+  #. Build :program:`tiboot3.bin` using :file:`j722s_evm_r5_defconfig` along
+     with :file:`am62x_r5_usbdfu.config` fragment. Build :program:`tispl.bin`
+     and :program:`u-boot.img` using :file:`j722s_evm_a53_defconfig`.
+     For instructions to build the bootloader images please refer to
+     :ref:`Build-U-Boot-label`.
   #. Load the bootloader images tiboot3.bin, tispl.bin and u-boot.img using
      the dfu-util from host PC.
   #. Once the U-Boot is up, use DFU command from u-boot to flash the

--- a/source/linux/Foundational_Components/U-Boot/UG-General-Info.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-General-Info.rst
@@ -393,12 +393,12 @@ Build U-Boot
 
    .. ifconfig:: CONFIG_part_variant in ('J722S')
 
-      +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------+------------------------------------+
-      |  Board                     |            SD/eMMC Boot         |           UART boot            |           OSPI boot            |           USB DFU                  |           USB MSC                  |
-      +============================+=================================+================================+================================+====================================+====================================+
-      |    J722S EVM               |    j722s\_evm\_r5\_defconfig    |   j722s\_evm\_r5\_defconfig    |   j722s\_evm\_r5\_defconfig    |   j722s\_evm\_r5\_usbdfu.config    |   j722s\_evm\_r5\_usbmsc.config    |
-      |                            |    j722s\_evm\_a53\_defconfig   |   j722s\_evm\_a53\_defconfig   |   j722s\_evm\_a53\_defconfig   |   j722s\_evm\_a53\_defconfig       |   j722s\_evm\_a53\_defconfig       |
-      +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------+------------------------------------+
+      +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------------------------+-------------------------------------------------------+
+      |  Board                     |            SD/eMMC Boot         |           UART boot            |           OSPI boot            |                     USB DFU                          |           USB MSC                                     |
+      +============================+=================================+================================+================================+======================================================+=======================================================+
+      |    J722S EVM               |  | ``j722s_evm_r5_defconfig``   |  | ``j722s_evm_r5_defconfig``  |  | ``j722s_evm_r5_defconfig``  |  | ``j722s_evm_r5_defconfig am62x_r5_usbdfu.config`` |  | ``j722s_evm_r5_defconfig am62x_r5_usbmsc.config``  |
+      |                            |  | ``j722s_evm_a53_defconfig``  |  | ``j722s_evm_a53_defconfig`` |  | ``j722s_evm_a53_defconfig`` |  | ``j722s_evm_a53_defconfig``                       |  | ``j722s_evm_a53_defconfig``                        |
+      +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------------------------+-------------------------------------------------------+
 
    .. ifconfig:: CONFIG_part_variant in ('J721E','J7200','J721S2','J784S4','J742S2')
 
@@ -427,8 +427,8 @@ Build U-Boot
          $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig
 
          To build with config fragments
-         $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig j722s_evm_r5_usbdfu.config
-         $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig j722s_evm_r5_usbmsc.config
+         $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig am62x_r5_usbdfu.config
+         $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig am62x_r5_usbmsc.config
 
          $ make ARCH=arm O=<output directory>/r5 CROSS_COMPILE="$CROSS_COMPILE_32" BINMAN_INDIRS=${PREBUILT_IMAGES}
 


### PR DESCRIPTION
To enable USB DFU boot on J722S SoC, the bootloader "tiboot3.bin" has to be built by applying the config fragment "am62x_r5_usbdfu.config" on "j722s_evm_r5_defconfig".

To enable USB MSC boot on J722S SoC, the bootloader "tiboot3.bin" has to be built by applying the config fragment "am62x_r5_usbmsc.config" on "j722s_evm_r5_defconfig".

Document this.

While at it, update the format in the existing table that documents the configs to be used for various boot-modes, by switching to the newer notation for representing files.