### PR TITLE
Chore/clean configs

### DIFF
--- a/configs/AM335X/AM335X_linux_tags.py
+++ b/configs/AM335X/AM335X_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM335X Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM335X/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM335X/AM335X_linux_tags.py
+++ b/configs/AM335X/AM335X_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM335X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM335X'
 html_title = 'Processor SDK Linux for AM335X Documentation'
 

--- a/configs/AM437X/AM437X_linux_tags.py
+++ b/configs/AM437X/AM437X_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM437X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM437X'
 html_title = 'Processor SDK Linux for AM437X Documentation'
 

--- a/configs/AM437X/AM437X_linux_tags.py
+++ b/configs/AM437X/AM437X_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM437X Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM437X/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM57X/AM57X_linux_tags.py
+++ b/configs/AM57X/AM57X_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM57X Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM57X/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM57X/AM57X_linux_tags.py
+++ b/configs/AM57X/AM57X_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM57X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM57X'
 html_title = 'Processor SDK Linux for AM57X Documentation'
 

--- a/configs/AM62AX/AM62AX_linux_tags.py
+++ b/configs/AM62AX/AM62AX_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK AM62Ax Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62AX/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM62AX/AM62AX_linux_tags.py
+++ b/configs/AM62AX/AM62AX_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62AX'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for AM62Ax'
 html_title = 'Processor SDK AM62Ax Documentation'
 

--- a/configs/AM62LX/AM62LX_buildroot_tags.py
+++ b/configs/AM62LX/AM62LX_buildroot_tags.py
@@ -7,8 +7,3 @@ html_title = 'Buildroot AM62L Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62LX/buildroot/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'buildroot'
-
-

--- a/configs/AM62LX/AM62LX_buildroot_tags.py
+++ b/configs/AM62LX/AM62LX_buildroot_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62L'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Buildroot for AM62L'
 html_title = 'Buildroot AM62L Documentation'
 

--- a/configs/AM62LX/AM62LX_debian_tags.py
+++ b/configs/AM62LX/AM62LX_debian_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62LX'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Debian for AM62LX'
 html_title = 'Debian AM62LX Documentation'
 

--- a/configs/AM62LX/AM62LX_debian_tags.py
+++ b/configs/AM62LX/AM62LX_debian_tags.py
@@ -7,8 +7,3 @@ html_title = 'Debian AM62LX Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62LX/debian/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'debian'
-
-

--- a/configs/AM62LX/AM62LX_linux_tags.py
+++ b/configs/AM62LX/AM62LX_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62L'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Linux SDK for AM62L'
 html_title = 'Linux SDK for AM62L Documentation'
 

--- a/configs/AM62LX/AM62LX_linux_tags.py
+++ b/configs/AM62LX/AM62LX_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Linux SDK for AM62L Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62LX/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/AM62PX/AM62PX_android_tags.py
+++ b/configs/AM62PX/AM62PX_android_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK AM62Px Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62PX/android/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'android'
-
-

--- a/configs/AM62PX/AM62PX_android_tags.py
+++ b/configs/AM62PX/AM62PX_android_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62PX'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Android for AM62Px'
 html_title = 'Processor SDK AM62Px Documentation'
 

--- a/configs/AM62PX/AM62PX_debian_tags.py
+++ b/configs/AM62PX/AM62PX_debian_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62PX'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Debian for AM62Px'
 html_title = 'Debian AM62Px Documentation'
 

--- a/configs/AM62PX/AM62PX_debian_tags.py
+++ b/configs/AM62PX/AM62PX_debian_tags.py
@@ -7,8 +7,3 @@ html_title = 'Debian AM62Px Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62PX/debian/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'debian'
-
-

--- a/configs/AM62PX/AM62PX_linux_tags.py
+++ b/configs/AM62PX/AM62PX_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK AM62Px Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62PX/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/AM62PX/AM62PX_linux_tags.py
+++ b/configs/AM62PX/AM62PX_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62PX'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for AM62Px'
 html_title = 'Processor SDK AM62Px Documentation'
 

--- a/configs/AM62X/AM62X_android_tags.py
+++ b/configs/AM62X/AM62X_android_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK AM62x Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62X/android/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'android'
-
-

--- a/configs/AM62X/AM62X_android_tags.py
+++ b/configs/AM62X/AM62X_android_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Android for AM62x'
 html_title = 'Processor SDK AM62x Documentation'
 

--- a/configs/AM62X/AM62X_buildroot_tags.py
+++ b/configs/AM62X/AM62X_buildroot_tags.py
@@ -7,8 +7,3 @@ html_title = 'Buildroot AM62x Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62X/buildroot/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'buildroot'
-
-

--- a/configs/AM62X/AM62X_buildroot_tags.py
+++ b/configs/AM62X/AM62X_buildroot_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Buildroot for AM62x'
 html_title = 'Buildroot AM62x Documentation'
 

--- a/configs/AM62X/AM62X_debian_tags.py
+++ b/configs/AM62X/AM62X_debian_tags.py
@@ -7,8 +7,3 @@ html_title = 'Debian AM62x Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62X/debian/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'debian'
-
-

--- a/configs/AM62X/AM62X_debian_tags.py
+++ b/configs/AM62X/AM62X_debian_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Debian for AM62x'
 html_title = 'Debian AM62x Documentation'
 

--- a/configs/AM62X/AM62X_linux_tags.py
+++ b/configs/AM62X/AM62X_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK AM62x Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM62X/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/AM62X/AM62X_linux_tags.py
+++ b/configs/AM62X/AM62X_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM62X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for AM62x'
 html_title = 'Processor SDK AM62x Documentation'
 

--- a/configs/AM64X/AM64X_debian_tags.py
+++ b/configs/AM64X/AM64X_debian_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM64X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Debian for AM64x'
 html_title = 'Debian AM64x Documentation'
 

--- a/configs/AM64X/AM64X_debian_tags.py
+++ b/configs/AM64X/AM64X_debian_tags.py
@@ -7,8 +7,3 @@ html_title = 'Debian AM64x Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM64X/debian/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'debian'
-
-

--- a/configs/AM64X/AM64X_linux_tags.py
+++ b/configs/AM64X/AM64X_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM64X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for AM64X'
 html_title = 'Processor SDK AM64X Documentation'
 

--- a/configs/AM64X/AM64X_linux_tags.py
+++ b/configs/AM64X/AM64X_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK AM64X Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM64X/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/AM65X/AM65X_linux_tags.py
+++ b/configs/AM65X/AM65X_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM65X'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM65X'
 html_title = 'Processor SDK Linux for AM65X Documentation'
 

--- a/configs/AM65X/AM65X_linux_tags.py
+++ b/configs/AM65X/AM65X_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM65X Documentation'
 
 # The master toctree document.
 master_doc = 'devices/AM65X/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM67/AM67_linux_tags.py
+++ b/configs/AM67/AM67_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM67 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM67/AM67_linux_tags.py
+++ b/configs/AM67/AM67_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM67'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM67'
 html_title = 'Processor SDK Linux for AM67 Documentation'
 

--- a/configs/AM67A/AM67A_linux_tags.py
+++ b/configs/AM67A/AM67A_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK Linux for AM67A Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/AM67A/AM67A_linux_tags.py
+++ b/configs/AM67A/AM67A_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'AM67A'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for AM67A'
 html_title = 'Processor SDK Linux for AM67A Documentation'
 

--- a/configs/AM68/AM68_linux_tags.py
+++ b/configs/AM68/AM68_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM68'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM68'
 html_title = 'Processor SDK Linux for AM68 Documentation'
 

--- a/configs/AM68/AM68_linux_tags.py
+++ b/configs/AM68/AM68_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM68 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM68A/AM68A_linux_tags.py
+++ b/configs/AM68A/AM68A_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM68A Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM68A/AM68A_linux_tags.py
+++ b/configs/AM68A/AM68A_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM68A'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM68A'
 html_title = 'Processor SDK Linux for AM68A Documentation'
 

--- a/configs/AM69/AM69_linux_tags.py
+++ b/configs/AM69/AM69_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM69 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/AM69/AM69_linux_tags.py
+++ b/configs/AM69/AM69_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM69'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM69'
 html_title = 'Processor SDK Linux for AM69 Documentation'
 

--- a/configs/AM69A/AM69A_linux_tags.py
+++ b/configs/AM69A/AM69A_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'AM69A'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for AM69A'
 html_title = 'Processor SDK Linux for AM69A Documentation'
 

--- a/configs/AM69A/AM69A_linux_tags.py
+++ b/configs/AM69A/AM69A_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for AM69A Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/CORESDK/CORESDK_linux_tags.py
+++ b/configs/CORESDK/CORESDK_linux_tags.py
@@ -1,9 +1,6 @@
 # Device Family is CORESDK = CORESDK family
 fam_name = 'CORESDK'
 
-# This is coresdk specific information (i.e. not for specific sdk type)
-sdk_product = 'general'
-
 # Processor SDK Linux documentation build configuration file
 
 # The master toctree document.

--- a/configs/CORESDK/CORESDK_linux_tags.py
+++ b/configs/CORESDK/CORESDK_linux_tags.py
@@ -5,7 +5,6 @@ fam_name = 'CORESDK'
 
 # The master toctree document.
 master_doc = 'linux/index'
-
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'ProcessorSDKLinuxdoc'
 
@@ -41,5 +40,3 @@ texinfo_documents = [
    'Miscellaneous'),
 ]
 
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/DRA821A/DRA821A_linux_tags.py
+++ b/configs/DRA821A/DRA821A_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'DRA821A'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for DRA821A'
 html_title = 'Processor SDK Linux for DRA821A Documentation'
 

--- a/configs/DRA821A/DRA821A_linux_tags.py
+++ b/configs/DRA821A/DRA821A_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for DRA821A Documentation'
 
 # The master toctree document.
 master_doc = 'devices/DRA821A/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/GEN/GEN_android_tags.py
+++ b/configs/GEN/GEN_android_tags.py
@@ -40,6 +40,3 @@ texinfo_documents = [
    'Texas Instruments Incorporated', 'ProcessorSDKAndroid', 'One line description of project.',
    'Miscellaneous'),
 ]
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'android'

--- a/configs/GEN/GEN_android_tags.py
+++ b/configs/GEN/GEN_android_tags.py
@@ -1,7 +1,6 @@
 # Device Family is GEN = General family
 fam_name = 'GEN'
-# SDK is general (i.e. not automotive)
-sdk_product = 'general'
+
 # Processor SDK Android documentation build configuration file
 
 # The master toctree document.

--- a/configs/GEN/GEN_linux_tags.py
+++ b/configs/GEN/GEN_linux_tags.py
@@ -40,6 +40,3 @@ texinfo_documents = [
    'Texas Instruments Incorporated', 'ProcessorSDKLinux', 'One line description of project.',
    'Miscellaneous'),
 ]
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/GEN/GEN_linux_tags.py
+++ b/configs/GEN/GEN_linux_tags.py
@@ -1,7 +1,6 @@
 # Device Family is GEN = General family
 fam_name = 'GEN'
-# SDK is general (i.e. not automotive)
-sdk_product = 'general'
+
 # Processor SDK Linux documentation build configuration file
 
 # The master toctree document.

--- a/configs/GEN/GEN_tags.py
+++ b/configs/GEN/GEN_tags.py
@@ -1,4 +1,2 @@
 # Device Family is GEN = General family
 fam_name = 'GEN'
-# SDK is general (i.e. not automotive)
-sdk_product = 'general'

--- a/configs/J7200/J7200_linux_tags.py
+++ b/configs/J7200/J7200_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'J7200'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for J7200'
 html_title = 'Processor SDK Linux for J7200 Documentation'
 

--- a/configs/J7200/J7200_linux_tags.py
+++ b/configs/J7200/J7200_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for J7200 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/J721E/J721E_linux_tags.py
+++ b/configs/J721E/J721E_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for J721e Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/J721E/J721E_linux_tags.py
+++ b/configs/J721E/J721E_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'J721E'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for J721e'
 html_title = 'Processor SDK Linux for J721e Documentation'
 

--- a/configs/J721S2/J721S2_linux_tags.py
+++ b/configs/J721S2/J721S2_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for J721s2 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/J721S2/J721S2_linux_tags.py
+++ b/configs/J721S2/J721S2_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'J721S2'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for J721s2'
 html_title = 'Processor SDK Linux for J721s2 Documentation'
 

--- a/configs/J722S/J722S_linux_tags.py
+++ b/configs/J722S/J722S_linux_tags.py
@@ -2,8 +2,6 @@
 fam_name = 'J722S'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
-
 project = u'Processor SDK Linux for J722S'
 html_title = 'Processor SDK J722S Documentation'
 

--- a/configs/J722S/J722S_linux_tags.py
+++ b/configs/J722S/J722S_linux_tags.py
@@ -7,8 +7,3 @@ html_title = 'Processor SDK J722S Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'
-
-

--- a/configs/J742S2/J742S2_linux_tags.py
+++ b/configs/J742S2/J742S2_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for J742s2 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/J742S2/J742S2_linux_tags.py
+++ b/configs/J742S2/J742S2_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'J742S2'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for J742s2'
 html_title = 'Processor SDK Linux for J742s2 Documentation'
 

--- a/configs/J784S4/J784S4_linux_tags.py
+++ b/configs/J784S4/J784S4_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'J784S4'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for J784s4'
 html_title = 'Processor SDK Linux for J784s4 Documentation'
 

--- a/configs/J784S4/J784S4_linux_tags.py
+++ b/configs/J784S4/J784S4_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for J784s4 Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/TDA4VM/TDA4VM_linux_tags.py
+++ b/configs/TDA4VM/TDA4VM_linux_tags.py
@@ -7,6 +7,3 @@ html_title = 'Processor SDK Linux for TDA4VM Documentation'
 
 # The master toctree document.
 master_doc = 'devices/J7_Family/linux/index'
-
-# OS for the build. Sphinx uses source/{sdk_os} when looking for doc inputs
-sdk_os = 'linux'

--- a/configs/TDA4VM/TDA4VM_linux_tags.py
+++ b/configs/TDA4VM/TDA4VM_linux_tags.py
@@ -2,7 +2,6 @@
 fam_name = 'TDA4VM'
 
 # Project name and HTML title
-sdk_product = 'null' #todo: remove after the new structure is used for all device families
 project = u'Processor SDK Linux for TDA4VM'
 html_title = 'Processor SDK Linux for TDA4VM Documentation'
 


### PR DESCRIPTION
- chore(configs): prune unused sdk_os

  This was an old def only used for a little bit, but it was inherited by all of
  the devices added later.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- chore(configs): prune unused sdk_product

  This was an old def only used for a little bit, but it was inherited by all of
  the devices added later.

  Signed-off-by: Randolph Sapp <rs@ti.com>