### PR TITLE
docs(linux): AM62X: Issue_Tracker: Remove eMMC bug ref: EXT_EP-12076

### DIFF
--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -223,7 +223,6 @@ Issues Open
    :widths: 15, 70
 
    "EXT_EP-12299","AM62x large number of TCP packets with TX checksum errors"
-   "EXT_EP-12076","copying files to eMMC triggers cqe error"
    "EXT_EP-12074","ti-rpmsg-char: Squash resource leaks"
    "EXT_EP-12072","misleading GPMC message in kernel log"
    "EXT_EP-12081","AM62x: Make Debugging SPL doc specific to AM62x"


### PR DESCRIPTION
EXT_EP-12076: "copying files to eMMC triggers cqe error" Is not a SW Bug on 11.00 Release.

The correct bug was https://sir.ext.ti.com/jira/browse/EXT_EP-12086 and Is fixed in 10.01 release already.

This fix is to cleanup Release notes reference to reflect right SDK status.