### PR TITLE
feat(linux): PCIe Root Complex: Document support for 64-Bit Address Space

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex.rst
@@ -668,6 +668,17 @@ Following is a brief explanation of layers shown in the diagram:
     <value> is the resulting value to be written with "EC" bit of the
     register set.
 
+    .. rubric:: **64-Bit Address Space with 4 GB Size**
+       :name: 64-bit-address-space
+
+    The PCIe Controller support for 64-Bit addressing in the System's
+    Address Space with 4 GB Size is enabled in the device-tree.
+    The 4 GB region is split as:
+
+    1. 4 KB ECAM region for Configuration Accesses
+    2. 1 MB IO region
+    3. Remaining region (4 GB - 1 MB - 4 KB) as 32-bit Non-Prefetchable MEM
+
     .. rubric:: **Testing Details**
        :name: testing-details
 


### PR DESCRIPTION
The Cadence PCIe Controller supports 64-Bit Address Space on the following K3 SoCs:
    AM64, AM68, AM69, J7200, J721E, J721S2, J722S, J742S2 and J784S4.

The 64-Bit Address Space provides a larger 4 GB region compared to the 128 MB region in the 32-Bit Address Space. Since the Linux device-tree for the aforementioned SoCs has been updated to switch to the 64-Bit Address Space, document it.