### PR TITLE
fix(j7-perf): update associated toctree entries

### DIFF
--- a/configs/AM67/AM67_linux_toc.txt
+++ b/configs/AM67/AM67_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/AM67A/AM67A_linux_toc.txt
+++ b/configs/AM67A/AM67A_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/AM68/AM68_linux_toc.txt
+++ b/configs/AM68/AM68_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/AM68A/AM68A_linux_toc.txt
+++ b/configs/AM68A/AM68A_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/AM69/AM69_linux_toc.txt
+++ b/configs/AM69/AM69_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/AM69A/AM69A_linux_toc.txt
+++ b/configs/AM69A/AM69A_linux_toc.txt
@@ -14,7 +14,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J7200/J7200_linux_toc.txt
+++ b/configs/J7200/J7200_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J721E/J721E_linux_toc.txt
+++ b/configs/J721E/J721E_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J721S2/J721S2_linux_toc.txt
+++ b/configs/J721S2/J721S2_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J722S/J722S_linux_toc.txt
+++ b/configs/J722S/J722S_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J742S2/J742S2_linux_toc.txt
+++ b/configs/J742S2/J742S2_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/J784S4/J784S4_linux_toc.txt
+++ b/configs/J784S4/J784S4_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components

--- a/configs/TDA4VM/TDA4VM_linux_toc.txt
+++ b/configs/TDA4VM/TDA4VM_linux_toc.txt
@@ -15,7 +15,7 @@ devices/J7_Family/linux/Release_Specific
 devices/J7_Family/linux/Release_Specific_Release_Notes
 devices/J7_Family/linux/Release_Specific_Yocto_layer_Configuration
 devices/J7_Family/linux/Release_Specific_Migration_Guide
-devices/J7_Family/linux/Release_Specific_Performance_Guide
+devices/J7_Family/linux/Release_Specific_Kernel_Performance_Guide
 devices/J7_Family/linux/Release_Specific_Supported_Platforms_and_Versions
 devices/J7_Family/linux/Release_Specific_QSG
 linux/Foundational_Components


### PR DESCRIPTION
Part of a previous series was flattening some useless includes. This would have been fine on it's own but it was combined with a rename that resulted in invalid toctree entries.

I need to add some scripts to check for this automatically in the future.

Fixes: 65fe58d4 (chore(j7-perf): flatten useless include, 2025-04-30)