### PR TITLE
docs(linux): AM62LX: Update Release Summary with OTP Programming label

### DIFF
--- a/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
@@ -49,7 +49,7 @@ What's new
   - New 2-Stage A53 Boot Flow
   - ATF Based Device Manager including SCMI
   - U-Boot: Legacy Boot Flow, Boot modes (UART, MMCSD, OSPI), GPMC NAND, CPSW, DMA
-  - U-Boot: User and Reduced Bootmode OTP Programming
+  - U-Boot: :ref:`User and Reduced Bootmode OTP Programming  <programming-user-otp-fuses-label>`
   - U-Boot: :ref:`Key writer lite Programming <key-writer-lite-label>`
   - Kernel: DMA, GPIO, I2C, UART, MMCSD, OSPI NOR, eCAP, eQEP, CPSW, McASP/Audio, DSS, DSI
   - Kernel: :ref:`DTHEv2 Crypto Accelerator <DTHEv2-Crypto-Accelerator>`


### PR DESCRIPTION
Guide for Programming user OTP fuses and reduced boot-mode is unique for AM62L.
Adding the label reference in Release summary.