### PR TITLE
fix(dtb): paths were changed in 9.0

### DIFF
--- a/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
+++ b/source/linux/Foundational_Components/Kernel/_Users_Guide.rst
@@ -650,7 +650,7 @@ Installing the Kernel Image and Device Tree Binaries
 
         cd <kernel sources dir>
         sudo cp arch/arm/boot/zImage <rootfs path>/boot
-        sudo cp arch/arm/boot/dts/<dt file>.dtb <rootfs path>/boot
+        sudo cp arch/arm/boot/dts/<dt file>.dtb <rootfs path>/boot/dtb
 
     For example, if you wanted to copy the kernel image and BeagleBone
     Black device tree file to the rootfs partition of a SD card you would
@@ -670,7 +670,7 @@ Installing the Kernel Image and Device Tree Binaries
 
         cd <kernel sources dir>
         sudo cp arch/arm64/boot/Image <rootfs path>/boot
-        sudo cp arch/arm64/boot/dts/ti/<dt file>.dtb <rootfs path>/boot
+        sudo cp arch/arm64/boot/dts/ti/<dt file>.dtb <rootfs path>/boot/dtb/ti
 
     For example, if you wanted to copy the kernel image and AM64x EVM
     device tree file to the rootfs partition of a SD card you would
@@ -680,7 +680,7 @@ Installing the Kernel Image and Device Tree Binaries
 
          cd <kernel sources dir>
          sudo cp arch/arm64/boot/Image /media/rootfs/boot
-         sudo cp arch/arm64/boot/dts/ti/k3-am642-evm.dtb /media/rootfs/boot
+         sudo cp arch/arm64/boot/dts/ti/k3-am642-evm.dtb /media/rootfs/boot/dtb/ti
 
 Starting with U-boot 2013.10, the kernel and device tree binaries are read from
 the root file system's boot directory when booting from MMC/EMMC. (NOT from the

--- a/source/linux/Foundational_Components/PRU-ICSS/RPMsg_Quick_Start_Guide.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/RPMsg_Quick_Start_Guide.rst
@@ -247,7 +247,7 @@ the previous section. Let's do that now.
 
 #. Copy the new device tree binary to the SD card
 
-   -   sudo cp arch/arm/boot/dts/am335x-boneblack.dtb /media/user/rootfs/boot/
+   -   sudo cp arch/arm/boot/dts/am335x-boneblack.dtb /media/user/rootfs/boot/dtb/
 
    **Once again the example .dtb given above is for the BeagleBone
    Black. Check

--- a/source/linux/Industrial_Protocols/_SORTE.rst
+++ b/source/linux/Industrial_Protocols/_SORTE.rst
@@ -105,12 +105,11 @@ as master and at least two EVMs running as slave (slave1/slave2).
 Prior to running the applications, connect master Port0 to slave1 Port0,
 and slave1 Port1 to slave2 Port0.
 
-On the filesystem under /boot directory, link <platfrom>-pru-excl-uio.dtb
-as the default dtb file, and then reboot the EVM. For AM571x IDK, ensure
-that Jumper J51 is not placed. That selects between LCD
-function (J51 placed) and ICSS1 Ethernet (J51 removed). This also
-indicates that ICSS-EMAC unit test cannot run with LCD connected on the
-AM571x IDK board.
+On the filesystem under :file:`/boot/dtb/` directory, link
+:file:`<platfrom>-pru-excl-uio.dtb` as the default dtb file, and then reboot the
+EVM. For AM571x IDK, ensure that Jumper J51 is not placed. That selects between
+LCD function (J51 placed) and ICSS1 Ethernet (J51 removed). This also indicates
+that ICSS-EMAC unit test cannot run with LCD connected on the AM571x IDK board.
 
 After the EVMs are rebooted with the PRU UIO dtb files, run slave2 first,
 then slave1, and lastly master. Note that the master device will wait until


### PR DESCRIPTION
SDK 9.0 changed where dtbs are located for both legacy and non-legacy devices (even if there wasn't an official release for non-legacy devices before 9.1). Some paths were updated but these instances were missed.

Fixes #326