### PR TITLE
ci(check-files): check for unreachable files

### DIFF
--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -1,0 +1,69 @@
+---
+name: "check-files"
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'source/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/texasinstruments/processor-sdk-doc:latest
+      options: --entrypoint /bin/bash
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Update refs and settings
+        run: |
+          git config --global --add safe.directory "$PWD"
+          git switch -C pr
+          git fetch --no-tags --depth=1 origin master
+          git switch master
+
+      - name: Run check-files.sh
+        run: |
+          # Disable color output
+          export NO_COLOR=true
+
+          # Run the test
+          bin/delta.sh -a master -b pr -- ./bin/check-files.sh
+
+          # Prepare summary
+          WARNING_COUNT=$(wc -l < _new-warn.log)
+          if [ "$WARNING_COUNT" -gt "0" ]; then
+            echo "New unreachable files found with check-files.sh:"
+            echo '```text'
+            cat _new-warn.log
+            echo '```'
+          else
+            echo "No new unreachable files found with check-files.sh"
+          fi >> "$GITHUB_STEP_SUMMARY"
+
+          # Prepare the artifacts
+          mkdir -p ./results
+          echo "${{ github.event.number }}" > ./results/id
+          cp "$GITHUB_STEP_SUMMARY" ./results/summary
+          echo "$(wc -l < _new-warn.log)" > ./results/problem-count
+
+          # Exit with error if there are new warnings
+          [ "$WARNING_COUNT" -eq "0" ]
+
+      - name: Save results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: results
+          path: results/
+          retention-days: 1

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -6,6 +6,7 @@ on:
     workflows:
       - rstcheck
       - check_toc_txt
+      - check-files
     types:
       - completed
 


### PR DESCRIPTION
Use the delta script to check for any new unreachable collateral files. This will indicate when files not directly part of the documentation should be cleaned up.