### PR TITLE
docs(U-Boot): Refactor K3 and OMAP Build Guide

### DIFF
--- a/configs/AM335X/AM335X_linux_toc.txt
+++ b/configs/AM335X/AM335X_linux_toc.txt
@@ -22,8 +22,14 @@ linux/Release_Specific_Yocto_layer_Configuration
 linux/Release_Specific_Supported_Platforms_and_Versions
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-OMAP
+linux/Foundational_Components/U-Boot/BG-Setup-OMAP
+linux/Foundational_Components/U-Boot/BG-Build-OMAP
+linux/Foundational_Components/U-Boot/BG-Target-Images-OMAP
+linux/Foundational_Components/U-Boot/BG-Bootflow-OMAP
+linux/Foundational_Components/U-Boot/BG-Environment-OMAP
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-OMAP
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-NAND

--- a/configs/AM437X/AM437X_linux_toc.txt
+++ b/configs/AM437X/AM437X_linux_toc.txt
@@ -22,8 +22,14 @@ linux/Release_Specific_Yocto_layer_Configuration
 linux/Release_Specific_Supported_Platforms_and_Versions
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-OMAP
+linux/Foundational_Components/U-Boot/BG-Setup-OMAP
+linux/Foundational_Components/U-Boot/BG-Build-OMAP
+linux/Foundational_Components/U-Boot/BG-Target-Images-OMAP
+linux/Foundational_Components/U-Boot/BG-Bootflow-OMAP
+linux/Foundational_Components/U-Boot/BG-Environment-OMAP
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-OMAP
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-NAND

--- a/configs/AM57X/AM57X_linux_toc.txt
+++ b/configs/AM57X/AM57X_linux_toc.txt
@@ -21,8 +21,14 @@ devices/AM57X/linux/Release_Specific_Performance_Guide
 linux/Release_Specific_Supported_Platforms_and_Versions
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-OMAP
+linux/Foundational_Components/U-Boot/BG-Setup-OMAP
+linux/Foundational_Components/U-Boot/BG-Build-OMAP
+linux/Foundational_Components/U-Boot/BG-Target-Images-OMAP
+linux/Foundational_Components/U-Boot/BG-Bootflow-OMAP
+linux/Foundational_Components/U-Boot/BG-Environment-OMAP
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-OMAP
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-NAND

--- a/configs/AM62AX/AM62AX_linux_toc.txt
+++ b/configs/AM62AX/AM62AX_linux_toc.txt
@@ -26,8 +26,14 @@ linux/Overview/Processor_SDK_Linux_create_SD_card
 linux/Foundational_Components
 linux/index_Edge_AI
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-Memory-K3

--- a/configs/AM62LX/AM62LX_linux_toc.txt
+++ b/configs/AM62LX/AM62LX_linux_toc.txt
@@ -23,8 +23,14 @@ linux/Overview/Processor_SDK_Linux_create_SD_card
 
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Memory-K3
 linux/Foundational_Components/U-Boot/UG-SPI

--- a/configs/AM62PX/AM62PX_linux_toc.txt
+++ b/configs/AM62PX/AM62PX_linux_toc.txt
@@ -25,8 +25,14 @@ linux/Overview/Processor_SDK_Linux_create_SD_card
 
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 #linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-Memory-K3

--- a/configs/AM62X/AM62X_linux_toc.txt
+++ b/configs/AM62X/AM62X_linux_toc.txt
@@ -24,8 +24,14 @@ linux/Overview/Processor_SDK_Linux_create_SD_card
 
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 #linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-Memory-K3

--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -24,8 +24,14 @@ devices/AM64X/linux/RT_Linux_Performance_Guide
 
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Memory-K3
 linux/Foundational_Components/U-Boot/UG-SPI

--- a/configs/AM65X/AM65X_linux_toc.txt
+++ b/configs/AM65X/AM65X_linux_toc.txt
@@ -19,8 +19,14 @@ devices/AM65X/linux/Release_Specific_Performance_Guide
 devices/AM65X/linux/Release_Specific_Supported_Platforms_and_Versions
 linux/Foundational_Components
 linux/Foundational_Components_U-Boot
+linux/Foundational_Components/U-Boot/Build-Guide-K3
+linux/Foundational_Components/U-Boot/BG-Setup-K3
+linux/Foundational_Components/U-Boot/BG-Build-K3
+linux/Foundational_Components/U-Boot/BG-Target-Images-K3
+linux/Foundational_Components/U-Boot/BG-Bootflow-K3
+linux/Foundational_Components/U-Boot/BG-Environment-K3
+linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3
 linux/Foundational_Components/U-Boot/Users-Guide
-linux/Foundational_Components/U-Boot/UG-General-Info
 linux/Foundational_Components/U-Boot/UG-DFU
 linux/Foundational_Components/U-Boot/UG-Network
 linux/Foundational_Components/U-Boot/UG-NAND

--- a/source/devices/AM335X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM335X/linux/Release_Specific_Release_Notes.rst
@@ -87,6 +87,7 @@ See :ref:`here <release-specific-supported-platforms-and-versions>` for a list o
 
 |
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM437X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM437X/linux/Release_Specific_Release_Notes.rst
@@ -85,6 +85,8 @@ See :ref:`here <release-specific-supported-platforms-and-versions>` for a list o
 
 |
 
+.. _release-specific-build-information:
+
 Build Information
 =================
 

--- a/source/devices/AM57X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM57X/linux/Release_Specific_Release_Notes.rst
@@ -106,6 +106,7 @@ See `here <../../../linux/Release_Specific_Supported_Platforms_and_Versions.html
 
 |
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -49,7 +49,7 @@ What's new
   - Out-of-the-Box EdgeAI Gallery App powered by QT 6.9 for seamless AI experiences - :ref:`Edge AI Gallery - User Guide <Edge-AI-Gallery-User-Guide-label>`
   - EdgeAI memory carveouts now supported via `k3-am62a7-sk-edgeai.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62a7-sk-edgeai.dtso?h=11.01.07>`_ in ti-linux-kernel & applied by default in the AM62A board environment via the name_overlays variable in ti-u-boot as seen in `board/ti/am62ax/am62ax.env <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/board/ti/am62ax/am62ax.env?h=11.01.07#n22>`_ - `FAQ - EdgeAI memory carveouts <https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/11_01_07_05/exports/docs/devices/AM62AX/edgeai/faq.html#why-does-error-unable-to-map-memory-0xa2000000-appear-after-applying-a-custom-dtbo-using-name-overlays-from-sdk-11-1-with-edgeai>`__
   - Support for SELinux via meta-selinux with tisdk-edgeai-image - :ref:`Building the SELinux image with Yocto <building-the-sdk-with-yocto>` and :ref:`SELinux oeconfig file <yocto-layer-configuration>`
-  - EdgeAI DM R5 (:file:`dm_edgeai_mcu1_0_release_strip.out`) & C7x IPC (:file:`dsp_edgeai_c7x_1_release_strip.out`) firmwares delivered via `ti-linux-firmware <https://git.ti.com/cgit/processor-firmware/ti-linux-firmware/tree/?h=11.01.07>`__
+  - EdgeAI DM R5 (:file:`dm_edgeai_mcu1_0_release_strip.out`) & C7x IPC (:file:`dsp_edgeai_c7x_1_release_strip.out`) firmwares delivered via `ti-linux-firmware v11.01.07 <https://git.ti.com/cgit/processor-firmware/ti-linux-firmware/tree/?h=11.01.07>`__
   - Linux Remoteproc driver now boots remote cores (MCU R5 & C7x) by default during Linux kernel boot time to support Low Power Mode (LPM) with EdgeAI firmwares.
   - Simplified the Yocto build process for :file:`tisdk-edgeai-image` by eliminating the unnecessary edgeai branding step - :ref:`Building the SDK with Yocto <building-the-sdk-with-yocto>`
   - EdgeAI DM R5 & C7x firmwares now default to remote endpoint 14 for consistency across Sitara AM6x platforms with Linux RPMsg userspace application - :ref:`IPC for AM62ax <foundational-components-ipc>`
@@ -87,6 +87,7 @@ What's new
   - DM Firmware 11.01.00.05
   - Yocto scarthgap 5.0
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
@@ -71,6 +71,7 @@ What's new
   - Armbian-based Debian 13 (Trixie)
   - Buildroot 2024.11.1
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -74,6 +74,7 @@ What's new
   - DM Firmware 11.01.00.05
   - Yocto scarthgap 5.0
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -72,6 +72,7 @@ What's new
   - DM Firmware 11.01.00.05
   - Yocto scarthgap 5.0
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
@@ -69,6 +69,7 @@ What's new
   - TIFS Firmware `v11.01.02 <https://software-dl.ti.com/tisci/esd/11_01_02/release_notes/release_notes.html>`__ (Click on the link for more information)
   - Yocto scarthgap 5.0
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/devices/AM65X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM65X/linux/Release_Specific_Release_Notes.rst
@@ -78,15 +78,12 @@ See :ref:`here <release-specific-supported-platforms-and-versions>` for a list o
 
 .. _release-specific-sdk-components-versions:
 
+.. _release-specific-build-information:
 
 Build Information
 =================
 
 .. _u-boot-release-notes:
-.. _optee-release-notes:
-.. _tf-a-release-notes:
-.. _ti-linux-fw-release-notes:
-
 
 U-Boot
 ------
@@ -98,6 +95,7 @@ U-Boot
 | uBoot Tag: 09.03.05
 |
 
+.. _tf-a-release-notes:
 
 TF-A
 ----
@@ -108,6 +106,8 @@ TF-A
 | Tag: 2.10+
 |
 
+.. _optee-release-notes:
+
 OP-TEE
 ------
 
@@ -116,6 +116,8 @@ OP-TEE
 | Branch: master
 | Tag: 4.1.0
 |
+
+.. _ti-linux-fw-release-notes:
 
 ti-linux-firmware
 -----------------

--- a/source/devices/J7_Family/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/J7_Family/linux/Release_Specific_Release_Notes.rst
@@ -85,6 +85,8 @@ Processor SDK 11.00 Release has following new features:
   * HMAC support added in crypto driver
   * MCU_1_1 in split mode support added
 
+.. _release-specific-build-information:
+
 Build Information
 =================
 

--- a/source/linux/Foundational_Components/Boot_Monitor/_Boot_Monitor_Release_Notes.rst
+++ b/source/linux/Foundational_Components/Boot_Monitor/_Boot_Monitor_Release_Notes.rst
@@ -3,6 +3,8 @@
 Boot Monitor Release Notes
 ==============================
 
+.. _release-specific-build-information:
+
 .. rubric:: Build Information
    :name: build-information
 

--- a/source/linux/Foundational_Components/Kernel/_Processor_SDK_Linux_Kernel_Release_Notes.rst
+++ b/source/linux/Foundational_Components/Kernel/_Processor_SDK_Linux_Kernel_Release_Notes.rst
@@ -3,6 +3,8 @@
 Kernel Release Notes
 ======================
 
+.. _release-specific-build-information:
+
 Build Information
 -------------------
 

--- a/source/linux/Foundational_Components/Kernel/_Processor_SDK_Linux_RT_Kernel_Release_Notes.rst
+++ b/source/linux/Foundational_Components/Kernel/_Processor_SDK_Linux_RT_Kernel_Release_Notes.rst
@@ -3,6 +3,8 @@
 RT Kernel Release Notes
 ========================
 
+.. _release-specific-build-information:
+
 Build Information
 -------------------
 Please refer to the :ref:`release-specific-build-information-rt-linux-kernel` section of the release notes for details.

--- a/source/linux/Foundational_Components/U-Boot/BG-Bootflow-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Bootflow-K3.rst
@@ -1,0 +1,606 @@
+.. _u-boot-build-guide-bootflow-k3:
+
+########
+Bootflow
+########
+
+.. _Boot-Flow-label:
+
+*********
+Boot Flow
+*********
+
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family')
+
+   Booting the Linux kernel on an embedded platform is not as simple as simply
+   pointing a program counter to the kernel location and letting the processor
+   run. This section will review the four bootloader software stages that must
+   be run before the kernel can be booted and run on the device.
+
+   Application processors such as the the AM335x are complex pieces of hardware,
+   but have limited internal RAM (e.g., 128KB). Because of this limited amount
+   of RAM, multiple bootloader stages are needed. These bootloader stages
+   systematically unlock the full functionality of the device so that all
+   complexities of the device are available to the kernel.
+
+   There are four distinct bootloader stages:
+
+   .. Image:: /images/U-Boot_Boot_Order_32bit.png
+
+   1. ROM Code
+
+   The first stage bootloader is housed in ROM on the device. The ROM code is
+   the first block of code that is automatically run on device start-up or
+   after power-on reset (POR). The ROM bootloader code is hardcoded into the
+   device and cannot be changed by the user. Because of this, it is important
+   to get an understanding of what exactly the ROM code is doing.
+
+   The ROM code has two main functions:
+
+   * Configuration of the device and initialization of primary peripherals
+   such as stack setup, configuring the Watchdog Timer (see TRM for details)
+   as well as the PLL and system clocks configuration
+   * Readies the device for next bootloader by checking boot sources for next
+   stage of bootloader (SPL) as well as loading the actual next stage
+   bootloader code into memory and starting it
+
+   The list of booting devices that the ROM code will search through for the
+   second stage bootloader is configured by the voltage levels set on the
+   devices SYSBOOT pins on startup. These pins also set other boot parameters
+   (i.e. expected crystal frequency, bus width of external memory). For more
+   information on the SYSBOOT pins and associated boot parameters see the
+   device TRM.
+
+   2. SPL or MLO
+
+   The second stage bootloader is known as the SPL (Secondary Program Loader),
+   but is sometimes referred to as the MLO (MMC Card Loader). The SPL is the
+   first stage of U-Boot, and must be loaded from one of the boot sources into
+   internal RAM. The SPL has very limited configuration or user interaction,
+   and mainly serves to initialize the external DDR memory and set-up the boot
+   process for the next bootloader stage: U-Boot.
+
+   3. U-Boot
+
+   U-Boot allows for powerful command-based control over the kernel boot
+   environment via a serial terminal. The user has control over a number of
+   parameters such as boot arguments and the kernel boot command. In addition,
+   U-Boot environment variables can be configured. These environment variables
+   are stored in the **uEnv.txt** file on your storage medium or directly in
+   a Flash-based memory if configured such. These environment variables can be
+   viewed, modified, and saved using the **env print**, **env set**, and
+   **env save** commands, respectively. U-Boot is also a very useful tool to
+   program and manipulate a wide range of external memory devices as well as
+   a helpful aid during custom board bringup.
+
+   4. Linux Kernel
+
+   **zImage** is the compressed kernel image wrapped with header info that
+   describes the kernel. This header includes the target architecture, the
+   operating system, kernel size, entry points, etc. The loading of the kernel
+   image is typically performed through the use of scripts stored in the U-Boot
+   environment (all starting with the **bootcmd** ENV variable that gets
+   executed after the autoboot countdown expires or manually by entering the
+   **boot** command at the U-Boot prompt). This also involves passing a board-
+   specific device tree blob (DTB) as an argument to U-Boot's **bootz**
+   command that will extract and start the actual kernel.
+
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM335X_family', 'AM437X_family', 'AM62LX_family')
+
+   On K3 architecture based devices, ROM supports boot only via MCU(R5). This means that
+   bootloader has to run on R5 core. In order to meet this constraint, keeping
+   safety in picture and to have faster boot time, the software boot architecture
+   is designed as below:
+
+   .. ifconfig:: CONFIG_part_family not in ('J7_family', 'AM64X_family', 'AM62X_family', 'AM62AX_family')
+
+      .. code-block:: text
+
+            +------------------------------------------------------------------------+
+            |        DMSC            |         R5            |        ARM64          |
+            +------------------------------------------------------------------------+
+            |    +--------+          |                       |                       |
+            |    |  Reset |          |                       |                       |
+            |    +--------+          |                       |                       |
+            |         :              |                       |                       |
+            |    +--------+          |   +-----------+       |                       |
+            |    | *ROM*  |----------|-->| Reset rls |       |                       |
+            |    +--------+          |   +-----------+       |                       |
+            |    |        |          |         :             |                       |
+            |    |  ROM   |          |         :             |                       |
+            |    |services|          |         :             |                       |
+            |    |        |          |   +-------------+     |                       |
+            |    |        |          |   |  *R5 ROM*   |     |                       |
+            |    |        |          |   +-------------+     |                       |
+            |    |        |<---------|---|Load and auth|     |                       |
+            |    |        |          |   | tiboot3.bin |     |                       |
+            |    |        |          |   +-------------+     |                       |
+            |    |        |          |         :             |                       |
+            |    |        |          |         :             |                       |
+            |    |        |          |         :             |                       |
+            |    |        |          |   +-------------+     |                       |
+            |    |        |          |   |  *R5 SPL*   |     |                       |
+            |    |        |          |   +-------------+     |                       |
+            |    |        |          |   |    Load     |     |                       |
+            |    |        |          |   |  sysfw.itb  |     |                       |
+            |    | Start  |          |   +-------------+     |                       |
+            |    | System |<---------|---|    Start    |     |                       |
+            |    |Firmware|          |   |    SYSFW    |     |                       |
+            |    +--------+          |   +-------------+     |                       |
+            |        :               |   |             |     |                       |
+            |    +---------+         |   |   Load      |     |                       |
+            |    | *SYSFW* |         |   |   system    |     |                       |
+            |    +---------+         |   | Config data |     |                       |
+            |    |         |<--------|---|             |     |                       |
+            |    |         |         |   +-------------+     |                       |
+            |    |         |         |   |             |     |                       |
+            |    |         |         |   |    DDR      |     |                       |
+            |    |         |         |   |   config    |     |                       |
+            |    |         |         |   +-------------+     |                       |
+            |    |         |         |   |             |     |                       |
+            |    |         |<--------|---| Start A53   |     |                       |
+            |    |         |         |   |  and Reset  |     |                       |
+            |    |         |         |   +-------------+     |                       |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |---------|-----------------------|---->| Reset rls |     |
+            |    |         |         |                       |     +-----------+     |
+            |    |  DMSC   |         |                       |          :            |
+            |    |Services |         |                       |     +-----------+     |
+            |    |         |<--------|-----------------------|---->|*ATF/OPTEE*|     |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |         |                       |          :            |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |<--------|-----------------------|---->| *A53 SPL* |     |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |         |                       |     |   Load    |     |
+            |    |         |         |                       |     | u-boot.img|     |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |         |                       |          :            |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |<--------|-----------------------|---->| *U-Boot*  |     |
+            |    |         |         |                       |     +-----------+     |
+            |    |         |         |                       |     |  prompt   |     |
+            |    |         |         |                       |     +-----------+     |
+            |    +---------+         |                       |                       |
+            |                        |                       |                       |
+            +------------------------------------------------------------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('J721E')
+
+      .. code-block:: text
+
+         +------------------------------------------------------------------------+-----------------------+
+         |        DMSC            |      MCU R5           |        A72            |  MAIN R5/C66x/C7x     |
+         +------------------------------------------------------------------------+-----------------------+
+         |    +--------+          |                       |                       |                       |
+         |    |  Reset |          |                       |                       |                       |
+         |    +--------+          |                       |                       |                       |
+         |         :              |                       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    | *ROM*  |----------|-->| Reset rls |       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |  ROM   |          |         :             |                       |                       |
+         |    |services|          |         :             |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |   |  *R5 ROM*   |     |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |<---------|---|Load and auth|     |                       |                       |
+         |    |        |          |   | tiboot3.bin |     |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |   |  *R5 SPL*   |     |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |   |    Load     |     |                       |                       |
+         |    |        |          |   |  sysfw.itb  |     |                       |                       |
+         |    | Start  |          |   +-------------+     |                       |                       |
+         |    | System |<---------|---|    Start    |     |                       |                       |
+         |    |Firmware|          |   |    SYSFW    |     |                       |                       |
+         |    +--------+          |   +-------------+     |                       |                       |
+         |        :               |   |             |     |                       |                       |
+         |    +---------+         |   |   Load      |     |                       |                       |
+         |    | *SYSFW* |         |   |   system    |     |                       |                       |
+         |    +---------+         |   | Config data |     |                       |                       |
+         |    |         |<--------|---|             |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    DDR      |     |                       |                       |
+         |    |         |         |   |   config    |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    Load     |     |                       |                       |
+         |    |         |         |   |  tispl.bin  |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |   Load R5   |     |                       |                       |
+         |    |         |         |   |   firmware  |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |<--------|---| Start A72   |     |                       |                       |
+         |    |         |         |   | and jump to |     |                       |                       |
+         |    |         |         |   | DM fw image |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |---------|-----------------------|---->| Reset rls |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |  TIFS   |         |                       |          :            |                       |
+         |    |Services |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->|*ATF/OPTEE*|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *A72 SPL* |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |   Load    |     |                       |
+         |    |         |         |                       |     | u-boot.img|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *U-Boot*  |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  prompt   |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  Load R5  |     |                       |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start R5 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| R5 starts |    |
+         |    |         |         |                       |     |  Load C6  |     |      +-----------+    |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start C6 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| C6 starts |    |
+         |    |         |         |                       |     |  Load C7  |     |      +-----------+    |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start C7 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| C7 starts |    |
+         |    +---------+         |                       |                       |      +-----------+    |
+         |                        |                       |                       |                       |
+         +------------------------------------------------------------------------+-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('J7200', 'J721S2', 'J784S4','J742S2')
+
+      .. code-block:: text
+
+         +------------------------------------------------------------------------+-----------------------+
+         |        SMS             |      MCU R5           |        A72            |  MAIN R5/C7x          |
+         +------------------------------------------------------------------------+-----------------------+
+         |    +--------+          |                       |                       |                       |
+         |    |  Reset |          |                       |                       |                       |
+         |    +--------+          |                       |                       |                       |
+         |         :              |                       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    | *ROM*  |----------|-->| Reset rls |       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |  ROM   |          |         :             |                       |                       |
+         |    |services|          |         :             |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |   |  *R5 ROM*   |     |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |<---------|---|Load and auth|     |                       |                       |
+         |    |        |          |   | tiboot3.bin |     |                       |                       |
+         |    | Start  |          |   +-------------+     |                       |                       |
+         |    |  TIFS  |<---------|---|    Start    |     |                       |                       |
+         |    |        |          |   |    TIFS     |     |                       |                       |
+         |    +--------+          |   +-------------+     |                       |                       |
+         |        :               |   |             |     |                       |                       |
+         |    +---------+         |   |   Load      |     |                       |                       |
+         |    | *TIFS*  |         |   |   system    |     |                       |                       |
+         |    +---------+         |   | Config data |     |                       |                       |
+         |    |         |<--------|---|             |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |  *R5 SPL*   |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    DDR      |     |                       |                       |
+         |    |         |         |   |   config    |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    Load     |     |                       |                       |
+         |    |         |         |   |  tispl.bin  |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |   Load R5   |     |                       |                       |
+         |    |         |         |   |   firmware  |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |<--------|---| Start A72   |     |                       |                       |
+         |    |         |         |   | and jump to |     |                       |                       |
+         |    |         |         |   | DM fw image |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |---------|-----------------------|---->| Reset rls |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |  TIFS   |         |                       |          :            |                       |
+         |    |Services |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->|*ATF/OPTEE*|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *A72 SPL* |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |   Load    |     |                       |
+         |    |         |         |                       |     | u-boot.img|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *U-Boot*  |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  prompt   |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  Load R5  |     |                       |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start R5 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| R5 starts |    |
+         |    |         |         |                       |     |  Load C7  |     |      +-----------+    |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start C7 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| C7 starts |    |
+         |    |         |         |                       |                       |      +-----------+    |
+         |    |         |         |                       |                       |                       |
+         |    +---------+         |                       |                       |                       |
+         |                        |                       |                       |                       |
+         +------------------------------------------------------------------------+-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+      .. code-block:: text
+
+         +------------------------------------------------------------------------+-----------------------+
+         |        DMSC            |      MAIN R50         |         A53           |   MAIN R51            |
+         +------------------------------------------------------------------------+-----------------------+
+         |    +--------+          |                       |                       |                       |
+         |    |  Reset |          |                       |                       |                       |
+         |    +--------+          |                       |                       |                       |
+         |         :              |                       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    | *ROM*  |----------|-->| Reset rls |       |                       |                       |
+         |    +--------+          |   +-----------+       |                       |                       |
+         |    |        |          |         :             |                       |                       |
+         |    |  ROM   |          |         :             |                       |                       |
+         |    |services|          |         :             |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |          |   |  *R5 ROM*   |     |                       |                       |
+         |    |        |          |   +-------------+     |                       |                       |
+         |    |        |<---------|---|Load and auth|     |                       |                       |
+         |    |        |          |   | tiboot3.bin |     |                       |                       |
+         |    | Start  |          |   +-------------+     |                       |                       |
+         |    | SYSFW  |<---------|---|    Start    |     |                       |                       |
+         |    |        |          |   |    SYSFW    |     |                       |                       |
+         |    +--------+          |   +-------------+     |                       |                       |
+         |        :               |   |             |     |                       |                       |
+         |    +---------+         |   |   Load      |     |                       |                       |
+         |    | *SYSFW* |         |   |   system    |     |                       |                       |
+         |    +---------+         |   | Config data |     |                       |                       |
+         |    |         |<--------|---|             |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |         :             |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |  *R5 SPL*   |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    DDR      |     |                       |                       |
+         |    |         |         |   |   config    |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |   |    Load     |     |                       |                       |
+         |    |         |         |   |  tispl.bin  |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |<--------|---| Start A53   |     |                       |                       |
+         |    |         |         |   +-------------+     |                       |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |---------|-----------------------|---->| Reset rls |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |  SYSFW  |         |                       |          :            |                       |
+         |    |Services |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->|*ATF/OPTEE*|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *A53 SPL* |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |   Load    |     |                       |
+         |    |         |         |                       |     | u-boot.img|     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |          :            |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|---->| *U-Boot*  |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  prompt   |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |         |                       |     |  Load R5  |     |                       |
+         |    |         |         |                       |     |  Firmware |     |                       |
+         |    |         |         |                       |     +-----------+     |                       |
+         |    |         |<--------|-----------------------|-----|  Start R5 |     |      +-----------+    |
+         |    |         |---------|-----------------------|-----+-----------+-----|----->| R5 starts |    |
+         |    |         |         |                       |                       |      +-----------+    |
+         |    |         |         |                       |                       |                       |
+         |    +---------+         |                       |                       |                       |
+         |                        |                       |                       |                       |
+         +------------------------------------------------------------------------+-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'J722S')
+
+      .. code-block:: text
+
+         +------------------------------------------------------------------------+
+         |        TIFS            |      Main R5          |        A53            |
+         +------------------------------------------------------------------------+
+         |    +--------+          |                       |                       |
+         |    |  Reset |          |                       |                       |
+         |    +--------+          |                       |                       |
+         |         :              |                       |                       |
+         |    +--------+          |   +-----------+       |                       |
+         |    | *ROM*  |----------|-->| Reset rls |       |                       |
+         |    +--------+          |   +-----------+       |                       |
+         |    |        |          |         :             |                       |
+         |    |  ROM   |          |         :             |                       |
+         |    |services|          |         :             |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |   |  *R5 ROM*   |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |<---------|---|Load and auth|     |                       |
+         |    |        |          |   | tiboot3.bin |     |                       |
+         |    +--------+          |   +-------------+     |                       |
+         |    |        |<---------|---| Load sysfw  |     |                       |
+         |    |        |          |   | part to TIFS|     |                       |
+         |    |        |          |   | core        |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |         :             |                       |
+         |    |        |          |         :             |                       |
+         |    |        |          |         :             |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |   |  *R5 SPL*   |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |   |    DDR      |     |                       |
+         |    |        |          |   |   config    |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |   |    Load     |     |                       |
+         |    |        |          |   |  tispl.bin  |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |   |   Load R5   |     |                       |
+         |    |        |          |   |   firmware  |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |<---------|---| Start A53   |     |                       |
+         |    |        |          |   | and jump to |     |                       |
+         |    |        |          |   | DM fw image |     |                       |
+         |    |        |          |   +-------------+     |                       |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |----------|-----------------------|---->| Reset rls |     |
+         |    |        |          |                       |     +-----------+     |
+         |    |  TIFS  |          |                       |          :            |
+         |    |Services|          |                       |     +-----------+     |
+         |    |        |<---------|-----------------------|---->|*ATF/OPTEE*|     |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |          |                       |          :            |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |<---------|-----------------------|---->| *A53 SPL* |     |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |          |                       |     |   Load    |     |
+         |    |        |          |                       |     | u-boot.img|     |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |          |                       |          :            |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |<---------|-----------------------|---->| *U-Boot*  |     |
+         |    |        |          |                       |     +-----------+     |
+         |    |        |          |                       |     |  prompt   |     |
+         |    |        |----------|-----------------------|-----+-----------+-----|
+         |    +--------+          |                       |                       |
+         |                        |                       |                       |
+         +------------------------------------------------------------------------+
+
+   Here |__SYSFW_CORE_NAME__| acts as master and provides all the critical services. R5/ARM64
+   requests |__SYSFW_CORE_NAME__| to get these services done as shown in the above diagram.
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   Unlike with most other K3 SoCs the AM62LX does not have an Cortext-R5
+   MCU core which ROM uses to initialize the SoC therefore uses a 2
+   phase ROM boot. The first phase will load the tiboot3.bin image which
+   contains Trusted-Firmware-A's BL-1 loader along with the typical X.509
+   certificate to authenticate and validate the image which is used to
+   intialize the console and DDR for the next phase.
+
+   .. code-block:: text
+
+      ┌───────────────────┐┌───────────────────┐
+      │    Secure ROM     ││    Public ROM     │
+      │     SMS (M4)      ││   (Cortex-A53)    │
+      │                   ││                   │
+      │┌─────────────────┐││                   │
+      ││  Reset Release  │││                   │
+      │└────────┬────────┘││                   │
+      │         │         ││                   │
+      │┌────────▼────────┐││                   │
+      ││    ROM Init     │││                   │
+      │└────────┬────────┘││                   │
+      │         │         ││                   │
+      │┌────────▼────────┐││┌─────────────────┐│
+      ││   Release A53   ┼┼┼►   Release A53   ││
+      │└─────────────────┘││└────────┬────────┘│
+      │                   ││         │         │
+      │  Validate Image   ││┌────────▼────────┐│
+      │┌─────────────────┐│││    ROM Init     ││
+      ││ Integrity Check ◄┼┼┼   (1st Phase)   ││
+      │├─────────────────│││└────────┬────────┘│
+      ││ Authentication  │││         │         │
+      │├─────────────────┤││┌────────▼────────┐│
+      ││    Decryption   ││││       WFI       ││
+      │└────────┬────────┘││└─────────────────┘│
+      │         │         ││                   │
+      │┌────────▼────────┐││    End of ROM     │
+      ││  Wait for WFI   │││~~~~~~~~~~~~~~~~~~~│
+      ││  on Cortex-A53  │││     Start of      │
+      │└────────┬────────┘││       BL-1        │
+      │         │         ││                   │
+      │┌────────▼────────┐││┌─────────────────┐│
+      ││    Start BL-1   ┼┼┼►    DDR Init     ││
+      │└────────┬────────┘││└────────┬────────┘│
+      │         │         ││         │         │
+      │┌────────▼────────┐││┌────────▼────────┐│
+      ││  Wait for BL-1  ◄┼┼┼  Send BL-1 Done ││
+      ││     Done Msg    │││└────────┬────────┘│
+      │└─────────────────┘││         │         │
+      │                   ││┌────────▼────────┐│
+      │                   │││       WFI       ││
+      │                   ││└─────────────────┘│
+      └───────────────────┘└───────────────────┘
+
+   After the BL-1 sends a message back to the Secure ROM to indicate it
+   has completed, the Secure ROM will reset the A53 back into Public ROM
+   to begin the 2nd ROM boot phase to load the tispl.bin into the SoC.
+
+   .. code-block:: text
+
+      ┌───────────────────┐┌───────────────────┐
+      │    Secure ROM     ││    Public ROM     │
+      │     SMS (M4)      ││   (Cortex-A53)    │
+      │                   ││                   │
+      │┌─────────────────┐││                   │
+      ││  Program Reset  │││┌─────────────────┐│
+      ││   Vector And    ┼┼┼►   Release A53   ││
+      ││    Reset A53    │││└────────┬────────┘│
+      │└─────────────────┘││         │         │
+      │                   ││         │         │
+      │   Validate Image  ││┌────────▼────────┐│
+      │┌─────────────────┐│││    ROM Init     ││
+      ││ Integrity Check ◄┼┼┼   (2nd Phase)   ││
+      │├─────────────────┤││└────────┬────────┘│
+      ││ Authentication  │││         │         │
+      │├─────────────────┤││┌────────▼────────┐│
+      ││   Decryption    ││││       WFI       ││
+      │└────────┬────────┘││└─────────────────┘│
+      │         │         ││                   │
+      │┌────────▼────────┐││     End of ROM    │
+      ││  Wait for WFI   │││~~~~~~~~~~~~~~~~~~~│
+      ││  on Cortex-A53  │││                   │
+      │└────────┬────────┘││                   │
+      │         │         ││                   │
+      │┌────────▼────────┐││                   │
+      ││  Program Reset  │││┌─────────────────┐│
+      ││   Vector And    ┼┼┼►   TF-A (BL-31)  ││
+      ││    Reset A53    │││└────────┬────────┘│
+      │└────────┬────────┘││         │         │
+      │         │         ││┌────────▼────────┐│
+      │┌────────▼────────┐│││    U-Boot SPL   ││
+      ││  Prep M4 Reset  │││└────────┬────────┘│
+      │└────────┬────────┘││         │         │
+      │         │         ││┌────────▼────────┐│
+      │┌────────▼────────┐│││     U-Boot      ││
+      ││    Boot TI-FS   │││└────────┬────────┘│
+      │└────────┬────────┘││         │         │
+      │         │         ││         │         │
+      │     End of ROM    ││         │         │
+      │~~~~~~~~~~~~~~~~~~~││         │         │
+      │         │         ││┌────────▼────────┐│
+      │┌────────▼────────┐│││                 ││
+      ││                 ││││                 ││
+      ││      TI-FS      ││││      Linux      ││
+      └┴─────────────────┴┘└┴─────────────────┴┘
+
+   From there TIFS, TF-A and U-Boot will has completed their
+   initialization routines which can begin loading the operating system
+   and complete the boot process.

--- a/source/linux/Foundational_Components/U-Boot/BG-Bootflow-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Bootflow-OMAP.rst
@@ -1,0 +1,85 @@
+.. _u-boot-build-guide-bootflow-omap:
+
+########
+Bootflow
+########
+
+.. _Boot-Flow-label:
+
+*********
+Boot Flow
+*********
+
+Booting the Linux kernel on an embedded platform is not as simple as simply
+pointing a program counter to the kernel location and letting the processor
+run. This section will review the four bootloader software stages that must
+be run before the kernel can be booted and run on the device.
+
+Application processors such as these are complex pieces of hardware,
+but have limited internal RAM (e.g., 128KB). Because of this limited amount
+of RAM, multiple bootloader stages are needed. These bootloader stages
+systematically unlock the full functionality of the device so that all
+complexities of the device are available to the kernel.
+
+There are four distinct bootloader stages:
+
+.. Image:: /images/U-Boot_Boot_Order_32bit.png
+
+#. ROM Code
+
+   The first stage bootloader is housed in ROM on the device. The ROM code is
+   the first block of code that is automatically run on device start-up or
+   after power-on reset (POR). The ROM bootloader code is hardcoded into the
+   device and cannot be changed by the user. Because of this, it is important
+   to get an understanding of what exactly the ROM code is doing.
+
+   The ROM code has two main functions:
+
+   * Configuration of the device and initialization of primary peripherals
+     such as stack setup, configuring the Watchdog Timer (see TRM for details)
+     as well as the PLL and system clocks configuration
+
+   * Readies the device for next bootloader by checking boot sources for next
+     stage of bootloader (SPL) as well as loading the actual next stage
+     bootloader code into memory and starting it
+
+   The list of booting devices that the ROM code will search through for the
+   second stage bootloader is configured by the voltage levels set on the
+   devices SYSBOOT pins on startup. These pins also set other boot parameters
+   (i.e. expected crystal frequency, bus width of external memory). For more
+   information on the SYSBOOT pins and associated boot parameters see the
+   device TRM.
+
+#. SPL or MLO
+
+   The second stage bootloader is known as the SPL (Secondary Program Loader),
+   but is sometimes referred to as the MLO (MMC Card Loader). The SPL is the
+   first stage of U-Boot, and must be loaded from one of the boot sources into
+   internal RAM. The SPL has very limited configuration or user interaction,
+   and mainly serves to initialize the external DDR memory and set-up the boot
+   process for the next bootloader stage: U-Boot.
+
+#. U-Boot
+
+   U-Boot allows for powerful command-based control over the kernel boot
+   environment via a serial terminal. The user has control over a number of
+   parameters such as boot arguments and the kernel boot command. In addition,
+   U-Boot environment variables can be configured. These environment variables
+   are stored in the **uEnv.txt** file on your storage medium or directly in
+   a Flash-based memory if configured such. These environment variables can be
+   viewed, modified, and saved using the **env print**, **env set**, and
+   **env save** commands, respectively. U-Boot is also a very useful tool to
+   program and manipulate a wide range of external memory devices as well as
+   a helpful aid during custom board bringup.
+
+#. Linux Kernel
+
+   **zImage** is the compressed kernel image wrapped with header info that
+   describes the kernel. This header includes the target architecture, the
+   operating system, kernel size, entry points, etc. The loading of the kernel
+   image is typically performed through the use of scripts stored in the U-Boot
+   environment (all starting with the **bootcmd** ENV variable that gets
+   executed after the autoboot countdown expires or manually by entering the
+   **boot** command at the U-Boot prompt). This also involves passing a board-
+   specific device tree blob (DTB) as an argument to U-Boot's **bootz**
+   command that will extract and start the actual kernel.

--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -1,0 +1,497 @@
+.. _u-boot-build-guide-build-k3:
+
+#####
+Build
+#####
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. rubric:: Build BL-1
+
+   .. note::
+
+      The following commands are intended to be run from the root of the
+      TF-A tree unless otherwise specified. The root of the TF-A tree is
+      the top-level directory and can be identified by looking for the
+      "licenses" directory.
+
+   .. rubric:: Setting up the toolchain paths
+
+   .. include:: ../../Overview/GCC_ToolChain.rst
+      :start-after: .. start_include_yocto_toolchain_host_setup
+      :end-before: .. end_include_yocto_toolchain_host_setup
+
+   .. code-block:: console
+
+      $ cd <path to tf-a dir>
+
+      $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=am62l am62l_bl1
+
+      <or to build bl-1 and bl-31 binaries from TF-A repo>
+
+	   $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=am62l
+
+.. _Build-U-Boot-label:
+
+************
+Build U-Boot
+************
+
+.. note::
+
+   The following commands are intended to be run from the root of the
+   U-Boot tree unless otherwise specified. The root of the U-Boot tree is
+   the top-level directory and can be identified by looking for the
+   "MAINTAINERS" file.
+
+.. ifconfig:: CONFIG_part_variant not in ('AM65X', 'AM64X', 'AM62LX')
+
+   .. note:: Note about HSM Rearchitecture
+
+      After HSM rearchitecture in bootloader, loading of remote cores with firmware
+      will be supported at A72 SPL stage only and not at R5 SPL stage. Early loading
+      of remote core firmware in R5 SPL requires core reset functionality. As part
+      of HSM rearchitecture, this functionality has moved into the DM service which
+      requires SPL to re-implement device and clock control. This support is not
+      present in Uboot R5 SPL due to memory constraints on the existing 64-bit TI devices.
+
+.. ifconfig:: CONFIG_part_variant not in ('AM65X', 'AM62LX')
+
+   .. note::
+      As of Processor SDK 9.0, compilation of bootloader images will no longer require
+      different defconfigs for GP and HS devices. The same build commands will generate images
+      for GP, HS-SE and HS-FS devices.
+
+.. rubric:: Prebuilt Images
+
+Several prebuilt images are required from the TI Processor SDK for building U-Boot on K3 based platforms.
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   - TF-A (**BL-1** and **BL-31**): Refer to :ref:`foundational-components-atf`
+     for more information
+   - ti-linux-firmware (**BINMAN_INDIRS**): Prebuilt TIFS binaries are
+     available in `ti-linux-firmware <https://git.ti.com/cgit/processor-firmware/ti-linux-firmware/?h=ti-linux-firmware>`__.
+
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
+
+   - TF-A (BL-31): Refer to :ref:`foundational-components-atf` for more information
+   - OP-TEE (TEE): Refer to :ref:`foundational-components-optee` for more information
+   - ti-linux-firmware (BINMAN_INDIRS): Prebuilt binaries for DM and SYSFW available `here
+     <https://git.ti.com/cgit/processor-firmware/ti-linux-firmware/log/?h=ti-linux-firmware>`__.
+
+All of these are available in the SDK at :file:`<path to tisdk>/board-support/prebuilt-images>`
+
+Go :ref:`here <download-and-install-sdk>` to download and install the SDK.
+
+.. rubric:: Setting up the toolchain paths
+
+.. include:: ../../Overview/GCC_ToolChain.rst
+   :start-after: .. start_include_yocto_toolchain_host_setup
+   :end-before: .. end_include_yocto_toolchain_host_setup
+
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
+
+   .. rubric:: Compiling R5 and ARM64 images
+
+   Use the following table to determine what defconfig to use to configure with:
+
+.. ifconfig:: CONFIG_part_variant in ('AM65X')
+
+   +----------------------------+------------------------------------+--------------------------------+--------------------------------+
+   |  Board                     |   SD / eMMC / UART / OSPI Boot     |         Hyper Flash            |           USB DFU              |
+   +============================+====================================+================================+================================+
+   |    AM65x EVM/IDK           |   ``am65x_evm_r5_defconfig``       |                                |                                |
+   |                            |   ``am65x_evm_a53_defconfig``      |                                |                                |
+   +----------------------------+------------------------------------+--------------------------------+--------------------------------+
+   |    AM65x HS EVM/IDK        | ``am65x_hs_evm_r5_defconfig``      |                                |                                |
+   |                            | ``am65x_hs_evm_a53_defconfig``     |                                |                                |
+   +----------------------------+------------------------------------+--------------------------------+--------------------------------+
+
+   *on GP*
+
+   .. code-block:: console
+
+      $ cd <path to u-boot dir>
+
+      R5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am65x_evm_r5_defconfig O=<output directory>/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=<output directory>/r5 BINMAN_INDIRS=<path to tisdk>/board-support/prebuilt-images
+
+      A53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am65x_evm_a53_defconfig O=<output directory>/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=<path to tisdk>/board-support/prebuilt-images/bl31.bin TEE=<path to tisdk>/board-support/prebuilt-images/bl32.bin O=<output directory>/a53 BINMAN_INDIRS=<path to tisdk>/board-support/prebuilt-images
+
+
+
+   *on HS*
+
+   .. code-block:: console
+
+      $ cd <path to u-boot dir>
+
+      R5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am65x_hs_evm_r5_defconfig O=<output directory>/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=<output directory>/r5 BINMAN_INDIRS=<path to tisdk>/board-support/prebuilt-images
+
+
+      A53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am65x_hs_evm_a53_defconfig O=<output directory>/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=<path to tisdk>/board-support/prebuilt-images/bl31.bin TEE=<path to tisdk>/board-support/prebuilt-images/bl32.bin O=<output directory>/a53 BINMAN_INDIRS=<path to tisdk>/board-support/prebuilt-images
+
+
+
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+   +----------------------------+---------------------------------+---------------------------------+
+   |  Board                     |     SD / UART / OSPI Boot       |      eMMC Boot                  |
+   +============================+=================================+=================================+
+   |    AM64X EVM               | ``am64x_evm_r5_defconfig``      |  ``am64x_evm_r5_defconfig``     |
+   |                            | ``am64x_evm_a53_defconfig``     |  ``am64x_evm_a53_defconfig``    |
+   +----------------------------+---------------------------------+---------------------------------+
+   |    AM64X SK                | ``am64x_evm_r5_defconfig``      |                                 |
+   |                            | ``am64x_evm_a53_defconfig``     |                                 |
+   +----------------------------+---------------------------------+---------------------------------+
+
+   .. note::
+
+      Where to get the sources: :ref:`Getting the U-Boot Source Code-label`
+
+   .. code-block:: console
+
+      $ export UBOOT_DIR=<path-to-ti-u-boot>
+      $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
+      $ export TFA_DIR=<path-to-arm-trusted-firmware>
+      $ export OPTEE_DIR=<path-to-ti-optee-os>
+
+   .. note::
+
+      The instructions below assume all binaries are built manually. For instructions to build :file:`bl31.bin` go to: :ref:`foundational-components-optee`.
+      For instructions to build :file:`tee-pager_v2.bin` (:file:`bl32.bin`) go to: :ref:`foundational-components-atf`. BINMAN_INDIRS can point to
+      :file:`<path-to-tisdk>/board-support/prebuilt-images/am64xx-evm` to use the pre-built binaries that come in the pre-built SDK (:file:`bl31.bin` for BL31, :file:`bl32.bin` for TEE).
+
+   .. code-block:: console
+
+      $ cd $UBOOT_DIR
+
+      R5
+      To build tiboot3.bin. Saved in $UBOOT_DIR/out/r5.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am64x_evm_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      A53
+      To build tispl.bin and u-boot.img. Saved in $UBOOT_DIR/out/a53.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am64x_evm_a53_defconfig O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/bl32.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+.. ifconfig:: CONFIG_part_variant in ('J721E')
+
+   +----------------------------+---------------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+
+   |  Board                     |            SD/eMMC Boot         |           UART Boot            |           OSPI Boot            |         Hyper Flash            |           USB DFU              |
+   +============================+=================================+================================+================================+================================+================================+
+   |    J721E EVM               | ``j721e_evm_r5_defconfig``      | ``j721e_evm_r5_defconfig``     | ``j721e_evm_r5_defconfig``     | ``j721e_evm_r5_defconfig``     | ``j721e_evm_r5_defconfig``     |
+   |                            | ``j721e_evm_a72_defconfig``     | ``j721e_evm_a72_defconfig``    | ``j721e_evm_a72_defconfig``    | ``j721e_evm_a72_defconfig``    | ``j721e_evm_a72_defconfig``    |
+   +----------------------------+---------------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+
+   |    J721E SK                | ``j721e_evm_r5_defconfig``      | ``j721e_evm_r5_defconfig``     | ``j721e_evm_r5_defconfig``     |                                |                                |
+   |                            | ``j721e_evm_a72_defconfig``     | ``j721e_evm_a72_defconfig``    | ``j721e_evm_a72_defconfig``    |                                |                                |
+   +----------------------------+---------------------------------+--------------------------------+--------------------------------+--------------------------------+--------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('J7200')
+
+   +----------------------------+---------------------------------+--------------------------------+
+   |  Board                     |            SD/eMMC Boot         |           UART Boot            |
+   +============================+=================================+================================+
+   |    J7200 EVM               |  ``j7200_evm_r5_defconfig``     | ``j7200_evm_r5_defconfig``     |
+   |                            |  ``j7200_evm_a72_defconfig``    | ``j7200_evm_a72_defconfig``    |
+   +----------------------------+---------------------------------+--------------------------------+
+
+
+.. ifconfig:: CONFIG_part_variant in ('J721S2')
+
+   +----------------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+
+   |  Board                     |            SD/eMMC Boot         |           UART Boot             |           OSPI Boot             |           USB DFU               |
+   +============================+=================================+=================================+=================================+=================================+
+   |    J721S2 EVM              | ``j721s2_evm_r5_defconfig``     | ``j721s2_evm_r5_defconfig``     | ``j721s2_evm_r5_defconfig``     | ``j721s2_evm_r5_defconfig``     |
+   |                            | ``j721s2_evm_a72_defconfig``    | ``j721s2_evm_a72_defconfig``    | ``j721s2_evm_a72_defconfig``    | ``j721s2_evm_a72_defconfig``    |
+   +----------------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+
+   |    AM68 HS-FS SK           | ``j721s2_evm_r5_defconfig``     | ``j721s2_evm_r5_defconfig``     | ``j721s2_evm_r5_defconfig``     |                                 |
+   |                            | ``j721s2_evm_a72_defconfig``    | ``j721s2_evm_a72_defconfig``    | ``j721s2_evm_a72_defconfig``    |                                 |
+   +----------------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('J784S4')
+
+   +----------------------------+----------------------------------+---------------------------------+---------------------------------+---------------------------------+
+   |  Board                     |            SD/eMMC Boot          |           UART Boot             |           OSPI Boot             |           USB DFU               |
+   +============================+==================================+=================================+=================================+=================================+
+   |    J784S4 EVM              | ``j784s4_evm_r5_defconfig``      | ``j784s4_evm_r5_defconfig``     | ``j784s4_evm_r5_defconfig``     | ``j784s4_evm_r5_defconfig``     |
+   |                            | ``j784s4_evm_a72_defconfig``     | ``j784s4_evm_a72_defconfig``    | ``j784s4_evm_a72_defconfig``    | ``j784s4_evm_a72_defconfig``    |
+   +----------------------------+----------------------------------+---------------------------------+---------------------------------+---------------------------------+
+   |    AM69 HS-FS SK           |  ``j784s4_evm_r5_defconfig``     | ``j784s4_evm_r5_defconfig``     | ``j784s4_evm_r5_defconfig``     |                                 |
+   |                            |  ``j784s4_evm_a72_defconfig``    | ``j784s4_evm_a72_defconfig``    | ``j784s4_evm_a72_defconfig``    |                                 |
+   +----------------------------+----------------------------------+---------------------------------+---------------------------------+---------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('J742S2')
+
+   +----------------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+
+   |  Board                     |            SD/eMMC Boot         |           UART Boot             |           OSPI Boot             |           USB DFU               |
+   +============================+=================================+=================================+=================================+=================================+
+   |    J742S2 EVM              | ``j742s2_evm_r5_defconfig``     | ``j742s2_evm_r5_defconfig``     | ``j742s2_evm_r5_defconfig``     | ``j742s2_evm_r5_defconfig``     |
+   |                            | ``j742s2_evm_a72_defconfig``    | ``j742s2_evm_a72_defconfig``    | ``j742s2_evm_a72_defconfig``    | ``j742s2_evm_a72_defconfig``    |
+   +----------------------------+---------------------------------+---------------------------------+---------------------------------+---------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('J722S')
+
+   +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------------------------+-------------------------------------------------------+
+   |  Board                     |            SD/eMMC Boot         |           UART Boot            |           OSPI Boot            |                     USB DFU                          |           USB MSC                                     |
+   +============================+=================================+================================+================================+======================================================+=======================================================+
+   |    J722S EVM               | ``j722s_evm_r5_defconfig``      | ``j722s_evm_r5_defconfig``     | ``j722s_evm_r5_defconfig``     | ``j722s_evm_r5_defconfig am62x_r5_usbdfu.config``    | ``j722s_evm_r5_defconfig am62x_r5_usbmsc.config``     |
+   |                            | ``j722s_evm_a53_defconfig``     | ``j722s_evm_a53_defconfig``    | ``j722s_evm_a53_defconfig``    | ``j722s_evm_a53_defconfig``                          | ``j722s_evm_a53_defconfig``                           |
+   +----------------------------+---------------------------------+--------------------------------+--------------------------------+------------------------------------------------------+-------------------------------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('J721E','J7200','J721S2','J784S4','J742S2')
+
+   .. code-block:: console
+
+      $ cd <path to u-boot dir>
+      $ PREBUILT_IMAGES=<path to tisdk>/board-support/prebuilt-images
+
+      R5
+      $ make ARCH=arm O=<output directory>/r5 <soc>_evm_r5_defconfig
+      $ make ARCH=arm O=<output directory>/r5 CROSS_COMPILE="$CROSS_COMPILE_32" BINMAN_INDIRS=${PREBUILT_IMAGES}
+
+
+      A72
+      $ make ARCH=arm O=<output directory>/a72 <soc>_evm_a72_defconfig
+      $ make ARCH=arm O=<output directory>/a72 CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=${PREBUILT_IMAGES}/bl31.bin TEE=${PREBUILT_IMAGES}/bl32.bin BINMAN_INDIRS=${PREBUILT_IMAGES}
+
+.. ifconfig:: CONFIG_part_variant in ('J722S')
+
+   .. code-block:: console
+
+      $ cd <path to u-boot dir>
+      $ PREBUILT_IMAGES=<path to tisdk>/board-support/prebuilt-images
+
+      R5
+      $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig
+
+      To build with config fragments
+      $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig am62x_r5_usbdfu.config
+      $ make ARCH=arm O=<output directory>/r5 j722s_evm_r5_defconfig am62x_r5_usbmsc.config
+
+      $ make ARCH=arm O=<output directory>/r5 CROSS_COMPILE="$CROSS_COMPILE_32" BINMAN_INDIRS=${PREBUILT_IMAGES}
+
+
+      A53
+      $ make ARCH=arm O=<output directory>/a53 j722s_evm_a53_defconfig
+      $ make ARCH=arm O=<output directory>/a53 CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=${PREBUILT_IMAGES}/bl31.bin TEE=${PREBUILT_IMAGES}/bl32.bin BINMAN_INDIRS=${PREBUILT_IMAGES}
+
+
+.. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+   +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
+   |  Board        |     SD / eMMC / UART / OSPI Boot   |                         USB DFU                          |                            USB MSC                       |
+   +===============+====================================+==========================================================+==========================================================+
+   |  AM62X SK     | ``am62x_evm_r5_defconfig``         | ``am62x_evm_r5_defconfig am62x_r5_usbdfu.config``        | ``am62x_evm_r5_defconfig am62x_r5_usbmsc.config``        |
+   |               | ``am62x_evm_a53_defconfig``        | ``am62x_evm_a53_defconfig``                              | ``am62x_evm_a53_defconfig``                              |
+   +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
+   |  AM62X LP SK  | ``am62x_lpsk_r5_defconfig``        | ``am62x_lpsk_r5_defconfig am62x_r5_usbdfu.config``       | ``am62x_lpsk_r5_defconfig am62x_r5_usbmsc.config``       |
+   |               | ``am62x_lpsk_a53_defconfig``       | ``am62x_lpsk_a53_defconfig``                             | ``am62x_lpsk_a53_defconfig``                             |
+   +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
+   |  AM62SIP SK   | ``am62xsip_evm_r5_defconfig``      | ``am62xsip_evm_r5_defconfig am62x_r5_usbdfu.config``     | ``am62xsip_evm_r5_defconfig am62x_r5_usbmsc.config``     |
+   |               | ``am62xsip_evm_a53_defconfig``     | ``am62xsip_evm_a53_defconfig``                           | ``am62xsip_evm_a53_defconfig``                           |
+   +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
+
+   .. note::
+
+      Where to get the sources: :ref:`Getting the U-Boot Source Code-label`
+
+   .. code-block:: console
+
+      $ export UBOOT_DIR=<path-to-ti-u-boot>
+      $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
+      $ export TFA_DIR=<path-to-arm-trusted-firmware>
+      $ export OPTEE_DIR=<path-to-ti-optee-os>
+
+   .. note::
+
+      The instructions below assume all binaries are built manually. For instructions to build :file:`bl31.bin` go to: :ref:`foundational-components-optee`.
+      For instructions to build :file:`tee-pager_v2.bin` (:file:`bl32.bin`) go to: :ref:`foundational-components-atf`. BINMAN_INDIRS can point to
+      :file:`<path-to-tisdk>/board-support/prebuilt-images/am62xx-evm` to use the pre-built binaries that come in the pre-built SDK (:file:`bl31.bin` for BL31, :file:`bl32.bin` for TEE).
+
+   .. code-block:: console
+
+      $ cd $UBOOT_DIR
+
+      R5
+      To build tiboot3.bin. Saved in $UBOOT_DIR/out/r5.
+
+      For AM62X
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am62x_evm_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      For AM62X LP
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am62x_lpsk_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      For AM62SIP
+      NOTE: AM62SIP Uses config fragment model.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am62x_evm_r5_defconfig am62xsip_sk_r5.config O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      A53
+      To build tispl.bin and u-boot.img. Saved in $UBOOT_DIR/out/a53. Requires bl31.bin, tee-pager_v2.bin
+
+      For AM62X or AM62SIP
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am62x_evm_a53_defconfig O=$UBOOT_DIR/out/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      For AM62X LP
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am62x_lpsk_a53_defconfig O=$UBOOT_DIR/out/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+
+.. ifconfig:: CONFIG_part_variant in ('AM62AX')
+
+   +-------------+----------------------------------+--------------------------------------------------------+--------------------------------------------------------+
+   |  Board      |            SD Boot               |                       USB DFU                          |                       USB MSC                          |
+   +=============+==================================+========================================================+========================================================+
+   |  AM62AX SK  | ``am62ax_evm_r5_defconfig``      | ``am62ax_evm_r5_defconfig am62x_r5_usbdfu.config``     | ``am62ax_evm_r5_defconfig am62x_r5_usbmsc.config``     |
+   |             | ``am62ax_evm_a53_defconfig``     | ``am62ax_evm_a53_defconfig``                           | ``am62ax_evm_a53_defconfig``                           |
+   +-------------+----------------------------------+--------------------------------------------------------+--------------------------------------------------------+
+
+   .. note::
+
+      Where to get the sources: :ref:`Getting the U-Boot Source Code-label`
+
+   .. code-block:: console
+
+      $ export UBOOT_DIR=<path-to-ti-u-boot>
+      $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
+      $ export TFA_DIR=<path-to-arm-trusted-firmware>
+      $ export OPTEE_DIR=<path-to-ti-optee-os>
+
+   .. note::
+
+      The instructions below assume all binaries are built manually. For instructions to build :file:`bl31.bin` go to: :ref:`foundational-components-optee`.
+      For instructions to build :file:`tee-pager_v2.bin` (:file:`bl32.bin`) go to: :ref:`foundational-components-atf`. BINMAN_INDIRS can point to
+      :file:`<path-to-tisdk>/board-support/prebuilt-images` to use the pre-built binaries that come in the pre-built SDK (:file:`bl31.bin` for BL31, :file:`bl32.bin` for TEE).
+
+   .. code-block:: console
+
+      $ cd $UBOOT_DIR
+
+      R5
+      To build tiboot3.bin. Saved in $UBOOT_DIR/out/r5.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am62ax_evm_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      A53
+      To build tispl.bin and u-boot.img. Saved in $UBOOT_DIR/out/a53. Requires bl31.bin, tee-pager_v2.bin.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am62ax_evm_a53_defconfig O=$UBOOT_DIR/out/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+.. ifconfig:: CONFIG_part_variant in ('AM62PX')
+
+   +-------------+----------------------------------+----------------------------------------------------------+--------------------------------------------------------+
+   |  Board      |            SD Boot               |                       USB DFU                            |                        USB MSC                         |
+   +=============+==================================+==========================================================+========================================================+
+   |  AM62PX SK  | ``am62px_evm_r5_defconfig``      | ``am62px_evm_r5_defconfig am62x_r5_usbdfu.config``       | ``am62px_evm_r5_defconfig am62x_r5_usbmsc.config``     |
+   |             | ``am62px_evm_a53_defconfig``     | ``am62px_evm_a53_defconfig``                             | ``am62px_evm_a53_defconfig``                           |
+   +-------------+----------------------------------+----------------------------------------------------------+--------------------------------------------------------+
+
+   .. note::
+
+      Where to get the sources: :ref:`Getting the U-Boot Source Code-label`
+
+   .. code-block:: console
+
+      $ export UBOOT_DIR=<path-to-ti-u-boot>
+      $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
+      $ export TFA_DIR=<path-to-arm-trusted-firmware>
+      $ export OPTEE_DIR=<path-to-ti-optee-os>
+
+   .. note::
+
+      The instructions below assume all binaries are built manually. For instructions to build :file:`bl31.bin` go to: :ref:`foundational-components-optee`.
+      For instructions to build :file:`tee-pager_v2.bin` (:file:`bl32.bin`) go to: :ref:`foundational-components-atf`. BINMAN_INDIRS can point to
+      :file:`<path-to-tisdk>/board-support/prebuilt-images` to use the pre-built binaries that come in the pre-built SDK (:file:`bl31.bin` for BL31, :file:`bl32.bin` for TEE).
+
+   .. code-block:: console
+
+      $ cd $UBOOT_DIR
+
+      R5
+      To build tiboot3.bin. Saved in $UBOOT_DIR/out/r5.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am62px_evm_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+      A53
+      To build tispl.bin and u-boot.img. Saved in $UBOOT_DIR/out/a53. Requires bl31.bin, tee-pager_v2.bin.
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am62px_evm_a53_defconfig O=$UBOOT_DIR/out/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. csv-table::
+      :header: "Board","SD / eMMC / UART / OSPI / USB DFU / USB MSC"
+
+      "AM62LX EVM", ``am62lx_evm_defconfig``
+
+   .. note::
+
+      Where to get the sources: :ref:`Getting the U-Boot Source Code-label`
+
+   .. code-block:: console
+
+      $ export UBOOT_DIR=<path-to-ti-u-boot>
+      $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
+      $ export TFA_DIR=<path-to-arm-trusted-firmware>
+
+   .. note::
+
+      The instructions below assume all binaries are built manually.
+      For instructions to build :file:`bl1.bin` or :file:`bl31.bin` go
+      to: :ref:`foundational-components-atf`.
+
+      **BINMAN_INDIRS** can point to
+      :file:`<path-to-tisdk>/board-support/prebuilt-images` to use
+      the pre-built binaries that come in the pre-built SDK.
+
+   .. code-block:: console
+
+      $ cd $UBOOT_DIR
+      $ make CROSS_COMPILE="$CROSS_COMPILE_64" am62lx_evm_defconfig
+      $ make CROSS_COMPILE="$CROSS_COMPILE_64" \
+         BL1=$TFA_DIR/build/k3/lite/release/bl1.bin \
+         BL31=$TFA_DIR/build/k3/lite/release/bl31.bin \
+         BINMAN_INDIRS=$TI_LINUX_FW_DIR
+
+.. ifconfig:: CONFIG_part_variant not in ('AM64X', 'AM62X', 'AM62AX', 'AM62LX')
+
+   .. note::
+
+      BINMAN_INDIRS is used to fetch the DM binary from :file:`board-support/prebuilt-images/ti-dm/` and SYSFW binaries from :file:`board-support/prebuilt-images/ti-sysfw/`. If not using the SDK, BINMAN_INDIRS can point to either ti-linux-firmware or any folder where DM is located in :file:`<path to folder>/ti-dm/` and SYSFW binaries are present in :file:`<path to folder>/ti-sysfw/`. Please make sure to use the absolute path.
+
+.. ifconfig:: CONFIG_part_variant in ('AM64X', 'AM62X', 'AM62AX')
+
+   .. note::
+
+      BINMAN_INDIRS is used to fetch the DM binary from :file:`<path to ti-linux-firmware>/ti-dm/` and SYSFW binaries from :file:`<path to ti-linux-firmware>/ti-sysfw/`. If using the SDK, BINMAN_INDIRS can point to :file:`<path to SDK>/board-support/prebuilt-images`. Else any folder where DM is located in :file:`<path to folder>/ti-dm/` and SYSFW binaries are present in :file:`<path to folder>/ti-sysfw/` can be used. Please make sure to use the absolute path.
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. note::
+
+      BINMAN_INDIRS is used to fetch the TIFS binaries from
+      :file:`<path to ti-linux-firmware>/ti-sysfw/`. If using the SDK,
+      BINMAN_INDIRS can point to
+      :file:`<path to SDK>/board-support/prebuilt-images`. Else any
+      folder where SYSFW binaries are present in
+      :file:`<path to folder>/ti-sysfw/` can be used. Please make sure
+      to use the absolute path.
+
+.. ifconfig:: CONFIG_part_variant in ('J721E', 'J7200', 'AM62X', 'AM62AX', 'AM62PX', 'J721S2', 'J784S4','J742S2', 'J722S')
+
+   .. note::
+
+      It is also possible to pick up a custom DM binary by adding TI_DM argument pointing to the file. If not provided, it defaults to picking up the DM binary from BINMAN_INDIRS. This is only applicable to devices that utilize split firmware.

--- a/source/linux/Foundational_Components/U-Boot/BG-Build-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-OMAP.rst
@@ -1,0 +1,151 @@
+.. _u-boot-build-guide-build-omap:
+
+#####
+Build
+#####
+
+.. _Build-U-Boot-label:
+
+************
+Build U-Boot
+************
+
+.. note::
+
+   The following commands are intended to be run from the root of the
+   U-Boot tree unless otherwise specified. The root of the U-Boot tree is
+   the top-level directory and can be identified by looking for the
+   "MAINTAINERS" file.
+
+We strongly recommend the use of separate object directories when
+building. This is done with O= parameter to make. We also recommend that
+you use an output directory name that is identical to the configuration
+target name. That way if you are working with multiple configuration
+targets it is very easy to know which folder contains the u-boot
+binaries that you are interested in.
+
+.. rubric:: Setting the tool chain path
+
+We strongly recommend using the toolchain that came with the Linux Core
+release that corresponds to this U-Boot release. For e.g:
+
+.. code-block:: console
+
+   $ export PATH=$HOME/<TOOLCHAIN_PATH>/bin:$PATH
+
+.. rubric:: Cleaning the Sources
+
+If you did not use a separate object directory:
+
+.. code-block:: console
+
+   $ make CROSS_COMPILE=arm-none-linux-gnueabihf- distclean
+
+.. ifconfig:: CONFIG_part_variant in ('AM335X')
+
+   If you used ``O=am335x\_evm`` as your object directory:
+
+   .. code-block:: console
+
+      $ rm -rf ./am335x_evm
+
+.. ifconfig:: CONFIG_part_variant in ('AM437X')
+
+   If you used ``O=am43xx\_evm`` as your object directory:
+
+   .. code-block:: console
+
+      $ rm -rf ./am43xx_evm
+
+.. ifconfig:: CONFIG_part_variant in ('AM57X')
+
+   If you used ``O=am57xx\_evm`` as your object directory:
+
+   .. code-block:: console
+
+      $ rm -rf ./am57xx_evm
+
+.. rubric:: Compiling MLO and u-boot
+
+Building of both u-boot and SPL is done at the same time. You must
+however first configure the build for the board you are working with.
+Use the following table to determine what defconfig to use to configure
+with:
+
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| Board                      | SD Boot                     | eMMC Boot                | NAND Boot                                    | UART Boot                | Ethernet Boot            | USB Ethernet Boot        | USB Host Boot                           | SPI Boot                                 |
++============================+=============================+==========================+==============================================+==========================+==========================+==========================+=========================================+==========================================+
+| AM335x GP EVM              | ``am335x_evm_defconfig``    |                          | ``am335x_evm_defconfig``                     | ``am335x_evm_defconfig`` | ``am335x_evm_defconfig`` | ``am335x_evm_defconfig`` |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM335x EVM-SK              | ``am335x_evm_defconfig``    |                          |                                              | ``am335x_evm_defconfig`` |                          | ``am335x_evm_defconfig`` |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM335x ICE                 | ``am335x_evm_defconfig``    |                          |                                              | ``am335x_evm_defconfig`` |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| BeagleBone Black           | ``am335x_evm_defconfig``    | ``am335x_evm_defconfig`` |                                              | ``am335x_evm_defconfig`` |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| BeagleBone White           | ``am335x_evm_defconfig``    |                          |                                              | ``am335x_evm_defconfig`` |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM437x GP EVM              | ``am43xx_evm_defconfig``    |                          | ``am43xx_evm_defconfig``                     | ``am43xx_evm_defconfig`` | ``am43xx_evm_defconfig`` | ``am43xx_evm_defconfig`` | ``am43xx_evm_usbhost_boot_defconfig``   |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM437x EVM-Sk              | ``am43xx_evm_defconfig``    |                          |                                              |                          |                          |                          | ``am43xx_evm_usbhost_boot_defconfig``   |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM437x IDK                 | ``am43xx_evm_defconfig``    |                          |                                              |                          |                          |                          |                                         | ``am43xx_evm_qspiboot_defconfig`` (XIP)  |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM437x ePOS EVM            | ``am43xx_evm_defconfig``    |                          | ``am43xx_evm_defconfig``                     |                          |                          |                          | ``am43xx_evm_usbhost_boot_defconfig``   |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM572x GP EVM              | ``am57xx_evm_defconfig``    |                          |                                              | ``am57xx_evm_defconfig`` |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM572x IDK                 | ``am57xx_evm_defconfig``    |                          |                                              |                          |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| AM571x IDK                 | ``am57xx_evm_defconfig``    |                          |                                              |                          |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| DRA74x/DRA72x/DRA71x EVM   | ``dra7xx_evm_defconfig``    | ``dra7xx_evm_defconfig`` | ``dra7xx_evm_defconfig``   (DRA71x EVM only) |                          |                          |                          |                                         | ``dra7xx_evm_defconfig``  (QSPI)         |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| K2HK EVM                   |                             |                          | ``k2hk_evm_defconfig``                       | ``k2hk_evm_defconfig``   | ``k2hk_evm_defconfig``   |                          |                                         | ``k2hk_evm_defconfig``                   |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| K2L EVM                    |                             |                          | ``k2l_evm_defconfig``                        | ``k2l_evm_defconfig``    |                          |                          |                                         | ``k2l_evm_defconfig``                    |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| K2E EVM                    |                             |                          | ``k2e_evm_defconfig``                        | ``k2e_evm_defconfig``    |                          |                          |                                         | ``k2e_evm_defconfig``                    |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| K2G GP EVM                 | ``k2g_evm_defconfig``       |                          |                                              | ``k2g_evm_defconfig``    | ``k2g_evm_defconfig``    |                          |                                         | ``k2g_evm_defconfig``                    |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| K2G ICE                    | ``k2g_evm_defconfig``       |                          |                                              |                          |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+| OMAP-L138 LCDK             | ``omapl138_lcdk_defconfig`` |                          | ``omapl138_lcdk_defconfig``                  |                          |                          |                          |                                         |                                          |
++----------------------------+-----------------------------+--------------------------+----------------------------------------------+--------------------------+--------------------------+--------------------------+-----------------------------------------+------------------------------------------+
+
+.. ifconfig:: CONFIG_part_variant in ('AM335X')
+
+   Then (Use ``am335x_evm`` and 'AM335x GP EVM' in this example):
+
+   .. code-block:: console
+
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am335x_evm am335x_evm_defconfig
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am335x_evm
+
+.. ifconfig:: CONFIG_part_variant in ('AM437X')
+
+   Then (Use ``am43xx_evm`` and 'AM437x GP EVM' in this example):
+
+   .. code-block:: console
+
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am43xx_evm am43xx_evm_defconfig
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am43xx_evm
+
+.. ifconfig:: CONFIG_part_variant in ('AM57X')
+
+   Then (Use ``am57xx_evm`` and 'AM57x GP EVM' in this example):
+
+   .. code-block:: console
+
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am57xx_evm am57xx_evm_defconfig
+      $ make CROSS_COMPILE=arm-none-linux-gnueabihf- O=am57xx_evm
+
+.. note::
+
+   Not all possible build targets for a given platform are listed
+   here as the community has additional build targets that are not
+   supported by TI. To find these read the :file:`boards.cfg` file and look for
+   the build target listed above. And please note that the main config file
+   will leverage other files under :file:`include/configs`, as seen by #include
+   statements.

--- a/source/linux/Foundational_Components/U-Boot/BG-Environment-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Environment-K3.rst
@@ -1,0 +1,100 @@
+.. _u-boot-build-guide-environment-k3:
+
+###########
+Environment
+###########
+
+******************
+U-Boot Environment
+******************
+
+.. note::
+
+   SDK 9.0 will not default to the environments that are saved on the boards,
+   It will default to the ones that are given with the particular uboot in
+   the release.
+
+By default the SDK builds will have the default environments whenever being
+run, to have some custom environments, one needs to rely on uEnv.txt
+file.
+
+The added benefit of using uEnv.txt is that it is more granular than the
+saveenv counterpart as we can choose to store the variables that are
+actually being set during the development workflow.
+
+**Writing to MMC/EMMC**
+
+.. code-block:: console
+
+  => env export -t $loadaddr <list of variables>
+  => fatwrite mmc ${mmcdev} ${loadaddr} ${bootenvfile} ${filesize}
+
+The following will update the uEnv.txt file on the bootmedia and then
+whenever "run envboot" is run on the board, uEnv.txt will be read based on
+mmcdev value to be read either from emmc/sd card.
+
+You can specifically choose the variables that you are changing in your
+development process so that the other variables are not affected due to the
+whole environment being saved. Optionally, one can save the full
+environment too in uEnv.txt by not specifying <list of variables> this
+will have some issues with the ethernet mac addresses not being overridden
+but other things will be set.
+
+**Reading from MMC/EMMC**
+
+By default run envboot will read it from the MMC/EMMC partition ( based on
+mmcdev) and set the environments.
+
+If manually needs to be done then the environment can be read from the
+filesystem and then imported
+
+.. code-block:: console
+
+  => fatload mmc ${mmcdev} ${loadaddr} ${bootenvfile}
+  => env import -t ${loadaddr} ${filesize}
+
+For production environments if one needs to rely on saveenv counterpart
+then they can always refer to the `commit <https://source.denx.de/u-boot/u-boot/-/commit/a5e8678e0a32f85ad012aea7641e9534ada5c0fe>`__
+
+.. rubric:: Networking Environment
+   :name: networking-environment
+
+When using a USB-Ethernet dongle a valid MAC address must be set in the
+environment. To create a valid address please read `**this
+page** <https://github.com/u-boot/u-boot/blob/v2024.04/doc/README.usb#L208>`__.
+Then issue the following command:
+
+.. code-block:: console
+
+   => setenv usbethaddr value:from:link:above
+
+You can use the **printenv** command to see if **usbethaddr** is already
+set.
+
+Then start the USB subsystem:
+
+.. code-block:: console
+
+   => usb start
+
+The default behavior of U-Boot is to utilize all information that a DHCP
+server passes to us when the user issues the **dhcp** command. This will
+include the dhcp parameter *next-server* which indicates where to fetch
+files from via TFTP. There may be times however where the dhcp server on
+your network provides incorrect information and you are unable to modify
+the server. In this case the following steps can be helpful:
+
+.. code-block:: console
+
+   => setenv autoload no
+   => dhcp
+   => setenv serverip correct.server.ip
+   => tftp
+
+Another alternative is to utilize the full syntax of the tftp command:
+
+.. code-block:: console
+
+   => setenv autoload no
+   => dhcp
+   => tftp ${loadaddr} server.ip:fileName

--- a/source/linux/Foundational_Components/U-Boot/BG-Environment-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Environment-OMAP.rst
@@ -1,0 +1,100 @@
+.. _u-boot-build-guide-environment-omap:
+
+###########
+Environment
+###########
+
+******************
+U-Boot Environment
+******************
+
+.. note::
+
+   SDK 9.0 will not default to the environments that are saved on the boards,
+   It will default to the ones that are given with the particular uboot in
+   the release.
+
+By default the SDK builds will have the default environments whenever being
+run, to have some custom environments, one needs to rely on uEnv.txt
+file.
+
+The added benefit of using uEnv.txt is that it is more granular than the
+saveenv counterpart as we can choose to store the variables that are
+actually being set during the development workflow.
+
+**Writing to MMC/EMMC**
+
+.. code-block:: console
+
+  => env export -t $loadaddr <list of variables>
+  => fatwrite mmc ${mmcdev} ${loadaddr} ${bootenvfile} ${filesize}
+
+The following will update the uEnv.txt file on the bootmedia and then
+whenever "run envboot" is run on the board, uEnv.txt will be read based on
+mmcdev value to be read either from emmc/sd card.
+
+You can specifically choose the variables that you are changing in your
+development process so that the other variables are not affected due to the
+whole environment being saved. Optionally, one can save the full
+environment too in uEnv.txt by not specifying <list of variables> this
+will have some issues with the ethernet mac addresses not being overridden
+but other things will be set.
+
+**Reading from MMC/EMMC**
+
+By default run envboot will read it from the MMC/EMMC partition ( based on
+mmcdev) and set the environments.
+
+If manually needs to be done then the environment can be read from the
+filesystem and then imported
+
+.. code-block:: console
+
+  => fatload mmc ${mmcdev} ${loadaddr} ${bootenvfile}
+  => env import -t ${loadaddr} ${filesize}
+
+For production environments if one needs to rely on saveenv counterpart
+then they can always refer to the `commit <https://source.denx.de/u-boot/u-boot/-/commit/a5e8678e0a32f85ad012aea7641e9534ada5c0fe>`__
+
+.. rubric:: Networking Environment
+   :name: networking-environment
+
+When using a USB-Ethernet dongle a valid MAC address must be set in the
+environment. To create a valid address please read `**this
+page** <https://github.com/u-boot/u-boot/blob/v2024.04/doc/README.usb#L208>`__.
+Then issue the following command:
+
+.. code-block:: console
+
+   => setenv usbethaddr value:from:link:above
+
+You can use the **printenv** command to see if **usbethaddr** is already
+set.
+
+Then start the USB subsystem:
+
+.. code-block:: console
+
+   => usb start
+
+The default behavior of U-Boot is to utilize all information that a DHCP
+server passes to us when the user issues the **dhcp** command. This will
+include the dhcp parameter *next-server* which indicates where to fetch
+files from via TFTP. There may be times however where the dhcp server on
+your network provides incorrect information and you are unable to modify
+the server. In this case the following steps can be helpful:
+
+.. code-block:: console
+
+   => setenv autoload no
+   => dhcp
+   => setenv serverip correct.server.ip
+   => tftp
+
+Another alternative is to utilize the full syntax of the tftp command:
+
+.. code-block:: console
+
+   => setenv autoload no
+   => dhcp
+   => tftp ${loadaddr} server.ip:fileName

--- a/source/linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-K3.rst
@@ -1,0 +1,280 @@
+.. _u-boot-build-guide-ram-device-trees-k3:
+
+####################
+RAM and Device Trees
+####################
+
+********************************
+Available RAM for image download
+********************************
+
+To know the amount of RAM available for downloading images or for other
+usage, use ``bdinfo`` command.
+
+.. code-block:: console
+
+   => bdinfo
+   arch_number = 0x00000000
+   boot_params = 0x80000100
+   DRAM bank   = 0x00000000
+   -> start    = 0x80000000
+   -> size     = 0x7F000000
+   baudrate    = 115200 bps
+   TLB addr    = 0xFEFF0000
+   relocaddr   = 0xFEF30000
+   reloc off   = 0x7E730000
+   irq_sp      = 0xFCEF8880
+   sp start    = 0xFCEF8870
+   Early malloc usage: 890 / 2000
+
+After booting, U-Boot relocates itself (along with its various reserved
+RAM areas) and places itself at end of available RAM (starting at
+``relocaddr`` in ``bdinfo`` output above). Only the stack is located
+just before that area. The address of top of the stack is in
+``sp start`` in ``bdinfo`` output and it grows downwards. Users should
+reserve at least about 1MB for stack, so in the example output above,
+RAM in the range of ``[0x80000000, 0xFCE00000]`` is safely available for
+use.
+
+************
+Device Trees
+************
+
+A note about device trees. Now all supported boards are required to use a
+device tree to boot. To facilitate this in supported platforms, a command
+in U-Boot environment **findfdt** is available that will set the **fdtfile**
+variable to the name of the device tree to use, as found with the kernel
+sources. In the Keystone-2 family devices (K2H/K/E/L/G), it is specified
+by **name\_fdt** variable for each platform. The device tree is expected
+to be loaded from the same media as the kernel, and from the same relative path.
+
+.. _AM64-SRAM-Layout-label:
+
+**************************************************
+SRAM memory Layout during initial bootloader stage
+**************************************************
+
+The SRAM memory layout explains the memory used for Bootloader's operation.
+
+   .. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+      .. code-block:: text
+
+         ┌──────────────────────────────────────┐0x70000000
+         │                                      │
+         │                                      │
+         │                                      │
+         │    SPL IMAGE (Max size 1.5 MB)       │
+         │                                      │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤0x7017FFFF
+         │                                      │
+         │           SPL STACK                  │
+         │                                      │
+         ├──────────────────────────────────────┤0x70192727
+         │          GLOBAL DATA(216 B)          │
+         ├──────────────────────────────────────┤0x701927FF
+         │                                      │
+         │       INITIAL HEAP (32 KB)           │
+         │                                      │
+         ├──────────────────────────────────────┤0x7019A7FF
+         │                                      │
+         │          BSS  (20 KB)                │
+         ├──────────────────────────────────────┤0x7019F7FF
+         │         EEPROM DATA (2 KB)           │
+         ├──────────────────────────────────────┤0x7019FFFF
+         │                                      │
+         │                                      │
+         │     UNALLOCATED AREA (123 KB)        │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤0x701BEBFB
+         │   BOOT PARAMETER INDEX TABLE (5124 B)│
+         ├──────────────────────────────────────┤0x701BFFFF
+         │                                      │
+         │             TF-A (128 KB)            │
+         │                                      │
+         ├──────────────────────────────────────┤0x701DFFFF
+         │                                      │
+         │      DMSC CODE AREA (128 KB)         │
+         │                                      │
+         └──────────────────────────────────────┘0x701FFFFF
+
+      - In the last 128 KB of memory used by DMSC during run time, initial 80 KB
+         gets freed after a security handover happens. The last 48 KB still will be used by DMSC.
+      - For more details on Security handover see `here <https://software-dl.ti.com/tisci/esd/latest/6_topic_user_guides/security_handover.html>`__ .
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+      .. code-block:: text
+
+         ┌──────────────────────────────────────┐0x43c00000
+         │                                      │
+         │                                      │
+         │               SPL IMAGE              │
+         │           (Max size 192 KB)          │
+         │            (excluding BSS)           │
+         │             (196608B  Max)           │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c30000
+         │                                      │
+         │                                      │
+         │            STACK (13568B Max)        │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤
+         │         Global Data (428B Max)       │
+         ├──────────────────────────────────────┤
+         │                                      │
+         │            HEAP (28KB Max)           │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3a7f0
+         │                                      │
+         │             EMPTY (16B)              │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3a800
+         │                                      │
+         │                                      │
+         │         DM config data (2KB)         │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3b000
+         │                                      │
+         │             BSS (12KB)               │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3e000
+         │                                      │
+         │                                      │
+         │           EMPTY (4.5KB)              │
+         │        (Reserved for ROM)            │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3f1e0
+         │                                      │
+         │       ROM Boot parameter table       │
+         │    + Extended boot info (3.5 KB)     │
+         │                                      │
+         └──────────────────────────────────────┘0x43c3ffff
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62AX','AM62PX')
+
+      .. code-block:: console
+
+         ┌──────────────────────────────────────┐0x43c00000
+         │                                      │
+         │                                      │
+         │               SPL IMAGE              │
+         │           (Max size 188 KB)          │
+         │            (excluding BSS)           │
+         │             (192512B  Max)           │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c2f000
+         │                                      │
+         │                                      │
+         │            STACK (17KB Max)          │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤
+         │         Global Data (428B Max)       │
+         ├──────────────────────────────────────┤
+         │                                      │
+         │            HEAP (28997B Max)         │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3a7f0
+         │                                      │
+         │             EMPTY (16B)              │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3a800
+         │                                      │
+         │                                      │
+         │         DM config data (2KB)         │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3b000
+         │                                      │
+         │             BSS (12KB)               │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3e000
+         │                                      │
+         │                                      │
+         │           EMPTY (4.5KB)              │
+         │        (Reserved for ROM)            │
+         │                                      │
+         ├──────────────────────────────────────┤0x43c3f1e0
+         │                                      │
+         │       ROM Boot parameter table       │
+         │    + Extended boot info (3.5 KB)     │
+         │                                      │
+         └──────────────────────────────────────┘0x43c3ffff
+
+   .. ifconfig:: CONFIG_part_variant in ('J722S')
+
+      .. code-block:: console
+
+         ┌──────────────────────────────────────┐0x43c00000
+         │                                      │
+         │                                      │
+         │               SPL IMAGE              │
+         │            (excluding BSS)           │
+         │            (0x6ce00 B  Max)          │
+         │                                      │
+         ├──────────────────────────────────────┤0x43C6CE00
+         │              EMPTY (0x50 B)          │
+         │                                      │
+         ├──────────────────────────────────────┤0x43C6CE50
+         │                                      │
+         │                                      │
+         │          STACK (0x5000 B Max)        │
+         │                                      │
+         │                                      │
+         ├──────────────────────────────────────┤0x43C71E50
+         │       Global Data (0x1AC B Max)      │
+         │                 (+0x4)               │
+         │                                      │
+         ├──────────────────────────────────────┤0x43C72000
+         │                                      │
+         │            HEAP (0x9000 B Max)       │
+         |                                      |
+         ├──────────────────────────────────────┤0x43C7B000
+         │                                      │
+         │            SPL BSS (0x3000 B)        │
+         │                                      │
+         ├──────────────────────────────────────┤0x43C7E000
+         │                                      │
+         │       ROM Boot parameter table       │
+         │    + Extended boot info (3.5 KB)     │
+         │                                      │
+         └──────────────────────────────────────┘0x43C7F290
+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+      .. code-block:: text
+
+         ┌────────────────────┐ 0x7081_8000         ┬
+         │   Debug Buffers    │                     │
+         ├────────────────────┤ 0x7081_6000         │
+         │  TIFS ->  A53 IPC  │                     │
+         ├────────────────────┤ 0x7081_5000         │
+         │  A53  -> TIFS IPC  │                     │
+         ├────────────────────┤ 0x7081_4000         │
+         │                    │                     │
+         │    *Free Space*    │                     │
+         │                    │                     │
+         ├────────────────────┤ 0x7081_0000  ┬      │
+         │ Translation Table  │              │      │
+         ├────────────────────┤ 0x7080_D000  │      │
+         │        BSS         │              │      │  MSRAM (96k)
+         ├────────────────────┤ 0x7080_B9C0  │      │
+         │       Stack        │              │      │
+         ├────────────────────┤ 0x7080_B1C0  │ BL-1 │
+         │        Data        │              │      │
+         ├────────────────────┤ 0x7080_B000  │      │
+         │      RO-Data       │              │      │
+         ├────────────────────┤ 0x7080_6000  │      │
+         │        Code        │              │      │
+         ├────────────────────┤ 0x7080_0000  ┘     ─┤
+         │                    │                     │
+         │      ROM Data      │                     │ PSRAM (64k)
+         │                    │                     │
+         └────────────────────┘ 0x707F_0000         ┴

--- a/source/linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Ram-Device-Trees-OMAP.rst
@@ -1,0 +1,49 @@
+.. _u-boot-build-guide-ram-device-trees-omap:
+
+####################
+RAM and Device Trees
+####################
+
+********************************
+Available RAM for image download
+********************************
+
+To know the amount of RAM available for downloading images or for other
+usage, use ``bdinfo`` command.
+
+.. code-block:: console
+
+   => bdinfo
+   arch_number = 0x00000000
+   boot_params = 0x80000100
+   DRAM bank   = 0x00000000
+   -> start    = 0x80000000
+   -> size     = 0x7F000000
+   baudrate    = 115200 bps
+   TLB addr    = 0xFEFF0000
+   relocaddr   = 0xFEF30000
+   reloc off   = 0x7E730000
+   irq_sp      = 0xFCEF8880
+   sp start    = 0xFCEF8870
+   Early malloc usage: 890 / 2000
+
+After booting, U-Boot relocates itself (along with its various reserved
+RAM areas) and places itself at end of available RAM (starting at
+``relocaddr`` in ``bdinfo`` output above). Only the stack is located
+just before that area. The address of top of the stack is in
+``sp start`` in ``bdinfo`` output and it grows downwards. Users should
+reserve at least about 1MB for stack, so in the example output above,
+RAM in the range of ``[0x80000000, 0xFCE00000]`` is safely available for
+use.
+
+************
+Device Trees
+************
+
+A note about device trees. Now all supported boards are required to use a
+device tree to boot. To facilitate this in supported platforms, a command
+in U-Boot environment **findfdt** is available that will set the **fdtfile**
+variable to the name of the device tree to use, as found with the kernel
+sources. In the Keystone-2 family devices (K2H/K/E/L/G), it is specified
+by **name\_fdt** variable for each platform. The device tree is expected
+to be loaded from the same media as the kernel, and from the same relative path.

--- a/source/linux/Foundational_Components/U-Boot/BG-Setup-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Setup-K3.rst
@@ -1,0 +1,66 @@
+.. _u-boot-build-guide-setup-k3:
+
+#####
+Setup
+#####
+
+*************************
+Install host dependencies
+*************************
+
+To install host dependencies for building TI U-boot source (standalone)
+on Ubuntu 22.04+, run the following command in the terminal prompt:
+
+.. code-block:: console
+
+   sudo apt install git xz-utils build-essential autoconf flex bison libssl-dev bc libncurses-dev \
+   python3 python3-setuptools python3-dev python3-yaml python3-jsonschema python3-pyelftools \
+   swig yamllint libgnutls28-dev
+
+.. note::
+
+   The recommended host machine for building U-Boot is Ubuntu 22.04.
+   Users of Ubuntu 18.04 may need to install Python 3.7 or higher. If using the default Python 3.6
+   that comes with Ubuntu 18.04, users may need to install these additional dependencies:
+
+   .. code-block:: console
+
+      pip install dataclasses pyelftools jsonschema yamllint importlib-resources
+
+.. _Getting the U-Boot Source Code-label:
+
+***********************
+Getting the Source Code
+***********************
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. note::
+
+      AM62L devices use TF-A BL-1 boot loader to configure LPDDR4 to
+      enable secondary program loader.
+
+The easiest way to get access to the source code is by
+downloading and installing the Processor SDK Linux. Once installed,
+the source code is included in the SDK at the path :file:`<path to tisdk>/board-support`.
+For your convenience the sources also includes
+git repositories including commit history.
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   Alternatively, BL-1 and U-Boot sources can directly be fetched from GIT. The GIT
+   repo URL, branch and commit id can be found in the release notes:
+
+   - ti-u-boot version: :ref:`u-boot-release-notes`
+   - ti-linux-firmware version: :ref:`ti-linux-fw-release-notes`
+   - TF-A version: :ref:`tf-a-release-notes`
+
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
+
+   Alternatively, U-Boot sources can directly be fetched from GIT. The GIT
+   repo URL, branch and commit id can be found in the release notes:
+
+   - ti-u-boot version: :ref:`u-boot-release-notes`
+   - ti-linux-firmware version: :ref:`ti-linux-fw-release-notes`
+   - TF-A version: :ref:`tf-a-release-notes`
+   - OP-TEE version: :ref:`optee-release-notes`

--- a/source/linux/Foundational_Components/U-Boot/BG-Setup-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Setup-OMAP.rst
@@ -1,0 +1,49 @@
+.. _u-boot-build-guide-setup-omap:
+
+#####
+Setup
+#####
+
+*************************
+Install host dependencies
+*************************
+
+.. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X')
+
+   To install host dependencies for building TI U-boot source (standalone)
+   on Ubuntu 22.04+, run the following command in the terminal prompt:
+
+   .. code-block:: console
+
+      sudo apt install git xz-utils build-essential autoconf flex bison libssl-dev bc libncurses-dev \
+      python3 python3-setuptools python3-dev python3-yaml python3-jsonschema python3-pyelftools \
+      swig yamllint libgnutls28-dev
+
+.. note::
+
+   The recommended host machine for building U-Boot is Ubuntu 22.04.
+   Users of Ubuntu 18.04 may need to install Python 3.7 or higher. If using the default Python 3.6
+   that comes with Ubuntu 18.04, users may need to install these additional dependencies:
+
+   .. code-block:: console
+
+      pip install dataclasses pyelftools jsonschema yamllint importlib-resources
+
+.. _Getting the U-Boot Source Code-label:
+
+***********************
+Getting the Source Code
+***********************
+
+The easiest way to get access to the source code is by
+downloading and installing the Processor SDK Linux. Once installed,
+the source code is included in the SDK at the path :file:`<path to tisdk>/board-support`.
+For your convenience the sources also includes
+git repositories including commit history.
+
+Alternatively, U-Boot sources can directly be fetched from GIT. The GIT
+repo URL, branch and commit id can be found in the release notes:
+
+- ti-u-boot version: :ref:`u-boot-release-notes`
+
+

--- a/source/linux/Foundational_Components/U-Boot/BG-Target-Images-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Target-Images-K3.rst
@@ -1,0 +1,579 @@
+.. _u-boot-build-guide-target-images-k3:
+
+#############
+Target Images
+#############
+
+******
+Images
+******
+
+.. ifconfig:: CONFIG_part_variant in ('AM65X', 'J721E', 'J7200', 'AM64X', 'AM62X', 'AM62AX', 'AM62LX', 'AM62PX', 'J721S2', 'J784S4','J742S2', 'J722S')
+
+   Copy the below images to the boot partition of an SD card and boot.
+   Instructions to format the SD card can be found :ref:`here <processor-sdk-linux-create-sd-card>`.
+
+.. ifconfig:: CONFIG_part_variant in ('AM65X')
+
+   * GP
+
+      * :file:`tiboot3-am65x_sr2-gp-evm.bin` and :file:`sysfw-am65x_sr2-gp-evm.itb` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a53`
+
+   * HS
+
+      * :file:`tiboot3-am65x_sr2-hs-evm.bin` and :file:`sysfw-am65x_sr2-hs-evm.itb` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('J721E')
+
+   * GP
+
+      * :file:`tiboot3-j721e-gp-evm.bin` and :file:`sysfw-j721e-gp-evm.itb` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a72`
+
+   * HS-FS
+
+      * :file:`tiboot3-j721e_sr2-hs-fs-evm.bin` and :file:`sysfw-j721e_sr2-hs-fs-evm.itb` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+   * HS-SE
+
+      * :file:`tiboot3-j721e_sr2-hs-evm.bin` and :file:`sysfw-j721e_sr2-hs-evm.itb` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+.. ifconfig:: CONFIG_part_variant in ('J7200')
+
+   * GP
+
+      * :file:`tiboot3-j7200-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a72`
+
+   * HS-FS
+
+      * :file:`tiboot3-j7200_sr2-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+   * HS-SE
+
+      * :file:`tiboot3-j7200_sr2-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+.. ifconfig:: CONFIG_part_variant in ('J721S2')
+
+   * GP
+
+      * :file:`tiboot3-j721s2-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a72`
+
+   * HS-FS
+
+      * :file:`tiboot3-j721s2-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+   * HS-SE
+
+      * :file:`tiboot3-j721s2-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+.. ifconfig:: CONFIG_part_variant in ('J784S4')
+
+   * GP
+
+      * :file:`tiboot3-j784s4-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a72`
+
+   * HS-FS
+
+      * :file:`tiboot3-j784s4-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+   * HS-SE
+
+      * :file:`tiboot3-j784s4-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+.. ifconfig:: CONFIG_part_variant in ('J742S2')
+
+   * GP
+
+      * :file:`tiboot3-j742s2-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a72`
+
+   * HS-FS
+
+      * :file:`tiboot3-j742s2-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+   * HS-SE
+
+      * :file:`tiboot3-j742s2-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a72`
+
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+   * GP
+
+      * :file:`tiboot3-am64x-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a53`
+
+   * HS-FS
+
+      * :file:`tiboot3-am64x_sr2-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+   * HS-SE
+
+      * :file:`tiboot3-am64x_sr2-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('AM62X')
+
+   * GP
+
+      * :file:`tiboot3-am62x-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a53`
+
+   * HS-FS
+
+      * :file:`tiboot3-am62x-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+   * HS-SE
+
+      * :file:`tiboot3-am62x-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('AM62AX')
+
+   * GP
+
+      * :file:`tiboot3-am62ax-gp-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin_unsigned` and :file:`u-boot.img_unsigned` from :file:`<output directory>/a53`
+
+   * HS-FS
+
+      * :file:`tiboot3-am62ax-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+   * HS-SE
+
+      * :file:`tiboot3-am62ax-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('AM62PX')
+
+   * HS-FS
+
+      * :file:`tiboot3-am62px-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+   * HS-SE
+
+      * :file:`tiboot3-am62px-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('J722S')
+
+   * HS-FS
+
+      * :file:`tiboot3-j722s-hs-fs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+   * HS-SE
+
+      * :file:`tiboot3-j722s-hs-evm.bin` from :file:`<output directory>/r5`
+      * :file:`tispl.bin` and :file:`u-boot.img` from :file:`<output directory>/a53`
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   * **HS-FS**
+
+      * :file:`tiboot3-am62lx-hs-fs-evm.bin`
+      * :file:`tispl.bin`
+      * :file:`u-boot.img`
+
+.. ifconfig:: CONFIG_part_variant in ('AM65X', 'J721E', 'J7200', 'AM64X', 'AM62X', 'AM62AX', 'AM62PX', 'J721S2', 'J784S4','J742S2', 'J722S', 'AM62LX')
+
+   .. warning::
+
+      Rename :file:`tiboot3-<board>-evm.bin` to :file:`tiboot3.bin` in order for the device to load this binary from the SD card boot partition.
+      Also, (For GP devices only) rename :file:`tispl.bin_unsigned` to :file:`tispl.bin` and :file:`u-boot.img_unsigned` to :file:`u-boot.img` as well.
+
+*************
+Image Formats
+*************
+
+   .. ifconfig:: CONFIG_part_variant not in ('J7200', 'AM64X', 'J721S2', 'J721E', 'AM62X', 'AM62AX', 'AM62LX', 'J784S4','J742S2', 'J722S')
+
+      - tiboot3.bin
+
+      .. code-block:: text
+
+         +-----------------------+
+         |        X.509          |
+         |      Certificate      |
+         | +-------------------+ |
+         | |                   | |
+         | |        R5         | |
+         | |   u-boot-spl.bin  | |
+         | |                   | |
+         | +-------------------+ |
+         | |                   | |
+         | |     FIT header    | |
+         | | +---------------+ | |
+         | | |               | | |
+         | | |   DTB 1...N   | | |
+         | | +---------------+ | |
+         | +-------------------+ |
+         +-----------------------+
+
+      - tispl.bin
+
+      .. code-block:: text
+
+         +-----------------------+
+         |                       |
+         |       FIT HEADER      |
+         | +-------------------+ |
+         | |                   | |
+         | |      ARM64 ATF    | |
+         | +-------------------+ |
+         | |                   | |
+         | |     ARM64 OPTEE   | |
+         | +-------------------+ |
+         | |                   | |
+         | |      ARM64 SPL    | |
+         | +-------------------+ |
+         | |                   | |
+         | |   SPL DTB 1...N   | |
+         | +-------------------+ |
+         +-----------------------+
+
+      - sysfw.itb
+
+      .. code-block:: text
+
+         +-----------------------+
+         |                       |
+         |       FIT HEADER      |
+         | +-------------------+ |
+         | |                   | |
+         | |     sysfw.bin     | |
+         | +-------------------+ |
+         | |                   | |
+         | |    board config   | |
+         | +-------------------+ |
+         | |                   | |
+         | |     PM config     | |
+         | +-------------------+ |
+         | |                   | |
+         | |     RM config     | |
+         | +-------------------+ |
+         | |                   | |
+         | |    Secure config  | |
+         | +-------------------+ |
+         +-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('J721E')
+
+      - tiboot3.bin
+
+      .. code-block:: text
+
+         +-----------------------+
+         |        X.509          |
+         |      Certificate      |
+         | +-------------------+ |
+         | |                   | |
+         | |        R5         | |
+         | |   u-boot-spl.bin  | |
+         | |                   | |
+         | +-------------------+ |
+         | |                   | |
+         | |     FIT header    | |
+         | | +---------------+ | |
+         | | |               | | |
+         | | |   DTB 1...N   | | |
+         | | +---------------+ | |
+         | +-------------------+ |
+         +-----------------------+
+
+      - tispl.bin
+
+      .. code-block:: text
+
+         +-----------------------+
+         |                       |
+         |       FIT HEADER      |
+         | +-------------------+ |
+         | |                   | |
+         | |      A72 ATF      | |
+         | +-------------------+ |
+         | |                   | |
+         | |     A72 OPTEE     | |
+         | +-------------------+ |
+         | |                   | |
+         | |      R5 DM FW     | |
+         | +-------------------+ |
+         | |                   | |
+         | |      A72 SPL      | |
+         | +-------------------+ |
+         | |                   | |
+         | |   SPL DTB 1...N   | |
+         | +-------------------+ |
+         +-----------------------+
+
+      - sysfw.itb
+
+      .. code-block:: text
+
+         +-----------------------+
+         |                       |
+         |       FIT HEADER      |
+         | +-------------------+ |
+         | |                   | |
+         | |     sysfw.bin     | |
+         | +-------------------+ |
+         | |                   | |
+         | |    board config   | |
+         | +-------------------+ |
+         | |                   | |
+         | |     PM config     | |
+         | +-------------------+ |
+         | |                   | |
+         | |     RM config     | |
+         | +-------------------+ |
+         | |                   | |
+         | |    Secure config  | |
+         | +-------------------+ |
+         +-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('J7200', 'J721S2', 'J784S4','J742S2')
+
+      - tiboot3.bin:
+
+         .. code-block:: text
+
+                  +-----------------------+
+                  |        X.509          |
+                  |      Certificate      |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |        R5         | |
+                  | |   u-boot-spl.bin  | |
+                  | |                   | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |     FIT header    | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   DTB 1...N   | | |
+                  | | +---------------+ | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      FIT HEADER   | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   sysfw.bin   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |  board config | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   PM config   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   RM config   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | | Secure config | | |
+                  | | +---------------+ | |
+                  | +-------------------+ |
+                  +-----------------------+
+
+      - tispl.bin
+
+         .. code-block:: text
+
+                  +-----------------------+
+                  |                       |
+                  |       FIT HEADER      |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      A72 ATF      | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |     A72 OPTEE     | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      R5 DM FW     | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      A72 SPL      | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |   SPL DTB 1...N   | |
+                  | +-------------------+ |
+                  +-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+      - tiboot3.bin:
+
+         .. code-block:: text
+
+                  +-----------------------+
+                  |        X.509          |
+                  |      Certificate      |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |        R5         | |
+                  | |   u-boot-spl.bin  | |
+                  | |                   | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |     FIT header    | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   DTB 1...N   | | |
+                  | | +---------------+ | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      FIT HEADER   | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   sysfw.bin   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |  board config | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   PM config   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | |   RM config   | | |
+                  | | +---------------+ | |
+                  | | |               | | |
+                  | | | Secure config | | |
+                  | | +---------------+ | |
+                  | +-------------------+ |
+                  +-----------------------+
+
+      - tispl.bin
+
+         .. code-block:: text
+
+                  +-----------------------+
+                  |                       |
+                  |       FIT HEADER      |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      A53 ATF      | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |     A53 OPTEE     | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |      A53 SPL      | |
+                  | +-------------------+ |
+                  | |                   | |
+                  | |   SPL DTB 1...N   | |
+                  | +-------------------+ |
+                  +-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'J722S')
+
+      - tiboot3.bin:
+
+      .. code-block:: text
+
+         +-----------------------+
+         |        X.509          |
+         |      Certificate      |
+         | +-------------------+ |
+         | |                   | |
+         | |        R5         | |
+         | |   u-boot-spl.bin  | |
+         | |                   | |
+         | +-------------------+ |
+         | |                   | |
+         | |TIFS with board cfg| |
+         | |                   | |
+         | +-------------------+ |
+         | |                   | |
+         | |                   | |
+         | |     FIT header    | |
+         | | +---------------+ | |
+         | | |               | | |
+         | | |   DTB 1...N   | | |
+         | | +---------------+ | |
+         | +-------------------+ |
+         +-----------------------+
+
+      - tispl.bin
+
+      .. code-block:: text
+
+         +-----------------------+
+         |                       |
+         |       FIT HEADER      |
+         | +-------------------+ |
+         | |                   | |
+         | |      A53 ATF      | |
+         | +-------------------+ |
+         | |                   | |
+         | |     A53 OPTEE     | |
+         | +-------------------+ |
+         | |                   | |
+         | |      R5 DM FW     | |
+         | +-------------------+ |
+         | |                   | |
+         | |      A53 SPL      | |
+         | +-------------------+ |
+         | |                   | |
+         | |   SPL DTB 1...N   | |
+         | +-------------------+ |
+         +-----------------------+
+
+   .. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+      - tiboot3.bin
+
+      .. code-block:: text
+
+            TIBOOT3
+         ┌─────────────┐
+         │    X.509    │
+         │ Certificate │
+         │┌───────────┐│
+         ││   BL-1    ││
+         │├───────────┤│
+         ││   TIFS    ││
+         │├───────────┤│
+         ││ TIFS CERT ││
+         │└───────────┘│
+         └─────────────┘
+
+      - tispl.bin
+
+      .. code-block:: text
+
+            TISPL
+         ┌─────────────┐
+         │    X.509    │
+         │ Certificate │
+         │┌───────────┐│
+         ││   BL-31   ││
+         │├───────────┤│
+         ││   TIFS    ││
+         │├───────────┤│
+         ││ TIFS CERT ││
+         │├───────────┤│
+         ││ BRD + SEC ││
+         ││  CONFIGS  ││
+         │├───────────┤│
+         ││  U-BOOT   ││
+         ││    SPL    ││
+         │└───────────┘│
+         └─────────────┘

--- a/source/linux/Foundational_Components/U-Boot/BG-Target-Images-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Target-Images-OMAP.rst
@@ -1,0 +1,15 @@
+.. _u-boot-build-guide-target-images-omap:
+
+#############
+Target Images
+#############
+
+******
+Images
+******
+
+Copy the below images to the boot partition of an SD card and boot.
+Instructions to format the SD card can be found :ref:`here <processor-sdk-linux-create-sd-card>`.
+
+* :file:`MLO` from :file:`<output directory>`
+* :file:`u-boot.img` from :file:`<output directory>`

--- a/source/linux/Foundational_Components/U-Boot/Build-Guide-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/Build-Guide-K3.rst
@@ -1,0 +1,15 @@
+.. _u-boot-build-guide-k3:
+
+###########
+Build Guide
+###########
+
+.. toctree::
+   :maxdepth: 1
+
+   BG-Setup-K3
+   BG-Build-K3
+   BG-Target-Images-K3
+   BG-Bootflow-K3
+   BG-Environment-K3
+   BG-Ram-Device-Trees-K3

--- a/source/linux/Foundational_Components/U-Boot/Build-Guide-OMAP.rst
+++ b/source/linux/Foundational_Components/U-Boot/Build-Guide-OMAP.rst
@@ -1,0 +1,15 @@
+.. _u-boot-build-guide-omap:
+
+###########
+Build Guide
+###########
+
+.. toctree::
+   :maxdepth: 1
+
+   BG-Setup-OMAP
+   BG-Build-OMAP
+   BG-Target-Images-OMAP
+   BG-Bootflow-OMAP
+   BG-Environment-OMAP
+   BG-Ram-Device-Trees-OMAP

--- a/source/linux/Foundational_Components/U-Boot/Users-Guide.rst
+++ b/source/linux/Foundational_Components/U-Boot/Users-Guide.rst
@@ -6,31 +6,30 @@ User's Guide
 ############
 
 .. toctree::
-    :maxdepth: 1
+   :maxdepth: 1
 
-    UG-General-Info
-    UG-DFU
-    UG-Network
-    UG-Network-K3
-    UG-PCIeBoot
-    UG-NAND
-    UG-Memory-K3
-    UG-Memory-OMAP
-    UG-SPI
-    UG-QSPI
-    UG-NOR
-    UG-UART
-    UG-SATA
-    UG-UFS
-    UG-DDR3
-    UG-DDRSS
-    UG-DDRSS-J7
-    UG-HyperBus
-    UG-RemoteProc
-    UG-HSM
-    UG-AVS
-    UG-Thermal
-    UG-Splash-Screen
-    UG-Key-Writer-Lite
-    UG-Programming-OTPs
-    UG-Falcon-Mode
+   UG-DFU
+   UG-Network
+   UG-Network-K3
+   UG-PCIeBoot
+   UG-NAND
+   UG-Memory-K3
+   UG-Memory-OMAP
+   UG-SPI
+   UG-QSPI
+   UG-NOR
+   UG-UART
+   UG-SATA
+   UG-UFS
+   UG-DDR3
+   UG-DDRSS
+   UG-DDRSS-J7
+   UG-HyperBus
+   UG-RemoteProc
+   UG-HSM
+   UG-AVS
+   UG-Thermal
+   UG-Splash-Screen
+   UG-Key-Writer-Lite
+   UG-Programming-OTPs
+   UG-Falcon-Mode

--- a/source/linux/Foundational_Components_U-Boot.rst
+++ b/source/linux/Foundational_Components_U-Boot.rst
@@ -61,7 +61,9 @@ following platform(s):
 |
 
 .. toctree::
-    :maxdepth: 2
+   :maxdepth: 2
 
-    Foundational_Components/U-Boot/Users-Guide
-    Foundational_Components/U-Boot/Applications
+   Foundational_Components/U-Boot/Build-Guide-K3
+   Foundational_Components/U-Boot/Build-Guide-OMAP
+   Foundational_Components/U-Boot/Users-Guide
+   Foundational_Components/U-Boot/Applications

--- a/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
+++ b/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
@@ -140,7 +140,7 @@ Reducing bootloader time
 
         - `UART flashing tool AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/TOOLS_FLASH.html>`_
 
-        - `U-Boot eMMC flashing tool AM62X <https://software-dl.ti.com/processor-sdk-linux/esd/AM62X/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
+        - U-Boot eMMC flashing tool AM62X: :ref:`u-boot-build-guide-environment-k3`
 
         - `U-Boot SPI flashing tool AM62X <https://software-dl.ti.com/processor-sdk-linux/esd/AM62X/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-SPI.html#spi>`_
 
@@ -148,7 +148,7 @@ Reducing bootloader time
 
         - `UART flashing tool AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/11_01_00_16/exports/docs/api_guide_am62ax/TOOLS_FLASH.html>`_
 
-        - `U-Boot eMMC flashing tool AM62AX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/11_01_00_16/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
+        - U-Boot eMMC flashing tool AM62AX: :ref:`u-boot-build-guide-environment-k3`
 
         - `U-Boot SPI flashing tool AM62AX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/11_01_00_16/exports/docs/linux/Foundational_Components/U-Boot/UG-SPI.html#spi>`_
 
@@ -156,7 +156,7 @@ Reducing bootloader time
 
         - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
 
-        - `U-Boot eMMC flashing tool AM62PX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62PX/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#u-boot-environment>`_
+        - U-Boot eMMC flashing tool AM62PX: :ref:`u-boot-build-guide-environment-k3`
 
         - `U-Boot SPI flashing tool AM62PX <https://software-dl.ti.com/processor-sdk-linux/esd/AM62PX/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-SPI.html#spi>`_
 
@@ -680,7 +680,7 @@ Additional notes
 
         - SPL:
 
-            Rebuild `U-Boot <https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/latest/exports/docs/linux/Foundational_Components/U-Boot/UG-General-Info.html#build-u-boot>`_ with OSPI NOR support.
+            Rebuild :ref:`Build-U-Boot-label` with OSPI NOR support.
 
         - SBL:
 

--- a/source/linux/Release_Specific_CoreSDK_Release_Notes.rst
+++ b/source/linux/Release_Specific_CoreSDK_Release_Notes.rst
@@ -49,6 +49,7 @@ Released July 2025
   * Important Bug Fixes
       * Review Issue Tracker Section for the new fixes.
 
+.. _release-specific-build-information:
 
 Build Information
 =================

--- a/source/linux/Release_Specific_PLSDK_Release_Notes.rst
+++ b/source/linux/Release_Specific_PLSDK_Release_Notes.rst
@@ -107,6 +107,7 @@ See :ref:`release-specific-supported-platforms-and-versions` for a list of suppo
 
 |
 
+.. _release-specific-build-information:
 
 Build Information
 =====================================


### PR DESCRIPTION
Mostly cleanup and organization. Some content updated on OMAP. Turns large build guide into its own section under U-Boot, with 6 pages under the build guide. Give feedback if content needs more updating, and I will address in future PR.