### PR TITLE
feat(workflow): Add AM62DX in Github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
           - J722S
           - J742S2
           - J784S4
+          - AM62DX
         include:
           - os: android
             device: AM62PX


### PR DESCRIPTION
Add AM62DX device in the github workflow for CI/CD build of the processor-sdk-docs.