### PR TITLE
fix(edgeai): Drop unwanted references of GPU

### DIFF
--- a/configs/AM62AX/AM62AX_linux_config.txt
+++ b/configs/AM62AX/AM62AX_linux_config.txt
@@ -40,6 +40,5 @@ Configuration Values
 'CONFIG_image_type'       : 'edgeai'
 'CONFIG_icss_support'     : 'yes'
 'CONFIG_rt_linux_support' : 'yes'
-'CONFIG_gpu_ip'           : 'Rogue_AXE'
 'CONFIG_crypto'           : 'sa2ul'
 'CONFIG_mcrc64'           : 'mcrc64'

--- a/source/edgeai/sdk_components.rst
+++ b/source/edgeai/sdk_components.rst
@@ -103,10 +103,9 @@ Source code and documentation: `TI Edge AI TIOVX Apps <https://github.com/TexasI
 Foundation Linux
 ================
 The Edge AI app stack is built on top of foundation Linux components which
-includes, uBoot, Linux kernels, device drivers, multimedia codecs, GPU drivers
-and a lot more. The Foundation Linux is built using the Yocto project and sources
-publicly available to build the entire image completely from scratch. We also
-provide an installer, which packages pre-built Linux filesystem, board support
+includes, u-boot, Linux kernels, device drivers, multimedia codecs and many more.
+Developers use the Yocto project and publicly available sources to build Foundation Linux entirely from scratch.
+We also offer an installer, which packages pre-built Linux filesystem, board support
 package and tools to customize Linux layers of the software stack.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')


### PR DESCRIPTION
* AM62A SoC doesn't have a GPU. Hence, drop all references of term "GPU" from AM62A edgeai documentation.