### PR TITLE
feat(docker): add gnu tar for workflows

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
 		ripgrep \
 		shadow \
 		su-exec \
+		tar \
 		vale \
 		zip \
 	&& echo "**** create abc user and make our folders ****" \


### PR DESCRIPTION
Add GNU tar for our workflows since BusyBox tar doesn't support advanced command line parameters like hard-dereference.

Dependency for another feature.