### PR TITLE
docs(linux): AM62X: add release note for AM62SIP support

### DIFF
--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -46,6 +46,7 @@ What's new
 **Processor SDK Linux AM62X Release has following new features:**
 
   - Second 2025 LTS Reference Release Including RT combined branch model
+  - Add support for AM62SIP, which is an example of using AM62x with 512MiB of RAM
   - Falcon mode through R5 SPL :ref:`U-Boot Falcon Mode <U-Boot-Falcon-Mode>`
   - Important Bug Fixes on top of Processor SDK 11.00.09.04 Release
   - Review Issue Tracker Section for the new fixes.


### PR DESCRIPTION
The release 11.1 adds support for AM62SIP in a fashion that customers can take as an example for any 512MiB use case. Therefore add it to the change log.