### PR TITLE
feat(pm_cpuidle): Enabling and Utilizing AM62 Standby Mode

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -53,7 +53,7 @@ What's new
 
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here :ref:`RT Interrupt Latencies <RT-linux-performance>`
   - Support for streaming from OV2312 camera with `DS90UB954-Q1EVM <https://www.ti.com/tool/DS90UB954-Q1EVM>`_
-  - Power Management: :ref:`I/O Only Plus DDR <pm_io_only_plus_ddr>` mode
+  - How standby power mode works - :ref:`CPUIdle Documentation <cpuidle-guide>`
 
 **Component version:**
 

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -55,7 +55,7 @@ What's new
   - RT Kernel : Real-Time Linux Interrupt Latency numbers here - :ref:`RT Interrupt Latencies <RT-linux-performance>`
   - Support for streaming from multiple 0V5640 cameras with `Arducam V3Link (Fusion Mini) <https://www.arducam.com/product/arducam-v3link-camera-kit-for-ti-development-boards/>`_
   - TISCI: A53 hosts default priv_id value updated to 1 from 4 (to match all other SOCs)
-  - Power Management: :ref:`I/O Only Plus DDR <pm_io_only_plus_ddr>` mode
+  - How standby power mode works - :ref:`CPUIdle Documentation <cpuidle-guide>`
   - Out-of-Box TI Apps Launcher Application with Qt6 Framework - :ref:`TI Apps Launcher <TI-Apps-Launcher-User-Guide-label>`
   - Snagfactory Support - :ref:`Snagfactory Tool <Flash-via-Fastboot>`
   - Support for M2 CC33xx cards on Debian - `How to Enable M.2-CC33x1 in Linux <https://software-dl.ti.com/processor-sdk-linux/esd/AM62PX/10_01_10_04_Debian/exports/docs/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.html>`__

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -56,6 +56,7 @@ What's new
   - Snagfactory Support - :ref:`Snagfactory Tool <Flash-via-Fastboot>`
   - Support for M2 CC33xx cards on Debian - `How to Enable M.2-CC33x1 in Linux <https://software-dl.ti.com/processor-sdk-linux/esd/AM62X/10_01_10_04_Debian/exports/docs/linux/How_to_Guides/Target/How_To_Enable_M2CC3301_in_linux.html>`__
   - How to Enable PRU RPMsg - `Read FAQ <https://e2e.ti.com/support/processors-group/processors/f/791/t/1494495>`__
+  - How standby power mode works - :ref:`CPUIdle Documentation <cpuidle-guide>`
 
 **Component version:**
 

--- a/source/linux/Foundational_Components/Power_Management/pm_cpuidle.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_cpuidle.rst
@@ -1,3 +1,5 @@
+.. _cpuidle-guide:
+
 #######
 CPUIdle
 #######


### PR DESCRIPTION
Add comprehensive documentation for CPUIdle on AM62X, AM62AX, and AM62PX platforms explaining:

- Standby mode implementation through CPUIdle WFI state
- Integration between Linux CPUIdle framework and TF-A
- PSCI interaction via cpu_standby and validate_power_state hooks
- Source file references for both Linux and TF-A components
- Kernel configuration options and usage information

This documentation helps users understand that the TI "standby" mode is automatically handled by the CPUIdle framework without requiring special configuration.