### PR TITLE
chore(vale): disable red hat's merge conflict check

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,3 +9,4 @@ Vocab = PSDK
 BasedOnStyles = RedHat
 RedHat.PascalCamelCase = NO
 RedHat.GitLinks = NO
+RedHat.MergeConflictMarkers = NO


### PR DESCRIPTION
This check is rudimentary and incorrectly tags RST titles as merge conflict notes. As such it should be disabled until it's made aware of RST syntax.

Made in wake of reviewing #359 locally