### PR TITLE
feat: Add Software Buildsheets in processor-sdk-doc

### DIFF
--- a/configs/AM62DX/AM62DX_linux_toc.txt
+++ b/configs/AM62DX/AM62DX_linux_toc.txt
@@ -5,6 +5,7 @@ devices/AM62DX/linux/Overview/Download_and_Install_the_SDK
 linux/Overview/Run_Setup_Scripts
 devices/AM62DX/linux/Release_Specific
 devices/AM62DX/linux/Release_Specific_Release_Notes
+devices/AM62DX/linux/Release_Specific_Build_Sheet
 devices/AM62DX/linux/Release_Specific_Yocto_layer_Configuration
 devices/AM62DX/linux/Release_Specific_Migration_Guide
 devices/AM62DX/linux/Release_Specific_Kernel_Performance_Guide

--- a/configs/AM62PX/AM62PX_linux_toc.txt
+++ b/configs/AM62PX/AM62PX_linux_toc.txt
@@ -6,6 +6,7 @@ devices/AM62PX/linux/Overview/Download_and_Install_the_SDK
 linux/Overview/Run_Setup_Scripts
 devices/AM62PX/linux/Release_Specific
 devices/AM62PX/linux/Release_Specific_Release_Notes
+devices/AM62PX/linux/Release_Specific_Build_Sheet
 devices/AM62PX/linux/Release_Specific_Yocto_layer_Configuration
 devices/AM62PX/linux/Release_Specific_Migration_Guide
 devices/AM62PX/linux/Release_Specific_Kernel_Performance_Guide

--- a/configs/AM62X/AM62X_linux_toc.txt
+++ b/configs/AM62X/AM62X_linux_toc.txt
@@ -6,6 +6,7 @@ devices/AM62X/linux/Overview/Download_and_Install_the_SDK
 linux/Overview/Run_Setup_Scripts
 devices/AM62X/linux/Release_Specific
 devices/AM62X/linux/Release_Specific_Release_Notes
+devices/AM62X/linux/Release_Specific_Build_Sheet
 devices/AM62X/linux/Release_Specific_Yocto_layer_Configuration
 devices/AM62X/linux/Release_Specific_Migration_Guide
 devices/AM62X/linux/Release_Specific_Kernel_Performance_Guide

--- a/configs/AM64X/AM64X_linux_config.txt
+++ b/configs/AM64X/AM64X_linux_config.txt
@@ -17,7 +17,7 @@ Replacement Variables
 '__PART_FAMILY_DEVICE_NAMES__'   : 'AM64x'
 '__PRODUCT_LINE_NAME__'          : 'Sitara MPU'
 '__SDK_BUILD_MACHINE__'          : 'am64xx-evm'
-'__SDK_FULL_NAME__'              : 'Processor SDK'
+'__SDK_FULL_NAME__'              : 'Processor SDK AM64x'
 '__SDK_SHORT_NAME__'             : 'PSDK'
 '__SDK_INSTALL_FILE__'           : 'ti-processor-sdk-linux-am64xx-evm-<version>-Linux-x86-Install.bin'
 '__SDK_INSTALL_DIR__'            : 'ti-processor-sdk-linux-am64xx-evm-<version>'

--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -15,6 +15,7 @@ linux/Overview/GCC_ToolChain
 
 devices/AM64X/linux/Release_Specific
 devices/AM64X/linux/Release_Specific_Release_Notes
+devices/AM64X/linux/Release_Specific_Build_Sheet
 devices/AM64X/linux/Release_Specific_Yocto_layer_Configuration
 devices/AM64X/linux/Release_Specific_Migration_Guide
 devices/AM64X/linux/Release_Specific_Kernel_Performance_Guide

--- a/source/devices/AM62DX/linux/Release_Specific.rst
+++ b/source/devices/AM62DX/linux/Release_Specific.rst
@@ -5,6 +5,7 @@ Release Specific
 .. toctree::
    :maxdepth: 5
 
+   Release_Specific_Build_Sheet
    Release_Specific_Yocto_layer_Configuration
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide

--- a/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
@@ -1,0 +1,178 @@
+.. _build_sheet:
+
+====================
+Software Build Sheet
+====================
+
+Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
+The following table lists the supported features and modules for the corresponding category,
+along with the support status for Linux on A53, RTOS on MCU R5F, RTOS on WKUP R5, RTOS on A53, RTOS on C7X.
+
+The support status is indicated by the following codes:
+
+   - "Yes": The feature or module is supported.
+   - "No": The feature or module is not supported.
+   - "SDKx.y": The feature or module will be supported in a future version of the SDK.
+   - "NA": The feature or module is not applicable in the hardware.
+   - "ANY": The feature or module is a new update in this revision of the SDK.
+
+.. csv-table:: Software Build Sheet
+   :header: "Category", "Module", "SubModule", "RTOS on MCU R5F", "RTOS on WKUP R5", "RTOS on A53", "RTOS on C7X"
+   :widths: 20, 20, 20, 20, 20, 20, 20
+
+   System Interconnect,Bandwidth regulator,,No,No,No,No
+   ,CBASS auto-clock gating,,No,No,No,No
+   Initialization,I2C Bootloader Operation,,No,No,No,No
+   ,SPI Bootloader Operation,,No,No,No,No
+   ,QSPI Bootloader Operation,NOR,NA,No,NA,NA
+   ,,NAND,NA,No,NA,NA
+   ,OSPI Bootloader Operation,NOR,NA,Yes,NA,NA
+   ,,NAND (1-bit mode),NA,No,NA,NA
+   ,,NAND (8-bit mode),NA,No,NA,NA
+   ,GPMC Bootloader Operation,NOR,NA,No,NA,NA
+   ,,NAND,NA,No,NA,NA
+   ,Ethernet Bootloader Operation,,NA,No,NA,NA
+   ,USB Bootloader Operation,Host,NA,No,NA,NA
+   ,,Device,NA,No,NA,NA
+   ,MMCSD Bootloader Operation,SD Card (no UHS),NA,Yes,NA,NA
+   ,,eMMC,NA,Yes,NA,NA
+   ,UART Bootloader Operation,,NA,Yes,NA,NA
+   Device Configuration,Power Supply Modules,POK,No,No,No,No
+   ,,POR,No,No,No,No
+   ,,PRG,No,No,No,No
+   ,,PGD,No,No,No,No
+   ,,VTM,Yes,No,No,No
+   Power MaNAgement,Deep Sleep Low Power Mode  ,,NA,No,No,No
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,NA,No,No,No
+   ,,GT Timers,NA,No,No,No
+   ,,WKUP UART,NA,No,No,No
+   ,,I2C,NA,No,No,No
+   ,,MCU GPIO,NA,No,No,No
+   ,,I/O Daisy Chain,NA,No,No,No
+   ,,USB Connect/Disconnect,NA,No,No,No
+   ,,USB Remote Wakeup,NA,No,No,No
+   ,MCU-Only Low Power Mode,,NA,No,No,No
+   ,Standby Low Power Mode,,NA,No,No,No
+   ,Partial I/O Low Power Mode,,NA,No,No,No
+   ,IO + DDR low power mode,,NA,No,No,No
+   ,Boot-time OPP configurations,,No,No,No,No
+   ,Runtime Power MaNAgement,,NA,No,No,No
+   ,DFS/CPUFreq,,NA,No,No,No
+   ,CPUIdle (A53 WFI),,NA,No,No,No
+   ,CPUIdle (DDR in Self-Refresh),,NA,No,No,No
+   Interprocessor Communication,Mailbox,,Yes,Yes,Yes,Yes
+   ,Spinlock,,No,No,No,No
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,No,No,No,No
+   ,,LPDDR4,No,Yes,No,No
+   ,,Inline ECC (1bit err),No,Yes,No,No
+   ,,Inline ECC (mbit err),No,No,No,No
+   ,Region-based Address Translation,,Yes,Yes,NA,NA
+   Time Sync,Time Sync Module (CPTS),,No,No,No,No
+   ,Timer MaNAger,,No,No,No,No
+   ,Time Sync and Compare Events,,No,No,No,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,Yes,Yes
+   ,Peripheral DMA (PDMA),,No,No,No,No
+   ,RingAcc,,No,No,No,No
+   ,BCDMA,,Yes,Yes,Yes,Yes
+   ,DRU,,NA,NA,NA,Yes
+   ,Packet Streaming Interface Link,,No,No,No,No
+   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,NA,No,Yes,Yes
+   ,,Output,NA,No,Yes,Yes
+   ,,HDMI Output,NA,No,No,No
+   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
+   ,,Target,Yes,Yes,Yes,Yes
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,No,Yes,No
+   ,,Peripheral,Yes,No,Yes,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
+   ,,RS-485,NA,No,No,No
+   ,,IrDA,NA,No,No,No
+   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,Yes,Yes,Yes,No
+   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
+   ,,Target,No,No,No,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,No,No,No
+   ,,Peripheral,No,No,No,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
+   ,,RS-485,No,No,No,No
+   ,,IrDA,No,No,No,No
+   General Connectivity Peripherals (WKUP domain),Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,No
+   ,,Target,NA,No,No,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,NA,Yes,No,No
+   ,,RS-485,NA,No,No,No
+   ,,IrDA,NA,No,No,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,No,No,No,No
+   ,,EndPoint,No,No,No,No
+   ,,TSN,No,No,No,No
+   ,,TSN - VLAN,No,No,No,No
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,No,No,No,No
+   ,,Device 3.1,No,No,No,No
+   ,,Host 2.0,No,No,No,No
+   ,,Device 2.0,No,No,No,No
+   Memory Interfaces,Flash Subsystem (FSS),,No,No,No,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,No,No,No,No
+   ,,NAND,No,No,No,No
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,Yes,Yes,No
+   ,,NAND,No,No,No,No
+   ,Expanded Serial Peripheral Interface (xSPI),,No,No,No,No
+   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,No,No
+   ,,NAND,No,No,No,No
+   ,,NOR,No,No,No,No
+   ,,etc.,No,No,No,No
+   ,Error Location Module (ELM),,No,No,No,No
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,No,Yes,Yes,No
+   ,,eMMC,No,Yes,Yes,No
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,No,No,Yes,No
+   ,,CAN FD,No,No,Yes,No
+   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes,No,No,No
+   ,,CAN FD,Yes,No,No,No
+   ,Enhanced Capture (ECAP) Module,Capture,No,No,No,No
+   ,,PWM,No,No,Yes,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,No,No,Yes,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,No,No,Yes,No
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,NA,No,No,No
+   ,MIPI D-PHY Receiver (DPHY_RX),,NA,No,No,No
+   ,Multiple Camera,,NA,No,No,No
+   ,OV2312 RGB + IR sensor,,NA,No,No,No
+   ,iMX219 sensor,,NA,No,No,No
+   Timer Modules,Global Timebase Cunter (GTC),,No,No,No,No
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,No,No,Yes,No
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,No,No,No,No
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,No,No,No,No
+   ,Real-Time Clock (RTC),,No,Yes,No,No
+   ,Timers - MAIN domain,Timer,NA,No,Yes,Yes
+   ,,Capture,NA,No,No,No
+   ,,Compare,NA,No,No,No
+   ,,PWM,NA,No,No,No
+   ,Timers - MCU domain,Timer,Yes,No,No,No
+   ,,Capture,No,No,No,No
+   ,,Compare,No,No,No,No
+   ,,PWM,No,No,No,No
+   ,Timers - WKUP domain,Timer,NA,Yes,No,No
+   ,,Capture,NA,No,No,No
+   ,,Compare,NA,No,No,No
+   ,,PWM,NA,No,No,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,Yes,No,No,No
+   ,Error Signalling Module (ESM),,Yes,No,No,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes,No,No,No
+   ,SDL Driver Porting Layer(SDL DPL),,Yes,No,No,No
+   ,RTI(WWDG),,Yes,No,No,No
+   ,Voltage and Thermal Management(VTM),,Yes,No,No,No
+   ,Interconnect Isolation Gasket(STOG),,Yes,No,No,No
+   ,Interconnect Isolation Gasket(MTOG),,Yes,No,No,No
+   ,Power OK(POK),,Yes,No,No,No
+   ,PBIST(Built In Self Test),,Yes,No,No,No
+   ,ECC Aggregator,,Yes,No,No,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,NA,No,No,No
+   ,DISPLAY Parallel Interface (DPI),,NA,No,No,No
+   ,Dual Display,,NA,NA,NA,NA
+   Video Processing Unit,,,NA,No,No,No
+   Image Encoder,JPEG Encoder E5010,,,,,
+   On-Die Temperature sensor,,,NA,No,No,No
+   On-Chip Debug,,,NA,NA,NA,NA
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,NA,No,Yes,No
+   ,,AES-ECB,NA,No,Yes,No
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,NA,No,Yes,No
+   ,,SHA-512,NA,No,Yes,No
+   ,True Random Number Generator (TRNG),,NA,No,Yes,No
+   ISP (Image SigNAl Processing),Hardware accelerated ISP for RGB and IR,,NA,No,No,No
+   Deep Learning,Hardware accelerated deep learning,,NA,No,No,No

--- a/source/devices/AM62PX/linux/Release_Specific.rst
+++ b/source/devices/AM62PX/linux/Release_Specific.rst
@@ -6,6 +6,7 @@ Release Specific
    :maxdepth: 5
 
    Release_Specific_Release_Notes
+   Release_Specific_Build_Sheet
    Release_Specific_Yocto_layer_Configuration
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide

--- a/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
@@ -1,0 +1,178 @@
+.. _build_sheet:
+
+====================
+Software Build Sheet
+====================
+
+Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
+The following table lists the supported features and modules for the corresponding category,
+along with the support status for Linux on A53, RTOS on MCU R5F, RTOS on WKUP R5F.
+
+The support status is indicated by the following codes:
+
+   - "Yes": The feature or module is supported.
+   - "No": The feature or module is not supported.
+   - "SDKx.y": The feature or module will be supported in a future version of the SDK.
+   - "NA": The feature or module is not applicable in the hardware.
+   - "ANY": The feature or module is a new update in this revision of the SDK.
+
+.. csv-table:: Software Build Sheet
+   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU R5F", "RTOS on WKUP R5F"
+   :widths: 20, 20, 20, 20, 20, 20
+
+   System Interconnect,Bandwidth regulator,,No,No,No
+   ,CBASS auto-clock gating,,No,No,No
+   Initialization,I2C Bootloader Operation,,No,No,No
+   ,SPI Bootloader Operation,,No,No,No
+   ,QSPI Bootloader Operation,NOR,Yes,NA,No
+   ,,NAND,No,NA,No
+   ,OSPI Bootloader Operation,NOR,Yes,NA,Yes
+   ,,NAND (1-bit mode),No,NA,No
+   ,,NAND (8-bit mode),No,NA,No
+   ,GPMC Bootloader Operation,NOR,No,NA,No
+   ,,NAND,No,NA,No
+   ,Ethernet Bootloader Operation,,No,NA,No
+   ,USB Bootloader Operation,Host,Yes,NA,No
+   ,,Device,Yes,NA,No
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,Yes
+   ,,eMMC,Yes,NA,Yes
+   ,UART Bootloader Operation,,Yes,NA,Yes
+   Device Configuration,Power Supply Modules,POK,No,No,Yes
+   ,,POR,No,No,No
+   ,,PRG,No,No,No
+   ,,PGD,No,No,No
+   ,,VTM,Yes,Yes,Yes
+   Power Management,Deep Sleep Low Power Mode,,Yes,NA,NA
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,NA,NA
+   ,,GT Timers,No,NA,NA
+   ,,WKUP UART,Yes,NA,NA
+   ,,I2C,No,NA,NA
+   ,,MCU GPIO,Yes,NA,NA
+   ,,I/O Daisy Chain,Yes,NA,NA
+   ,,USB Connect/Disconnect,Yes,NA,NA
+   ,,USB Remote Wakeup,Yes,NA,NA
+   ,MCU-Only Low Power Mode,,Yes,NA,NA
+   ,Standby Low Power Mode,,SDK11.1,NA,NA
+   ,IO + DDR Low power mode,,Yes,NA,NA
+   ,Partial I/O Low Power Mode,,Yes,NA,NA
+   ,Boot-time OPP configurations,,Yes,No,No
+   ,Runtime Power Management,,Yes,NA,NA
+   ,DFS/CPUFreq,,Yes,NA,NA
+   ,CPUIdle (A53 WFI),,Yes,NA,NA
+   ,CPUIdle (DDR in Self-Refresh),,No,NA,NA
+   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,NA,NA,NA
+   ,Communication Subsystem (PRUSS-M),,,,
+   ,,Industrial Protocols,NA,NA,NA
+   Interprocessor Communication,Mailbox,,Yes,Yes,Yes
+   ,Spinlock,,Yes,No,No
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,NA,No,No
+   ,,LPDDR4,Yes,No,Yes
+   ,,Inline ECC (1bit err),Yes,No,Yes
+   ,,Inline ECC (mbit err),Yes,No,Yes
+   ,Region-based Address Translation,,No,Yes,Yes
+   Time Sync,Time Sync Module (CPTS),,Yes,No,No
+   ,Timer Manager,,No,No,No
+   ,Time Sync and Compare Events,,No,No,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,Yes
+   ,Peripheral DMA (PDMA),,Yes,No,No
+   ,RingAcc,,Yes,Yes,Yes
+   ,BCDMA,,Yes,Yes,Yes
+   ,Packet Streaming Interface Link,,Yes,No,No
+   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,Yes,NA,Yes
+   ,,Output,Yes,NA,Yes
+   ,,HDMI Output,Yes,NA,NA
+   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
+   ,,Target,No,Yes,Yes
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes
+   ,,Peripheral,No,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes
+   ,,RS-485,Yes,No,No
+   ,,IrDA,No,No,No
+   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,Yes,Yes,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
+   ,,Target,No,Yes,Yes
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes
+   ,,Peripheral,No,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes
+   ,,RS-485,Yes,No,No
+   ,,IrDA,No,No,No
+   "General Connectivity Peripherals
+   (WKUP domain)",Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
+   ,,Target,No,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,No,Yes
+   ,,RS-485,Yes,No,No
+   ,,IrDA,No,No,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No
+   ,,EndPoint,Yes,No,No
+   ,,TSN,Yes,No,No
+   ,,TSN - VLAN,Yes,No,No
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,No,No
+   ,,Device 3.1,NA,No,No
+   ,,Host 2.0,Yes,No,No
+   ,,Device 2.0,Yes,No,No
+   Memory Interfaces,Flash Subsystem (FSS),,No,No,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes,No,No
+   ,,NAND,NA,No,No
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,No,Yes
+   ,,NAND,Yes,No,No
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes,No,No
+   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,No
+   ,,NAND,Yes,No,No
+   ,,NOR,No,No,No
+   ,,etc.,No,No,No
+   ,Error Location Module (ELM),,Yes,No,No
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,No,Yes
+   ,,eMMC,Yes,No,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,No,Yes
+   ,,CAN FD,Yes,No,Yes
+   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes,Yes,No
+   ,,CAN FD,Yes,Yes,No
+   ,Enhanced Capture (ECAP) Module,Capture,Yes,No,No
+   ,,PWM,Yes,Yes,No
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,No
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,No,No
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes,NA,NA
+   ,MIPI D-PHY Receiver (DPHY_RX),,Yes,NA,NA
+   ,Multiple Camera,,Yes,NA,NA
+   Timer Modules,Global Timebase Cunter (GTC),,Yes,No,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No
+   ,Real-Time Clock (RTC),,Yes,Yes,No
+   ,Timers - MAIN domain,Timer,Yes,NA,NA
+   ,,Capture,No,NA,NA
+   ,,Compare,No,NA,NA
+   ,,PWM,Yes,NA,NA
+   ,Timers - MCU domain,Timer,No,Yes,NA
+   ,,Capture,No,No,NA
+   ,,Compare,No,No,NA
+   ,,PWM,No,No,NA
+   ,Timers - WKUP domain,Timer,Yes,NA,Yes
+   ,,Capture,No,NA,No
+   ,,Compare,No,NA,No
+   ,,PWM,No,NA,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,No
+   ,Error Signaling Module (ESM),,No,Yes,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No,Yes,No
+   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,No
+   ,RTI(WWDG),,No,Yes,No
+   ,Voltage and Thermal Management(VTM),,Yes,Yes,No
+   ,Interconnect Isolation Gasket(STOG),,No,Yes,No
+   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No
+   ,Power OK(POK),,No,Yes,No
+   ,PBIST(Built In Self Test),,No,Yes,No
+   ,ECC Aggregator,,No,Yes,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes,NA,Yes
+   ,DISPLAY Parallel Interface (DPI),,Yes,NA,Yes
+   ,DSI (display serial interface),,Yes,NA,No
+   ,Triple Display,,Yes,NA,No
+   Video Processing Unit,Cnm Wave521CL,,Yes,,
+   Graphics Processing Unit,IMG BXS,,Yes,NA,No
+   On-Die Temperature sensor,,,Yes,NA,NA
+   On-Chip Debug,,,NA,NA,NA
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,NA
+   ,,AES-ECB,Yes,NA,NA
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,NA
+   ,,SHA-512,Yes,NA,NA
+   ,True Random Number Generator (TRNG),,SDK11.0,NA,NA

--- a/source/devices/AM62X/linux/Release_Specific.rst
+++ b/source/devices/AM62X/linux/Release_Specific.rst
@@ -6,6 +6,7 @@ Release Specific
    :maxdepth: 5
 
    Release_Specific_Release_Notes
+   Release_Specific_Build_Sheet
    Release_Specific_Yocto_layer_Configuration
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide

--- a/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
@@ -1,0 +1,174 @@
+.. _build_sheet:
+
+====================
+Software Build Sheet
+====================
+
+Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
+The following table lists the supported features and modules for the corresponding category,
+along with the support status for Linux on A53, RTOS on MCU M4, RTOS on WKUP R5F, and RTOS on A53.
+
+The support status is indicated by the following codes:
+
+   - "Yes": The feature or module is supported.
+   - "No": The feature or module is not supported.
+   - "SDKx.y": The feature or module will be supported in a future version of the SDK.
+   - "NA": The feature or module is not applicable in the hardware.
+   - "ANY": The feature or module is a new update in this revision of the SDK.
+
+.. csv-table:: Software Build Sheet
+   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU M4", "RTOS on WKUP R5F", "RTOS on A53"
+   :widths: 20, 20, 20, 20, 20, 20, 20
+
+   System Interconnect,Bandwidth regulator,,No,No,No,No
+   ,CBASS auto-clock gating,,No,No,No,No
+   Initialization,I2C Bootloader Operation,,No,No,No,No
+   ,SPI Bootloader Operation,,No,No,No,No
+   ,QSPI Bootloader Operation,NOR,Yes,NA,No,NA
+   ,,NAND,No,NA,No,NA
+   ,OSPI Bootloader Operation,NOR,Yes,NA,Yes,NA
+   ,,NAND (1-bit mode),Yes,NA,No,NA
+   ,,NAND (8-bit mode),Yes,NA,Yes,NA
+   ,GPMC Bootloader Operation,NOR,No,NA,No,NA
+   ,,NAND,Yes,NA,Yes,NA
+   ,Ethernet Bootloader Operation,,Yes,NA,No,NA
+   ,USB Bootloader Operation,Host,No,NA,No,NA
+   ,,Device,Yes,NA,No,NA
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,No,NA
+   ,,eMMC,Yes,NA,Yes,NA
+   ,UART Bootloader Operation,,Yes,NA,Yes,NA
+   Device Configuration,Power Supply Modules,POK,No,No,Yes,No
+   ,,POR,No,No,No,No
+   ,,PRG,No,No,No,No
+   ,,PGD,No,No,No,No
+   ,,VTM,Yes,Yes,Yes,No
+   Power Management,Deep Sleep Low Power Mode,,Yes,NA,NA,No
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,NA,NA,No
+   ,,GT Timers,No,NA,NA,No
+   ,,WKUP UART,Yes,NA,NA,No
+   ,,I2C,No,NA,NA,No
+   ,,MCU GPIO,Yes,NA,NA,No
+   ,,I/O Daisy Chain,Yes,NA,NA,No
+   ,,USB Connect/Disconnect,Yes,NA,NA,No
+   ,,USB Remote Wakeup,Yes,NA,NA,No
+   ,MCU-Only Low Power Mode,,Yes,NA,NA,No
+   ,Standby Low Power Mode,,SDK11.1,NA,NA,No
+   ,Partial I/O Low Power Mode,,Yes,NA,NA,No
+   ,Boot-time OPP configurations,,Yes,No,No,No
+   ,Runtime Power Management,,Yes,NA,NA,No
+   ,DFS/CPUFreq,,Yes,NA,NA,No
+   ,CPUIdle (A53 WFI),,Yes,NA,NA,No
+   ,CPUIdle (DDR in Self-Refresh),,No,NA,NA,No
+   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,Yes,NA,NA,No
+   ,Communication Subsystem (PRUSS-M),,,,,
+   ,,Industrial Protocols,NA,NA,NA,NA
+   Interprocessor Communication,Mailbox,,Yes,Yes,Yes,Yes
+   ,Spinlock,,Yes,No,No,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,No,Yes,No
+   ,,LPDDR4,Yes,No,Yes,No
+   ,,Inline ECC (1bit err),Yes,No,Yes,No
+   ,,Inline ECC (mbit err),Yes,No,Yes,No
+   ,Region-based Address Translation,,No,Yes,Yes,No
+   Time Sync,Time Sync Module (CPTS),,Yes,No,No,No
+   ,Timer Manager,,No,No,No,No
+   ,Time Sync and Compare Events,,No,No,No,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,No,Yes,Yes
+   ,Peripheral DMA (PDMA),,Yes,No,Yes,Yes
+   ,RingAcc,,Yes,No,Yes,Yes
+   ,BCDMA,,Yes,No,Yes,Yes
+   ,Packet Streaming Interface Link,,Yes,No,No,No
+   General Connectivity Peripherals,Multichannel Audio Serial Port (McASP),Input,Yes,NA,NA,Yes
+   (MAIN domain),,Output,Yes,NA,NA,Yes
+   ,,HDMI Output,Yes,NA,NA,No
+   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
+   ,,Target,No,Yes,Yes,Yes
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes,Yes
+   ,,Peripheral,No,NA,NA,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
+   ,,RS-485,Yes,NA,NA,No
+   ,,IrDA,No,NA,NA,No
+   General Connectivity Peripherals,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
+   (MCU domain),Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
+   ,,Target,No,No,No,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes,Yes
+   ,,Peripheral,No,Yes,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
+   ,,RS-485,Yes,No,No,No
+   ,,IrDA,No,No,No,No
+   General Connectivity Peripherals,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
+   (WKUP domain),,Target,No,Yes,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,NA,Yes,Yes
+   ,,RS-485,Yes,NA,NA,No
+   ,,IrDA,No,NA,NA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No,No
+   ,,EndPoint,Yes,No,No,No
+   ,,TSN,Yes,No,No,No
+   ,,TSN - VLAN,Yes,No,No,No
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,NA,No,No
+   ,,Device 3.1,NA,NA,No,No
+   ,,Host 2.0,Yes,NA,No,No
+   ,,Device 2.0,Yes,NA,No,No
+   Memory Interfaces,Flash Subsystem (FSS),,No,NA,No,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes,NA,No,No
+   ,,NAND,NA,NA,No,No
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,NA,Yes,Yes
+   ,,NAND,Yes,NA,Yes,Yes
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes,NA,No,No
+   ,General-Purpose Memory Controller (GPMC),FPGA,No,NA,No,No
+   ,,NAND,Yes,NA,Yes,Yes
+   ,,NOR,No,NA,No,No
+   ,,etc.,No,NA,No,No
+   ,Error Location Module (ELM),,Yes,NA,No,No
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,NA,Yes,Yes
+   ,,eMMC,Yes,NA,Yes,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,NA,Yes,Yes
+   ,,CAN FD,Yes,NA,Yes,Yes
+   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes,Yes,No,Yes
+   ,,CAN FD,Yes,Yes,No,Yes
+   ,Enhanced Capture (ECAP) Module,Capture,Yes,No,No,Yes
+   ,,PWM,Yes,No,No,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,No,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,No,No,Yes
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes,NA,No,No
+   ,MIPI D-PHY Receiver (DPHY_RX),,Yes,NA,No,No
+   ,Multiple Camera,,Yes,NA,No,No
+   Timer Modules,Global Timebase Counter (GTC),,Yes,No,Yes,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No,Yes
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No,NA
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No,NA
+   ,Real-Time Clock (RTC),,Yes,No,No,Yes
+   ,Timers - MAIN domain,Timer,Yes,NA,NA,Yes
+   ,,Capture,No,NA,NA,No
+   ,,Compare,No,NA,NA,No
+   ,,PWM,Yes,NA,NA,No
+   ,Timers - MCU domain,Timer,No,Yes,NA,No
+   ,,Capture,No,No,NA,No
+   ,,Compare,No,No,NA,No
+   ,,PWM,No,No,NA,No
+   ,Timers - WKUP domain,Timer,Yes,NA,Yes,No
+   ,,Capture,No,NA,No,No
+   ,,Compare,No,NA,No,No
+   ,,PWM,No,NA,No,No
+   Internal Diagnostic Modules,Dual Clock Comparator (DCC),,No,Yes,Yes,No
+   ,Error Signaling Module (ESM),,No,Yes,Yes,No
+   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,Yes,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes,Yes,Yes,No
+   ,RTI(WWDG),,No,Yes,Yes,No
+   ,Voltage and Thermal Management(VTM),,No,Yes,Yes,No
+   ,Interconnect Isolation Gasket(STOG),,No,Yes,Yes,No
+   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No,No
+   ,Power OK(POK),,No,Yes,Yes,No
+   ,PBIST(Built In Self Test),,No,Yes,Yes,No
+   ,ECC Aggregator,,No,Yes,Yes,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes,No,No,No
+   ,DISPLAY Parallel Interface (DPI),,Yes,No,No,No
+   ,Dual Display,,Yes,No,No,No
+   Graphics Processing Unit,,,Yes,NA,NA,No
+   On-Die Temperature sensor,,,Yes,NA,NA,No
+   On-Chip Debug,,,NA,NA,NA,NA
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,NA,No
+   ,,AES-ECB,Yes,NA,NA,No
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,NA,No
+   ,,SHA-512,Yes,NA,NA,No
+   ,True Random Number Generator (TRNG),,Yes,NA,NA,No

--- a/source/devices/AM64X/linux/Release_Specific.rst
+++ b/source/devices/AM64X/linux/Release_Specific.rst
@@ -6,6 +6,7 @@ Release Specific
    :maxdepth: 5
 
    Release_Specific_Release_Notes
+   Release_Specific_Build_Sheet
    Release_Specific_Yocto_layer_Configuration
    Release_Specific_Migration_Guide
    Release_Specific_Kernel_Performance_Guide

--- a/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
@@ -1,0 +1,127 @@
+.. _build_sheet:
+
+====================
+Software Build Sheet
+====================
+
+Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
+The following table lists the supported features and modules for the corresponding category,
+along with the support status for Linux on A53, RTOS on R5F, RTOS on M4, RTOS on A53.
+
+The support status is indicated by the following codes:
+
+   - "Yes": The feature or module is supported.
+   - "No": The feature or module is not supported.
+   - "SDKx.y": The feature or module will be supported in a future version of the SDK.
+   - "N/A": The feature or module is not applicable in the hardware.
+   - "ANY": The feature or module is a new update in this revision of the SDK.
+
+.. csv-table:: Software Build Sheet
+   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on R5F", "RTOS on M4", "RTOS on A53"
+   :widths: 20, 20, 20, 20, 20, 20, 20
+
+   Memory Map,MAIN Domain Memory Map,,Yes,Yes,Yes,No
+   ,MCU Domain Memory Map,,Yes,Yes,Yes,No
+   ,Processors View Memory Map,,Yes,N/A,N/A,No
+   ,Region-based Address Translation,,No,Yes,Yes,No
+   System Interconnect,,,Yes,N/A,N/A,N/A
+   Initialization,I2C Bootloader Operation,,No,N/A,N/A,N/A
+   ,SPI Bootloader Operation,,No,N/A,N/A,N/A
+   ,QSPI Bootloader Operation,,Yes,Yes,N/A,N/A
+   ,OSPI Bootloader Operation,,Yes,Yes,N/A,N/A
+   ,PCIe Bootloader Operation,,No,N/A,N/A,N/A
+   ,GPMC Bootloader Operation,NOR,No,No,N/A,N/A
+   ,,NAND,Yes,No,N/A,N/A
+   ,Ethernet Bootloader Operation,,Yes,No,N/A,N/A
+   ,USB Bootloader Operation,Host,Yes,No,N/A,N/A
+   ,,Device,Yes,No,N/A,N/A
+   ,MMCSD Bootloader Operation,SD Card (4 bit),Yes,Yes,N/A,N/A
+   ,,SD Card (8 bit),No,No,N/A,N/A
+   ,,eMMC,Yes,Yes,N/A,N/A
+   ,UART Bootloader Operation,,Yes,Yes,N/A,N/A
+   Device Configuration,Power,,Yes,Yes,Yes,No
+   ,Reset,,Yes,Yes,Yes,Yes
+   ,Clocking,,Yes,Yes,Yes,Yes
+   Processors and Accelerators,Dual-R5F MCU Subsystem,,Yes,Yes,N/A,N/A
+   ,Dual-A53 MPU Subsystem,,Yes,N/A,N/A,Yes
+   ,Cortex-M4F Subsystem,,No,N/A,Yes,N/A
+   ,Programmable Real-Time Unit and Industrial Communication Subsystem - Gigabit,General PRU Use,Yes,Yes,No,No
+   ,,EtherCAT Device,No,Yes,No,No
+   ,,Profinet RT Device,No,Yes,No,No
+   ,,Profinet IRT Device,No,Yes,No,No
+   ,,EtherNet/IP adapter,No,Yes,No,No
+   ,,Ethernet Endpoint (EMAC),Yes,Yes,No,No
+   ,,Ethernet Switch,Yes,No,No,No
+   ,,Ethernet HSR,Yes,No,No,No
+   ,,IO Link Primary,No,Yes,No,No
+   ,,"HDSL, EnDat 2.2",No,Yes,No,No
+   Interprocessor Communication (IPC),Mailbox,,Yes,Yes,Yes,Yes
+   ,Spinlock,,Yes,Yes,Yes,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,Yes,N/A,N/A
+   ,,LPDDR4,Yes,No,N/A,N/A
+   ,,Inline ECC,Yes,Yes,N/A,N/A
+   ,Region-based Address Translation (RAT) Module,,No,Yes,Yes,No
+   Interrupts,MCU Domain Interrupt Maps,,Yes,Yes,Yes,Yes
+   ,MAIN Domain Interrupt Maps,,Yes,Yes,N/A,Yes
+   Time Sync,Time Sync Module (CPTS),,Yes,Yes,No,No
+   ,Timer Manager,,No,No,No,No
+   ,Time Sync and Compare Events,,Yes,No,No,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,N/A,Yes
+   ,Peripheral DMA (PDMA),,Yes,Yes,N/A,No
+   ,RingAcc,,Yes,Yes,N/A,No
+   ,Secure Proxy,,Yes,Yes,N/A,No
+   ,Interrup Aggregator,,Yes,Yes,N/A,No
+   ,Packet Streaming Interface Link,,Yes,Yes,N/A,No
+   General Connectivity Peripherals,Analog-to-Digital Converter (ADC),,Yes,Yes,No,Yes
+   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
+   ,Inter-Integrated Circuit (I2C) Interface,Controller,Yes,Yes,Yes,Yes
+   ,,Target,No,Yes,Yes,Yes
+   ,Multichannel Serial Peripheral Interface (MCSPI),Controller,Yes,Yes,Yes,Yes
+   ,,Peripheral,No,Yes,Yes,Yes
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
+   ,,RS-485,Yes,No,No,No
+   ,,IrDA,No,No,No,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW0),Switch,Yes,Yes,N/A,No
+   ,,EndPoint,Yes,Yes,N/A,No
+   ,Peripheral Component Interconnect Express (PCIe) Subsystem,Root Complex,Yes,Yes,N/A,No
+   ,,EndPoint,Yes,Yes,N/A,No
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.0,N/A,No,N/A,No
+   ,,Device 3.0,N/A,No,N/A,No
+   ,,Host 2.0,Yes,No,N/A,No
+   ,,Device 2.0,Yes,Yes,N/A,No
+   ,Serializer/Deserializer (SerDes),,Yes,Yes,N/A,No
+   Memory Interfaces,Flash Subsystem (FSS) ,,No,No,N/A,No
+   ,Octal Serial Peripheral Interface (OSPI),,Yes,Yes,N/A,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,N/A,No
+   ,,NAND,Yes,No,N/A,No
+   ,,NOR,No,No,N/A,No
+   ,,etc.,No,No,N/A,No
+   ,Error Location Module (ELM),,Yes,No,N/A,No
+   ,Multimedia Card Secure Digital (MMCSD) Interface,4-bit,Yes,Yes,N/A,Yes
+   ,,8-bit,Yes,Yes,N/A,Yes
+   Industrial and Control Interfaces,Enhanced Capture (ECAP) Module,Capture,No,Yes,N/A,Yes
+   ,,PWM,Yes,No,N/A,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,N/A,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,Yes,N/A,Yes
+   ,Controller Area Network (MCAN),Classic CAN,Yes,Yes,N/A,Yes
+   ,,Classic CAN FD,Yes,Yes,N/A,Yes
+   ,FSI,Receiver,No,Yes,N/A,No
+   ,,Transmitter,No,Yes,N/A,No
+   Timer Modules,Global Timebase Counter (GTC),,Yes,Yes,Yes,Yes
+   ,Windowed Watchdog Timer (WWDT),,Yes,Yes,No,Yes
+   ,Timers,Timer,Yes,Yes,Yes,Yes
+   ,,Capture,No,No,No,No
+   ,,Compare,No,No,No,No
+   ,,PWM,No,No,No,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,Yes,No
+   ,Error Signaling Module (ESM),,No,Yes,Yes,No
+   ,RTI(WWDG)	,,No,Yes,Yes,No
+   ,Voltage and Thermal Management(VTM)	,,No,Yes,Yes,No
+   ,Interconnect Isolation Gasket(STOG)	,,No,Yes,Yes,No
+   ,Interconnect Isolation Gasket(MTOG)	,,No,No,Yes,No
+   ,Power OK(POK)	,,No,Yes,Yes,No
+   ,PBIST(Built In Self Test)	,,No,Yes,Yes,No
+   ,LBIST(Built In Self Test)	,,No,No,Yes,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No,Yes,Yes,No
+   ,ECC AggrB70:B117egator,,No,Yes,Yes,No
+    On-Chip Debug,,,Yes,Yes,Yes,No


### PR DESCRIPTION
This adds the support for device specific build sheet information for the devices AM62X, AM62PX, AM64X and AM62DX in github documentation.