### PR TITLE
Bugfix/overview ifconfig

### DIFF
--- a/source/linux/Overview/_Processor_SDK_Linux_Software_Developers_Guide.rst
+++ b/source/linux/Overview/_Processor_SDK_Linux_Software_Developers_Guide.rst
@@ -94,24 +94,21 @@ suggestions at `E2E <https://e2e.ti.com/>`__.
         -
 
 
-.. ifconfig:: CONFIG_sdk in ('SITARA')
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
 
-   .. ifconfig:: CONFIG_part_variant not in ('AM62LX', 'AM62X', 'AM62AX', 'AM62PX', 'AM335X', 'AM437X', 'AM65X')
+   .. list-table::
+      :header-rows: 1
 
-      .. list-table::
-         :header-rows: 1
-
-         * - PRU-ICSS / PRU_ICSSG Protocols
-           -
-           -
-           -
-         * - :ref:`DUAL_EMAC <industrial-protocols-dual-emac>`
-           - :ref:`HSR_PRP <industrial-protocols-hsr-prp>`
-           - :ref:`PTP <industrial-protocols-ptp>`
-           - :ref:`RSTP <industrial-protocols-rstp>`
-         * - :ref:`CCLINK <industrial-protocols-cclink>`
-           - :ref:`SORTE <industrial-protocols-sorte>`
-           - :ref:`OPC/UA <industrial-protocols-opcua>`
-           -
-
+      * - PRU-ICSS / PRU_ICSSG Protocols
+        -
+        -
+        -
+      * - :ref:`DUAL_EMAC <industrial-protocols-dual-emac>`
+        - :ref:`HSR_PRP <industrial-protocols-hsr-prp>`
+        - :ref:`PTP <industrial-protocols-ptp>`
+        - :ref:`RSTP <industrial-protocols-rstp>`
+      * - :ref:`CCLINK <industrial-protocols-cclink>`
+        - :ref:`SORTE <industrial-protocols-sorte>`
+        - :ref:`OPC/UA <industrial-protocols-opcua>`
+        -
 


### PR DESCRIPTION
- chore(overview): reduce ifconfig logic

  This was needlessly complicated. Reduce to the only platforms that were 
  affected based on previous logic.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- fix(overview): remove incorrect ifconfig use

  Remove the last of the incorrect usage of the ifconfig directive. Replace
  these cumbersome tables with list-tables.

  This is a little goofy due to old formatting. To keep in line with what was
  previously here (and to prevent automatic numbering of these tables), we must
  place the header in the first row and pad accordingly.

  Signed-off-by: Randolph Sapp <rs@ti.com>

