### PR TITLE
docs(linux): Replace kmstest with kmsxxtest

### DIFF
--- a/source/linux/Foundational_Components/Graphics/Common/Display.rst
+++ b/source/linux/Foundational_Components/Graphics/Common/Display.rst
@@ -31,7 +31,7 @@ The list of available DRM blocks is viewable using the application
 
        For ADAS parts by default Display is disabled in linux via
        k3-<soc>-vision-apps.dtso and enabled to be controlled by one of the
-       real time r5f core. So modetest, kmstest, weston will not work.
+       real time r5f core. So modetest, kmsxxtest, weston will not work.
        To enabled it you need to modify k3-<soc>-vision-apps.dtso, rebuild
        linux-dtbs and install. Also need to disable Display in r5f, rebuild
        r5f FW using PSDK RTOS.

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7.rst
@@ -441,7 +441,7 @@ Another option is kms++, a C++11 library for kernel mode setting which includes 
 Testing tidss
 -------------
 
-kmstest from kms++ is a good tool for testing tidss features. Note that any other applications using DRM (Weston, X) must be killed first. Another tool from kms++ is kmsprint, which can be used to print various bits of information about tidss.
+kmsxxtest from kms++ is a good tool for testing tidss features. Note that any other applications using DRM (Weston, X) must be killed first. Another tool from kms++ is kmsprint, which can be used to print various bits of information about tidss.
 
 .. code-block:: console
 
@@ -456,7 +456,7 @@ kmstest from kms++ is a good tool for testing tidss features. Note that any othe
 
 .. code-block:: console
 
-  $ kmstest -c dp -r 640x480
+  $ kmsxxtest -c dp -r 640x480
   Connector 0/@39: DP-1
     Crtc 0/@37: 640x480 25.175 640/16/96/48/- 480/10/2/33/- 60 (59.94) 0xa 0x40
     Plane 0/@31: 0,0-640x480
@@ -475,7 +475,7 @@ kmstest from kms++ is a good tool for testing tidss features. Note that any othe
         Crtc 0 (38) 800x480 28.569 800/48/32/80 480/3/7/6 60 (60.00)
           Plane 0 (31) fb-id: 48 (crtcs: 0) 0,0 800x480 -> 0,0 800x480 (AR12 AB12 RA12 RG16 BG16 AR15 AB15 AR24 AB24 RA24 BA24 RG24 BG24 AR30 AB30 XR12 XB12 RX12 XR15 XB15 XR24 XB24 RX24 BX24 XR30 XB30 YUYV UYVY NV12)
             FB 48 800x480
-    $ kmstest --device=/dev/dri/card2
+    $ kmsxxtest --device=/dev/dri/card2
     Connector 0/@40: DSI-1
       Crtc 0/@38: 800x480 28.569 800/48/32/80/- 480/3/7/6/- 60 (60.00) 0xa 0x48
       Plane 0/@31: 0,0-800x480
@@ -507,8 +507,8 @@ tidss supports configuration via DRM properties. These are standard DRM properti
 
 .. _testing_tidss_properties:
 
-Testing tidss properties with modetest and kmstest
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Testing tidss properties with modetest and kmsxxtest
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As the name suggests, ``modetest`` is DRM based mode setting test program available along with libdrm.
 It is an easy-to-use tool to test different features provided by display HWs. The DRM driver for,
@@ -683,12 +683,12 @@ hence plane 41 remains unused.
 
 - **Cropping**
 
-``kmstest`` utility can be used to demonstrate cropping in a video frame using a test pattern.
+``kmsxxtest`` utility can be used to demonstrate cropping in a video frame using a test pattern.
 The user can specify the main video frame size and an input color format using the ``-f`` argument. Then the source region, also known as a view region, can be specified using the ``-v`` argument. This takes a secondary width and height to create a rectangle starting at a given coordinate. The destination region, or plane region, for the view can be specified using ``-p`` argument. This takes a third width, height and coordinate position to place an overlay with the associated view region's content.
 
 .. code-block:: console
 
-   $ kmstest -c hdmi -p 0:0,0-1000x1000 -f 1000x1000-XR24 -v 0,0-1000x1000
+   $ kmsxxtest -c hdmi -p 0:0,0-1000x1000 -f 1000x1000-XR24 -v 0,0-1000x1000
    Connector 1/@50: HDMI-A-1
    Crtc 1/@48: 1920x1080@59.93 138.500 1920/48/32/80/+ 1080/3/5/23/- 60 (59.93) 0x9 0x48
    Plane 0/@31: 0,0-1000x1000
@@ -702,7 +702,7 @@ The above example displays a ``1000x1000`` video frame on the screen at coordina
 
 .. code-block:: console
 
-   $ kmstest -c hdmi -p 0:0,0-800x800 -f 1000x1000 -v 0,0-800x800
+   $ kmsxxtest -c hdmi -p 0:0,0-800x800 -f 1000x1000 -v 0,0-800x800
    Connector 1/@50: HDMI-A-1
    Crtc 1/@48: 1920x1080@59.93 138.500 1920/48/32/80/+ 1080/3/5/23/- 60 (59.93) 0x9 0x48
    Plane 0/@31: 0,0-800x800
@@ -716,7 +716,7 @@ Taking as an input a video frame of dimensions ``1000x1000``,the example creates
 
 .. code-block:: console
 
-   $ kmstest -c hdmi -p 0:500,200-800x800 -f 1000x1000 -v 200,100-800x800
+   $ kmsxxtest -c hdmi -p 0:500,200-800x800 -f 1000x1000 -v 200,100-800x800
    Connector 1/@50: HDMI-A-1
    Crtc 1/@48: 1920x1080@59.93 138.500 1920/48/32/80/+ 1080/3/5/23/- 60 (59.93) 0x9 0x48
    Plane 0/@31: 500,200-800x800


### PR DESCRIPTION
The regular kmstest was provided by libdrm and also kmsxx[0], and hence there is a conflict due to whict kmstest is renamed to kmsxxtest in meta-oe[1]. Replace kmstest with kmsxxtest.

Links:
[0]: https://github.com/tomba/kmsxx/
[1]: https://git.openembedded.org/meta-openembedded/tree/meta-oe/dynamic-layers/meta-python/recipes-multimedia/kmsxx/kmsxx_git.bb#n29