### PR TITLE
Feature/extlinks

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,6 +16,7 @@
 import sys
 import os
 import importlib
+import json
 from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -36,6 +37,7 @@ from scripts import interpretvalues, sectinc, replacevars
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
@@ -257,6 +259,10 @@ latex_elements = {
 
 # Suppress warnings about excluded documents because every device gets a different toc tree
 suppress_warnings = ['toc.excluded']
+
+# Load extlinks config
+with open(os.path.join(rootdir, 'extlinks.json'), 'r', encoding='utf-8') as extconf:
+    extlinks = json.load(extconf)
 
 # -- Tag file loader ------------------------------------------------------
 

--- a/extlinks.json
+++ b/extlinks.json
@@ -1,0 +1,6 @@
+{
+  "ti-linux-kernel-binding": [
+    "https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/%s?h=ti-linux-6.12.y",
+    "Documentation/devicetree/bindings/%s"
+  ]
+}

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Display/DSS7.rst
@@ -309,7 +309,7 @@ Note: this is not a comprehensive list of features supported/not supported, and 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX', 'J722S')
 
  More detailed description of these properties can be found at:
- `Display device-tree file <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/display/ti/ti,am65x-dss.yaml?h=09.01.00.008>`__
+ :ti-linux-kernel-binding:`Display device-tree file <display/ti/ti,am65x-dss.yaml`
  Also there is a how-to guide available for dss sharing which walks through different examples for resource paritioning using these device-tree properties :
  `How to enable dss sharing between remote core and Linux <../../../../How_to_Guides/Target/How_to_enable_display_sharing_between_remotecore_and_Linux.html>`__
 

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet.rst
@@ -81,9 +81,8 @@ Device tree bindings
 
 The DT bindings description can be found at:
 
-| `Documentation/devicetree/bindings/net/ti,icssg-prueth.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,icssg-prueth.yaml?h=ti-linux-6.6.y>`__
-| `Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,davinci-mdio.yaml?h=ti-linux-6.6.y>`__
-|
+:ti-linux-kernel-binding:`net/ti,icssg-prueth.yaml`
+:ti-linux-kernel-binding:`net/ti,davinci-mdio.yaml`
 
 User guide
 ##########

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_sr10.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_sr10.rst
@@ -68,8 +68,7 @@ Device tree bindings
 
 The DT bindings description can be found at:
 
-| `Documentation/devicetree/bindings/net/ti,icssg-prueth.txt <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/net/ti,icssg-prueth.txt?h=ti-linux-5.10.y>`__
-|
+:ti-linux-kernel-binding:`net/ti,icssg-prueth.txt`
 
 User guide
 ##########

--- a/source/linux/Foundational_Components_IPC62ax.rst
+++ b/source/linux/Foundational_Components_IPC62ax.rst
@@ -164,7 +164,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.12.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 ::
 

--- a/source/linux/Foundational_Components_IPC62px.rst
+++ b/source/linux/Foundational_Components_IPC62px.rst
@@ -155,7 +155,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
    +------------------+--------------------+---------+----------------------------+
    | Memory Section   | Physical Address   | Size    | Description                |

--- a/source/linux/Foundational_Components_IPC62x.rst
+++ b/source/linux/Foundational_Components_IPC62x.rst
@@ -158,7 +158,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.12.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 +------------------+--------------------+---------+----------------------------+
 | Memory Section   | Physical Address   | Size    | Description                |

--- a/source/linux/Foundational_Components_IPC64x.rst
+++ b/source/linux/Foundational_Components_IPC64x.rst
@@ -163,7 +163,7 @@ R5F subsystems are operating in Split mode. If an R5F subsystem is run in
 Single-CPU mode, then R5F Core0 continues to use memory carveouts. However,
 R5F Core1 is unused in Single-CPU mode, so the Core1 memory carveouts can be
 reallocated to other cores. See the devicetree bindings documentation for more
-details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-5.10.y>`__
+details: :ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 ::
 

--- a/source/linux/Foundational_Components_IPC_J7200.rst
+++ b/source/linux/Foundational_Components_IPC_J7200.rst
@@ -152,7 +152,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 

--- a/source/linux/Foundational_Components_IPC_J721E.rst
+++ b/source/linux/Foundational_Components_IPC_J721E.rst
@@ -224,7 +224,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 

--- a/source/linux/Foundational_Components_IPC_J721S2.rst
+++ b/source/linux/Foundational_Components_IPC_J721S2.rst
@@ -178,7 +178,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 

--- a/source/linux/Foundational_Components_IPC_J722S.rst
+++ b/source/linux/Foundational_Components_IPC_J722S.rst
@@ -158,7 +158,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 

--- a/source/linux/Foundational_Components_IPC_J742S2.rst
+++ b/source/linux/Foundational_Components_IPC_J742S2.rst
@@ -195,7 +195,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 

--- a/source/linux/Foundational_Components_IPC_J784S4.rst
+++ b/source/linux/Foundational_Components_IPC_J784S4.rst
@@ -201,7 +201,8 @@ System memory is carved out for each remote processor core for IPC and for the
 remote processor's code/data section needs. The default
 memory carveouts (DMA pools) are shown below.
 
-See the devicetree bindings documentation for more details: `Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/Documentation/devicetree/bindings/remoteproc/ti,k3-r5f-rproc.yaml?h=ti-linux-6.6.y>`__
+See the devicetree bindings documentation for more details:
+:ti-linux-kernel-binding:`remoteproc/ti,k3-r5f-rproc.yaml`
 
 .. code-block:: text
 


### PR DESCRIPTION
- feat(extlinks): use ti-linux-kernel-binding role

  Use the new ti-linux-kernel-binding role provided through extlinks to reduce
  text and allow for quick branch changes.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- feat(extlinks): add extlinks and a suitable config

  Add the extlinks sphinx extensions and a basic JSON configuration file that we
  will load during the build. The conf.py is already pretty unwieldy so keeping
  this separate is probably a good idea.

  Signed-off-by: Randolph Sapp <rs@ti.com>

