### PR TITLE
fix(linux): Update urls to latest 11.01 MCU+SDK Docs

### DIFF
--- a/source/devices/AM62PX/index_RTOS.rst
+++ b/source/devices/AM62PX/index_RTOS.rst
@@ -8,4 +8,4 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_00_16/exports/docs/api_guide_am62px/index.html>`__

--- a/source/devices/AM62X/index_RTOS.rst
+++ b/source/devices/AM62X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/11_01_00_16/exports/docs/api_guide_am62x/index.html>`__
 

--- a/source/devices/AM64X/index_RTOS.rst
+++ b/source/devices/AM64X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/api_guide_am64x/index.html>`__
 


### PR DESCRIPTION
Updating MCU SDK Doc Urls to the latest SDK release 11.01 