### PR TITLE
fix(pm_low_power_modes): Add data type to devmem2 command

### DIFF
--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -132,8 +132,8 @@ I/O Only Plus DDR
 
    .. code-block:: console
 
-      root@<machine>:~# devmem2 0x4084014 0x20050000  # MCU_PADCONFIG5 for mcu_uart0
-      root@<machine>:~# devmem2 0x4084024 0x20050000  # MCU_PADCONFIG9 for wkup_uart0
+      root@<machine>:~# devmem2 0x4084014 w 0x20050000  # MCU_PADCONFIG5 for mcu_uart0
+      root@<machine>:~# devmem2 0x4084024 w 0x20050000  # MCU_PADCONFIG9 for wkup_uart0
 
    .. note::
 


### PR DESCRIPTION
Fix the devmem2 command to program the mcu_uart0 and wkup_uart0 by adding the data type of word to the command. Without having the data type in the command, it leads the command to fail.