### PR TITLE
fix: debian: Remove redundant feedback text

### DIFF
--- a/source/debian/_Debian_Developers_Guide.rst
+++ b/source/debian/_Debian_Developers_Guide.rst
@@ -3,7 +3,5 @@ Thank you for choosing to evaluate one of our `TI Processors
 of the Box experience is designed to quickly
 provide the information you need most while evaluating a TI
 microprocessor, specifically running one of the Software Architectures
-available, embedded Linux. We are always striving to improve this
-product. Please let us know if you have :ref:`ideas or
-suggestions <Feedback>`.
+available, Embedded Linux.
 

--- a/source/devices/AM62LX/debian/index.rst
+++ b/source/devices/AM62LX/debian/index.rst
@@ -26,9 +26,9 @@ Debian Developer's Guide
 .. rubric:: Feedback
    :name: feedback
 
-If you have feedback, suggestions, or ideas on how to improve the SDK
-or docs, it is very appreciated. Please post your ideas to the Linux
-forum listed at :ref:`Technical Support <technical-support>`.
+We are always striving to improve this product. If you have feedback, suggestions,
+or ideas on how to improve the SDK or docs, it is very appreciated. Please post your
+ideas to the Linux forum listed at :ref:`Technical Support <technical-support>`.
 
 
 +--------------------------------+----------------------------------------------------------------------------------------------------+

--- a/source/devices/AM62PX/debian/index.rst
+++ b/source/devices/AM62PX/debian/index.rst
@@ -26,9 +26,9 @@ Debian Developer's Guide
 .. rubric:: Feedback
    :name: feedback
 
-If you have feedback, suggestions, or ideas on how to improve the SDK
-or docs, it is very appreciated. Please post your ideas to the Linux
-forum listed at :ref:`Technical Support <technical-support>`.
+We are always striving to improve this product. If you have feedback, suggestions,
+or ideas on how to improve the SDK or docs, it is very appreciated. Please post your
+ideas to the Linux forum listed at :ref:`Technical Support <technical-support>`.
 
 
 +--------------------------------+----------------------------------------------------------------------------------------------------+

--- a/source/devices/AM62X/debian/index.rst
+++ b/source/devices/AM62X/debian/index.rst
@@ -26,9 +26,9 @@ Debian Developer's Guide
 .. rubric:: Feedback
    :name: feedback
 
-If you have feedback, suggestions, or ideas on how to improve the SDK
-or docs, it is very appreciated. Please post your ideas to the Linux
-forum listed at :ref:`Technical Support <technical-support>`.
+We are always striving to improve this product. If you have feedback, suggestions,
+or ideas on how to improve the SDK or docs, it is very appreciated. Please post your
+ideas to the Linux forum listed at :ref:`Technical Support <technical-support>`.
 
 
 +--------------------------------+----------------------------------------------------------------------------------------------------+

--- a/source/devices/AM64X/debian/index.rst
+++ b/source/devices/AM64X/debian/index.rst
@@ -24,9 +24,9 @@ Debian Developer's Guide
 .. rubric:: Feedback
    :name: feedback
 
-If you have feedback, suggestions, or ideas on how to improve the SDK
-or docs, it is very appreciated. Please post your ideas to the Linux
-forum listed at :ref:`Technical Support <technical-support>`.
+We are always striving to improve this product. If you have feedback, suggestions,
+or ideas on how to improve the SDK or docs, it is very appreciated. Please post your
+ideas to the Linux forum listed at :ref:`Technical Support <technical-support>`.
 
 
 +--------------------------------+----------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
In "Welcome to Debian Developer's Guide" section, we are asking people to let us know if they have any ideas by clicking on a hyperlink. The hyperlink leads people to the "Feedback" section, which is the next section on the same page. Unless one is eyeing the address bar on their browser, this gives the effect that the link led nowhere.

Since "Feedback" is the next section, where we ask for ideas anyway, the whole "Please let us know if you have ideas" line is redundant.

So fix this by removing the redundant line.