### PR TITLE
fix(linux): Updated 11.01 MCU+SDK Docs URLs for released devices

### DIFF
--- a/source/devices/AM62PX/index_RTOS.rst
+++ b/source/devices/AM62PX/index_RTOS.rst
@@ -8,4 +8,4 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/10_01_00_33/exports/docs/api_guide_am62px/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_00_16/exports/docs/api_guide_am62px/index.html>`__

--- a/source/devices/AM62X/index_RTOS.rst
+++ b/source/devices/AM62X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/10_01_00_33/exports/docs/api_guide_am62x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/11_01_00_16/exports/docs/api_guide_am62x/index.html>`__
 

--- a/source/devices/AM64X/index_RTOS.rst
+++ b/source/devices/AM64X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/api_guide_am64x/index.html>`__
 

--- a/source/devices/AM64X/linux/Overview/Build_and_Run_the_Demos.rst
+++ b/source/devices/AM64X/linux/Overview/Build_and_Run_the_Demos.rst
@@ -29,9 +29,8 @@ Below is a list of build targets supported by processor SDK AM64x:
 Refer the respective user guides to build Linux and other RTOS/NO-RTOS packages
 
 -  For Linux Kernel, u-boot & DTB     `[Use Link] <../../../linux/Foundational_Components.html>`__
--  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/index.html>`__
--  For Industrial Protocols (ECAT)    `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/INDUSTRIAL_COMMS.html>`__
--  For Industrial Drives (EnDAT,HDSL) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/10_01_00_32/exports/docs/api_guide_am64x/EXAMPLES_MOTORCONTROL.html>`__
+-  For RTOS/NO-RTOS source (MCU+ SDK) `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/api_guide_am64x/index.html>`__
+-  For Industrial Protocols (ECAT)    `[Use Link] <https://software-dl.ti.com/processor-industrial-sw/esd/ind_comms_sdk/am64x/11_00_00_08/docs/api_guide_am64x/index.html>`__
 
 
 

--- a/source/linux/Foundational_Components/Sysfw.rst
+++ b/source/linux/Foundational_Components/Sysfw.rst
@@ -30,5 +30,5 @@ The responsibilities of Device Manager are:
 * Forwarding response received from the DMSC to non-secure hosts for the above
   forwarded messages.
 
-Please refer to `TISCI User Guide <https://software-dl.ti.com/tisci/esd/22_01_02/index.html>`__
+Please refer to `TISCI User Guide <https://software-dl.ti.com/tisci/esd/11_01_02/index.html>`__
 for details.


### PR DESCRIPTION
Most of the links are updated with the latest string.
Trying to maintain the index.html with version controlled  to identify a specific release documentation.
* AM62, AM62P and AM64 are updated.
* SysFW old link is now pointed to the updated SDK release version 11.01.02. @kavitha-malarvizhi, please verify the same.
* INDUSTRIAL COMM SDK is updated to the latest ECAT reference.
* MOTOR CONTROL for AM64 is obsolete so removed.