### PR TITLE
fix(linux): Fix broken link to MMC u-boot docs

### DIFF
--- a/.github/styles/config/vocabularies/PSDK/accept.txt
+++ b/.github/styles/config/vocabularies/PSDK/accept.txt
@@ -28,3 +28,5 @@ Weston
 Trixie
 mmdebstrap
 bdebstrap
+fdisk
+umount

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -367,6 +367,55 @@ Driver Configuration
 
 |
 
+.. _mmc-support-linux:
+
+MMC support in Linux
+********************
+
+.. ifconfig:: CONFIG_part_family in ('AM62PX_family')
+
+   **eMMC HS400 support**
+
+   For 11.0 and 11.1 SDK, am62px device does not support eMMC HS400 mode due to errata `i2458 <https://www.ti.com/lit/pdf/sprz574>`__.
+   If support for HS400 is required, please add the following to k3-am62p-j722s-common-main.dtsi:
+
+   .. code-block:: diff
+
+      diff --git a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      index 3e5ca8a3eb86..a05b22a6e5a2 100644
+      --- a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      +++ b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
+      @@ -593,12 +593,16 @@ sdhci0: mmc@fa10000 {
+                      bus-width = <8>;
+                      mmc-ddr-1_8v;
+                      mmc-hs200-1_8v;
+      +               mmc-hs400-1_8v;
+                      ti,clkbuf-sel = <0x7>;
+                      ti,trm-icp = <0x8>;
+      +               ti,strobe-sel = <0x55>;
+                      ti,otap-del-sel-legacy = <0x1>;
+                      ti,otap-del-sel-mmc-hs = <0x1>;
+                      ti,otap-del-sel-ddr52 = <0x6>;
+                      ti,otap-del-sel-hs200 = <0x8>;
+      +               ti,otap-del-sel-hs400 = <0x5>; // at 0.85V VDD_CORE
+      +               //ti,otap-del-sel-hs400 = <0x7>; // at 0.75V VDD_CORE
+                      ti,itap-del-sel-legacy = <0x10>;
+                      ti,itap-del-sel-mmc-hs = <0xa>;
+                      ti,itap-del-sel-ddr52 = <0x3>;
+
+.. ifconfig:: CONFIG_part_family in ('AM62X_family')
+
+   **Missing eMMC support**
+
+   Support for eMMC is missing for AM62SIP SK in Processor SDK 11.01. Therefore, eMMC boot, reading/writting/accessing
+   the eMMC will not work on AM62SIP SK. If eMMC support is required, apply the following:
+   `commit <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/commit/?h=ti-linux-6.12.y&id=78e6abff3220>`__
+   in TI-Linux ti-linux-6.12.y branch to enable eMMC support in Linux.
+
+.. ifconfig:: CONFIG_part_family not in ('AM62X_family', 'AM62PX_family')
+
+   There is no missing MMC support for |__PART_FAMILY_DEVICE_NAMES__| device.
+
 .. ifconfig:: CONFIG_part_family not in ('General_family', 'AM57X_family', 'AM335X_family', 'AM437X_family')
 
    Steps for working around SD card issues in Linux
@@ -483,42 +532,7 @@ Driver Configuration
 
          sdhci2: mmc@fa20000 {
 
-eMMC HS400 support in Linux
-===========================
 
-.. ifconfig:: CONFIG_part_family in ('AM62PX_family')
-
-   For 11.0 SDK, am62px device does not support eMMC HS400 mode due to errata i2458.
-   If support for HS400 is anyways required, please add the following DT attributes to sdhci0 node:
-
-   .. code-block:: diff
-
-      diff --git a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
-      index 3e5ca8a3eb86..a05b22a6e5a2 100644
-      --- a/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
-      +++ b/arch/arm64/boot/dts/ti/k3-am62p-j722s-common-main.dtsi
-      @@ -593,12 +593,16 @@ sdhci0: mmc@fa10000 {
-                      bus-width = <8>;
-                      mmc-ddr-1_8v;
-                      mmc-hs200-1_8v;
-      +               mmc-hs400-1_8v;
-                      ti,clkbuf-sel = <0x7>;
-                      ti,trm-icp = <0x8>;
-      +               ti,strobe-sel = <0x55>;
-                      ti,otap-del-sel-legacy = <0x1>;
-                      ti,otap-del-sel-mmc-hs = <0x1>;
-                      ti,otap-del-sel-ddr52 = <0x6>;
-                      ti,otap-del-sel-hs200 = <0x8>;
-      +               ti,otap-del-sel-hs400 = <0x5>; // at 0.85V VDD_CORE
-      +               //ti,otap-del-sel-hs400 = <0x7>; // at 0.75V VDD_CORE
-                      ti,itap-del-sel-legacy = <0x10>;
-                      ti,itap-del-sel-mmc-hs = <0xa>;
-                      ti,itap-del-sel-ddr52 = <0x3>;
-
-.. ifconfig:: CONFIG_part_family not in ('AM62PX_family')
-
-	eMMC HS400 is not suppported, refer to :ref:`this <mmc-sd-supported-hs-modes>` table for the list of modes supported in Linux
-	for |__PART_FAMILY_NAME__| SoC.
 
 |
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Storage/MMC-SD.rst
@@ -1,22 +1,28 @@
 .. http://processors.wiki.ti.com/index.php/Linux_Core_MMC/SD_User%27s_Guide
 
-MMC/SD
-######
+MMCSD
+#####
+
+.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62PX_family')
+
+   .. warning::
+
+      There is important information on multimedia card (MMC) support for |__PART_FAMILY_DEVICE_NAMES__| device, go
+      :ref:`here <mmc-support-linux>` for more information.
 
 Introduction
 ************
 
-The multimedia card high-speed/SDIO (MMC/SDIO) host controller provides
-an interface between a local host (LH) such as a microprocessor unit
-(MPU) or digital signal processor (DSP) and either MMC, SD® memory
-cards, or SDIO cards and handles MMC/SDIO transactions with minimal LH
-intervention.
+The multimedia card secure digital (MMCSD) host controller provides an interface between a local host (LH)
+such as a microprocessor unit (MPU) or digital signal processor (DSP) and either embedded multimedia card (eMMC),
+secure digital (SD), or secure digital input/output (SDIO) devices. The MMCSD host controller handles MMCSD and
+SDIO protocol with minimal LH intervention.
 
 .. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
-   Main features of the MMC/SDIO host controllers:
+   Main features of the MMCSD host controllers:
 
-   -  Full compliance with MMC/SD command/response sets as defined in the
+   -  Full compliance with MMCSD command/response sets as defined in the
       Specification.
 
    -  Support:
@@ -29,9 +35,9 @@ intervention.
       -  Two slave DMA channels (1 for TX, 1 for RX)
       -  Designed for low power and programmable clock generation
       -  Maximum operating frequency of 48MHz
-      -  MMC/SD card hot insertion and removal
+      -  MMCSD card hot insertion and removal
 
-The following image shows the MMC/SD Driver Architecture:
+The following image shows the MMCSD Driver Architecture:
 
 .. Image:: /images/Mmcsd_Driver.png
 
@@ -41,23 +47,6 @@ References
 #. `JEDEC eMMC homepage <http://www.jedec.org/category/technology-focus-area/flash-memory-ssds-ufs-emmc//>`__
 #. `SD organization homepage <http://www.sdcard.org//>`__
 
-Acronyms & Definitions
-**********************
-
-+-----------+--------------------+
-| Acronym   | Definition         |
-+===========+====================+
-| MMC       | Multimedia Card    |
-+-----------+--------------------+
-| HS-MMC    | High Speed MMC     |
-+-----------+--------------------+
-| SD        | Secure Digital     |
-+-----------+--------------------+
-| SDHC      | SD High Capacity   |
-+-----------+--------------------+
-| SDIO      | SD Input/Output    |
-+-----------+--------------------+
-
 Features
 ********
 
@@ -66,12 +55,12 @@ Features
    The SD driver supports the following features:
 
    -  The driver is built in-kernel (part of vmlinux)
-   -  SD cards including SD High Speed and SDHC cards
+   -  SD cards including SD High Speed and secure digital high capacity (SDHC) cards
    -  Uses block bounce buffer to aggregate scattered blocks
 
 .. ifconfig:: CONFIG_part_family in ('J7_family')
 
-   The SD/MMC driver supports the following features:
+   The MMCSD driver supports the following features:
 
    - Support ADMA for DMA transfers
    - HS400 speed mode
@@ -80,17 +69,17 @@ Features
 
 .. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62AX_family', 'AM64X_family', 'AM62LX_family', 'AM62PX_family')
 
-   The SD/MMC driver supports the following features:
+   The MMCSD driver supports the following features:
 
    - Support ADMA for DMA transfers
    - HS200 speed mode
    - Support for both built-in and module mode
    - ext2/ext3/ext4 file system support
 
-.. _mmc-sd-supported-hs-modes:
+.. _mmc-supported-uhs-modes:
 
-SD: Supported High Speed Modes
-******************************
+Supported ultra high speed (UHS) modes
+**************************************
 
 .. ifconfig:: CONFIG_part_family in ('General_family', 'AM57X_family', 'AM65X_family')
 
@@ -153,9 +142,9 @@ SD: Supported High Speed Modes
    | PATRIOT 8G UHS CARD - Voltage switching fails and enumerates in high speed   |
    +------------------------------------------------------------------------------+
 
-   **Known Workaround**: For cards which doesn't enumerate in UHS mode,
+   **Known Workaround**: For cards that don't enumerate in UHS mode,
    removing the PULLUP resistor in CLK line and changing the GPIO to
-   PULLDOWN increases the frequency in which the card enumerates in UHS
+   PULLDOWN increases the frequency that the card enumerates in UHS
    modes.
 
    +--------------------+-------+---------+
@@ -236,14 +225,14 @@ SD: Supported High Speed Modes
       am62px, Y, Y, N
       am62lx, Y, Y, N
 
-Driver Configuration
+Driver configuration
 ********************
 
 .. ifconfig:: CONFIG_part_family in ('General_family', 'AM335X_family', 'AM437X_family', 'AM57X_family')
 
-   The default kernel configuration enables support for MMC/SD(built-in to kernel).
+   The default kernel configuration enables support for MMCSD(built-in to kernel).
 
-   The selection of MMC/SD/SDIO driver can be modified using the linux kernel
+   The selection of MMCSD/SDIO driver can be modified using the linux kernel
    configuration tool. Launch it by the following command:
 
    .. code-block:: console
@@ -270,7 +259,7 @@ Driver Configuration
 
       $ sudo -E make modules_install ARCH=arm INSTALL_MOD_PATH=path/to/filesystem
 
-   Boot the kernel upto kernel prompt and use modprobe to insert the driver
+   Boot the kernel up-to kernel prompt and use modprobe to insert the driver
    module and all its dependencies.
 
    .. code-block:: console
@@ -284,7 +273,7 @@ Driver Configuration
 
 .. ifconfig:: CONFIG_part_family in ('J7_family', 'AM62X_family', 'AM64X_family', 'AM62AX_family', 'AM62PX_family', 'AM62LX_family')
 
-   The default kernel configuration enables support for MMC/SD driver as
+   The default kernel configuration enables support for MMCSD driver as
    built-in to kernel. TI SDHCI driver is used. Following options need to be
    configured in Linux Kernel for successfully selecting SDHCI driver for
    |__PART_FAMILY_DEVICE_NAMES__|.
@@ -331,7 +320,7 @@ Driver Configuration
    If an operation is delayed for too long, it becomes critical, taking
    priority over the regular read/write from host. This can cause host
    operations to be delayed or take more time than expected. To avoid such
-   issues the MMC HW and core driver provide a framework which can check
+   issues the multimedia card (MMC) HW and core driver provide a framework that can check
    for pending background operations and give the card some time to service
    them before they become critical. This feature is already part of the
    framework and to start using it the User needs to enable:
@@ -347,8 +336,8 @@ Driver Configuration
 
       root@<machine>:mmc bkops enable /dev/mmcblk0
 
-   You can find the instance of eMMC by reading the ios timing spec form
-   debugfs:
+   You can find the instance of eMMC by reading the ios timing spec from
+   debug filesystem (debugfs):
 
    .. code-block:: console
 
@@ -416,10 +405,10 @@ MMC support in Linux
 
    There is no missing MMC support for |__PART_FAMILY_DEVICE_NAMES__| device.
 
-.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM57X_family', 'AM335X_family', 'AM437X_family')
+Steps for working around SD card issues in Linux
+************************************************
 
-   Steps for working around SD card issues in Linux
-   ************************************************
+.. ifconfig:: CONFIG_part_family not in ('General_family', 'AM57X_family', 'AM335X_family', 'AM437X_family')
 
    In some cases, failures can be seen while using some SD cards:
 
@@ -465,7 +454,7 @@ MMC support in Linux
    #. Restricting to a given speed mode
 
       By default the kernel driver tries to enumerate an SD card in the highest supported
-      speed mode. Below is the order in which the driver tries to enumerate an SD card:
+      speed mode. Below is the order that the driver tries to enumerate an SD card:
 
          - SDR104
          - DDR50
@@ -495,7 +484,7 @@ MMC support in Linux
          };
 
       Limiting to SD HS speed mode can also be done by using the property
-      **no-1-8-v**. This disables switching to 1.8V which is required for
+      **no-1-8-v**. This disables switching to 1.8V, which is required for
       UHS speed modes(SDR104, DDR50, SDR50, SDR25, SDR12):
 
       .. code-block:: dts
@@ -532,7 +521,10 @@ MMC support in Linux
 
          sdhci2: mmc@fa20000 {
 
+.. ifconfig:: CONFIG_part_family in ('General_family', 'AM57X_family', 'AM335X_family', 'AM437X_family')
 
+   Steps for working around SD card issues in Linux documentation is pending for |__PART_FAMILY_DEVICE_NAMES__|
+   please reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
 
 |
 
@@ -540,8 +532,8 @@ MMC support in Linux
 
 Listing MMC devices from Linux
 ******************************
-eMMC and SD cards are registered to the MMC subsystem and availiable as a block device
-as :file:`/dev/mmcblk{n}`. To find which device index **n** corresponds to eMMC device,
+eMMC and SD cards register with the MMC subsystem and are available as a block device
+as :file:`/dev/mmcblk{n}`. To find the device index **n** corresponding to an eMMC device,
 check which device includes :file:`mmcblk{n}boot0` and :file:`mmcblk{n}boot1`. Here,
 mmcblk0* is in eMMC.
 
@@ -557,9 +549,9 @@ mmcblk0* is in eMMC.
    brw-rw---- 1 root disk 179, 97 Jan  1 00:00 /dev/mmcblk1p1
    brw-rw---- 1 root disk 179, 98 Jan  8  2025 /dev/mmcblk1p2
 
-The disk partitions for each MMC device are displayed as :file:`/dev/mmcblk{n}p{x}`,
-to see what disk partitions exist for an eMMC device and if they are mounted, use the
-command :command:`lsblk`, like so:
+The disk partitions for each MMC device are displayed as :file:`/dev/mmcblk{n}p{x}`.
+To check existing or mounted disk partitions for an eMMC device, use the
+command :command:`lsblk`, such as:
 
 .. code-block:: console
 
@@ -572,24 +564,24 @@ command :command:`lsblk`, like so:
    |-mmcblk1p1  179:97   0  128M  0 part /run/media/boot-mmcblk1p1
    `-mmcblk1p2  179:98   0  1.9G  0 part /
 
-Use the :command:`mount` and :command:`umount` commands to mount and unmount disk partitions
-if they are formated, usally to vfat or ext4 types.
+Use the :command:`mount` and :command:`umount` commands to mount and unmount formatted disk
+partitions, usually to virtual file allocation table (vfat) or fourth extended file system (ext4) types.
 
 .. _mmc-create-partitions-in-emmc-linux:
 
 Create partitions in eMMC UDA
 *****************************
 
-In eMMC, the User Data Area (UDA) HW partition is the primary storage space generally used
-to flash the rootfs. To create disk partitions in UDA, use the :command:`fdisk` command.
-For ex: :samp:`fdisk /dev/mmcblk{n}` in which **n** is typically 0 or 1. In the example above,
+In eMMC, the user data area (UDA) HW partition is the primary storage space generally used
+to flash the root filesystem (rootfs). To create disk partitions in UDA, use the :command:`fdisk` command.
+For ex: :samp:`fdisk /dev/mmcblk{n}` in which **n** is typically 0 or 1. In the previous example,
 eMMC is :samp:`fdisk /dev/mmcblk0`.
 
-For documentation on using fdisk, please go to: `fdisk how-to <https://tldp.org/HOWTO/Partition/fdisk_partitioning.html>`__.
+For documentation on using fdisk command, go to: `fdisk how-to <https://tldp.org/HOWTO/Partition/fdisk_partitioning.html>`__.
 
 **Erase eMMC UDA**
 
-In Linux, before creating disk partitions, we can optionally erase eMMC UDA using :command:`dd`
+In Linux, before creating disk partitions, we can optionally erase eMMC UDA by using :command:`dd`
 command:
 
 .. code-block:: console
@@ -597,7 +589,7 @@ command:
    root@<machine>:~# umount /dev/mmcblk0*
    root@<machine>:~# dd if=/dev/zero of=/dev/mmcblk0 bs=1M count=n
 
-where ``n`` should be determined according the the following formula: ``count = total size UDA (bytes) / bs``.
+where ``n`` should be determined according to the following formula: ``count = total size UDA (bytes) / bs``.
 
 .. _mmc-create-boot-partition-emmc-linux:
 
@@ -605,7 +597,7 @@ Create "boot" partition
 =======================
 
 In this example create a "boot" partition of size 400 MiB which can be formatted to vfat type
-and will store the bootloader binaries.
+and will store the boot loader binaries.
 
 .. code-block:: console
 
@@ -648,7 +640,7 @@ and will store the bootloader binaries.
    Calling ioctl() to re-read partition table.
    Syncing disks.
 
-Make sure bootable flag is set for "boot" partition, ROM may not boot from this patitition
+Make sure bootable flag is set for "boot" partition, ROM might not boot from this partition
 if bootable flag is not set.
 
 .. _mmc-create-root-partition-emmc-linux:
@@ -700,7 +692,7 @@ Linux kernel Image, DTB, and the rootfs.
 Formatting eMMC partitions from Linux
 *************************************
 
-After creating a partition/s, the partition can be formated with the :command:`mkfs` command.
+After creating a partition/s, the partition can be formatted with the :command:`mkfs` command.
 For ex: :samp:`mkfs -t ext4 /dev/mmcblk{n}` where **mmcblk{n}** is the MMC device with the new
 disk partitions to format. The general syntax for formatting disk partitions in Linux is:
 
@@ -754,10 +746,10 @@ Flash eMMC for MMCSD boot
 *************************
 
 In this example, we show one simple method for flashing to eMMC for MMCSD boot from
-eMMC UDA in FS mode. Please know this is not the only method for flashing the eMMC
-for this bootmode.
+eMMC UDA in filesystem (FS) mode. Know this is not the only method for flashing the eMMC for this
+boot mode.
 
-This example assumes the current bootmode is MMCSD boot from SD (FS mode)
+This example assumes the current boot mode is MMCSD boot from SD (FS mode)
 
 .. _mmc-flash-emmc-uda-boot:
 
@@ -771,7 +763,7 @@ Flash to eMMC "boot" partition
    root@<machine>:~# mount /dev/mmcblk0p1 /mnt/eboot
    root@<machine>:~# mount /dev/mmcblk1p1 /mnt/sdboot
 
-Verify the partitions are mounted to the correct folders using :command:`lsblk` command in the
+Verify the partitions are mounted to the correct folders by using :command:`lsblk` command in the
 column labeled :file:`MOUNTPOINTS`.
 
 .. code-block:: console
@@ -787,7 +779,7 @@ column labeled :file:`MOUNTPOINTS`.
    |-mmcblk1p1  179:97   0  128M  0 part /mnt/sdboot
    `-mmcblk1p2  179:98   0  8.7G  0 part /
 
-Now we can copy bootloader binaries to eMMC and umount the partitions when writes finish.
+Now we can copy boot loader binaries to eMMC and umount the partitions when writes finish.
 
 .. code-block:: console
 
@@ -809,7 +801,7 @@ Flash to eMMC "root" partition
    [69229.982452] EXT4-fs (mmcblk0p2): mounted filesystem 74d40075-07e4-4bce-9401-6fccef68e934 r/w with ordered data mode. Quota mode: none.
    root@<machine>:~# mount /dev/mmcblk1p2 /mnt/sdroot
 
-Verify the partitions are mounted to the correct folders using :command:`lsblk` command in the
+Verify the partitions are mounted to the correct folders by using :command:`lsblk` command in the
 column labeled :file:`MOUNTPOINTS`.
 
 .. code-block:: console
@@ -826,7 +818,7 @@ column labeled :file:`MOUNTPOINTS`.
    `-mmcblk1p2  179:98   0  8.7G  0 part /mnt/sdroot
                                          /
 
-Now we can copy rootfs to eMMC (either from SD rootfs or from tarball) and umount the partitions
+Now we can copy rootfs to eMMC (either from SD rootfs or from tar file) and umount the partitions
 when writes finish.
 
 **From SD**
@@ -841,7 +833,7 @@ when writes finish.
    root@<machine>:~# umount /mnt/*
    [70154.205154] EXT4-fs (mmcblk0p2): unmounting filesystem 74d40075-07e4-4bce-9401-6fccef68e934.
 
-**From tarball**
+**From tar file**
 
 This sections requires for tisdk-base-image-<soc>evm.rootfs.tar.xz to have been previously copied
 to the SD card rootfs.

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -83,8 +83,8 @@ boot the device.
 .. note::
 
    For eMMC, typically, the device ships without a partition table If there is a need to
-   create a partition in UDA, please go :ref:`here <mmc-create-partitions-in-emmc-uda-from-linux>`
-   and to format the partition go :ref:`here <mmc-formatting-mmc-partition-from-linux>` before
+   create a partition in UDA, please go :ref:`here <mmc-create-partitions-in-emmc-linux>`
+   and to format the partition go :ref:`here <mmc-format-partition-linux>` before
    proceeding.
 
 To list disk partitions for any MMC device from u-boot prompt, use the

--- a/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Memory-K3.rst
@@ -1,11 +1,20 @@
 SD, eMMC and USB
 ################
 
-The following guide shows how to flash and boot from storage media like the
-embedded multimedia card (eMMC), secure digital (SD) card, and USB storage
-devices. While this is a step-by-step guide, it is in no way extensive and
-does not cover all the per-platform corner-cases. For any  issues/questions
-on this guide, please reach out to: `Help e2e <https://e2e.ti.com//>`__.
+.. ifconfig:: CONFIG_part_family in ('AM62X_family', 'AM62PX_family')
+
+   .. warning::
+
+      There is important information on multimedia card (MMC) support for |__PART_FAMILY_DEVICE_NAMES__| device, go
+      :ref:`here <uboot-mmc-support>` for more information.
+
+Overview
+********
+
+The following guide shows how to flash and boot from storage media such as the embedded multimedia
+card (eMMC), secure digital (SD) card, and USB storage devices. While this is a step-by-step guide,
+it is in no way extensive and does not cover all the per-platform corner-cases.
+For any  issues or questions on this guide, reach out to: `Help e2e <https://e2e.ti.com//>`__.
 
 MMC
 ***
@@ -15,7 +24,7 @@ MMC
 Listing MMC devices
 ===================
 
-Usually in all the platforms there will be two MMC instances of which one
+Usually in all the platforms there will be two multimedia card (MMC) instances of which one
 would be SD and the other would be eMMC. The device index of them can vary from
 one class of platforms to the other. For a given platform, the device index
 can be found in the following way:
@@ -29,7 +38,7 @@ can be found in the following way:
 The device index "**0**" for eMMC will be used when flashing to the eMMC device
 :ref:`here <how-to-emmc-boot>` using :command:`mmc dev` command.
 
-In u-boot environment, usually **mmcdev=n** is used to selct which MMC device to boot
+In u-boot environment, usually **mmcdev=n** is used to select which MMC device to boot
 Linux from, where **n** is the device index.
 
 MMC HW partitions
@@ -39,15 +48,15 @@ This sections includes a summary of MMC hardware partitions.
 
 **eMMC**
 
-   Normally eMMC is divided into 4 areas (aka HW partitions):
+   Normally eMMC is divided into 4 areas (also known as HW partitions):
 
-   - UDA (User Data Area): Used to store user data such as a file system. This partition can divided into disk partitions
+   - User data area (UDA): Used to store user data such as a file system. This partition can divided into disk partitions
    - Boot0/1: Used to store firmware and data needed during boot
-   - RPMB (Replay-protected memory-block area): Used to store secure data
+   - Replay protected memory block (RPMB) : Used to store secure data
 
 **SD**
 
-   SD card memory is not divided into sections like eMMC, but acts like UDA in eMMC where user can
+   SD card memory is not divided into sections such as eMMC, but acts like UDA in eMMC where user can
    create disk partitions in software allowing to divide the storage space into multiple sections.
 
 .. _uboot-selecting-mmc-device-and-partitions:
@@ -55,7 +64,7 @@ This sections includes a summary of MMC hardware partitions.
 Selecting MMC device and partitions
 ===================================
 
-To selct an MMC device in u-boot, the command: :command:`mmc dev` could be used.
+To select an MMC device in u-boot, the command: :command:`mmc dev` could be used.
 The general syntax is:
 
 .. code-block:: console
@@ -83,7 +92,7 @@ boot the device.
 .. note::
 
    For eMMC, typically, the device ships without a partition table If there is a need to
-   create a partition in UDA, please go :ref:`here <mmc-create-partitions-in-emmc-linux>`
+   create a partition in UDA, go :ref:`here <mmc-create-partitions-in-emmc-linux>`
    and to format the partition go :ref:`here <mmc-format-partition-linux>` before
    proceeding.
 
@@ -139,26 +148,26 @@ Where the general syntax is:
 
    $ ls <interface> [<dev[:partition]> [directory]]
 
-MMC supported bootmodes
+MMC supported boot modes
 ========================
 
-The K3 based processors support and recommends using *eMMC boot* from Boot0/1. For complete
-information on the MMC bootmodes supported by ROM, please refer to the device specific TRM,
-under: :file:`Initialization/Boot Mode Pins`. ROM supports the following two MMC bootmodes:
+The K3 based processors support and recommends using *eMMC boot* from Boot0 or Boot1. For complete
+information on the MMC boot modes supported by ROM, refer to the device specific TRM,
+under: :file:`Initialization/Boot Mode Pins`. ROM supports the following two MMC boot modes:
 
 **eMMC boot**
 
-   This bootmode is a special bootmode specific to eMMC device. In this bootmode, ROM cannot
-   boot from SD and can only boot from Boot0 or Boot1 in eMMC. Please go :ref:`here <how-to-emmc-boot>`
-   for a step-by-step guide to boot with this bootmode.
+   This boot mode is a special boot mode specific to eMMC device. In this boot mode, ROM cannot
+   boot from SD and can only boot from Boot0 or Boot1 in eMMC. Go :ref:`here <how-to-emmc-boot>`
+   for a step-by-step guide to boot with this boot mode.
 
 **MMCSD boot**
 
-   This bootmode allows to boot from either eMMC or SD device. With this bootmode, ROM can
-   only boot from SD card or UDA in eMMC. ROM allows to boot in RAW or FS mode, FS mode being
-   the recommended option and hence will have a subsequent guide to boot using this mode. Configuration
-   for selecting MMC device and RAW/FS mode, is done with bootmode pins, please refer to TRM for this
-   setup. To boot from eMMC UDA in FS mode, please go :ref:`here <how-to-mmcsd-boot-from-emmc-uda>`.
+   This boot mode allows to boot from either eMMC or SD device. With this boot mode, ROM can
+   only boot from SD card or UDA in eMMC. ROM allows to boot in raw or filesystem (FS) mode, FS mode being
+   the recommended option and therefore will have a subsequent guide to boot using this mode. Configuration
+   for selecting MMC device and raw/FS mode, is done with boot mode pins, refer to TRM for this
+   setup. To boot from eMMC UDA in FS mode, go :ref:`here <how-to-mmcsd-boot-from-emmc-uda>`.
 
 Flashing an MMC device using USB-DFU
 ====================================
@@ -167,17 +176,17 @@ To flash the eMMC device (Boot0) using USB-DFU, the device should
 be booted to u-boot prompt and a USB cable connected from the host machine
 to the device USB port configured to USB peripheral mode.
 
-From u-boot prompt execute the following:
+From u-boot prompt enter the following:
 
 .. code-block:: console
 
    => setenv dfu_alt_info ${dfu_alt_info_emmc}
    => dfu 0 mmc 0
 
-This comands assumes eMMC device exists and is mmc device 0.
+This command assumes eMMC device exists and is MMC device 0.
 
-On the host machine have the bootloader binaries ready to flash
-to eMMC Boot0. Execute the :command:`dfu-util` to transfer
+On the host machine have the boot loader binaries ready to flash
+to eMMC Boot0. Run the :command:`dfu-util` to transfer
 files to the device. The general syntax for dfu-util command is:
 
 .. code-block:: console
@@ -198,7 +207,7 @@ To see what are the dfu-targets, on the host machine run: :samp:`sudo dfu-util -
    Found DFU: [0451:6165] ver=0223, devnum=32, cfg=1, intf=0, path="1-10", alt=1, name="rootfs", serial="0000000000000591"
    Found DFU: [0451:6165] ver=0223, devnum=32, cfg=1, intf=0, path="1-10", alt=0, name="rawemmc", serial="0000000000000591"
 
-Then transfer each desired binary from the host to the device:
+Then transfer each binary from the host to the device:
 
 - Host:
 
@@ -222,8 +231,8 @@ Then transfer each desired binary from the host to the device:
 Flashing an SD card from a host PC
 ==================================
 
-This section assumes that you have flashed an SD card using the
-script "create-sdcard.sh" packaged in the installer or have
+This section assumes that you have flashed an SD card by using the
+script "create-sdcard.sh" packaged in the installation program or have
 made a compatible layout manually. In this case, you will need
 to copy the boot images:
 
@@ -253,7 +262,7 @@ Configuring USB in Host Mode
 .. ifconfig:: CONFIG_part_variant not in ('J721E', 'J7200', 'J721S2', 'AM64X', 'AM62X', 'AM65X')
 
    Configuring USB in host mode documentation is pending for |__PART_FAMILY_DEVICE_NAMES__|
-   please reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
+   reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
 
 .. ifconfig:: CONFIG_part_variant in ('J721E', 'J7200', 'J721S2')
 
@@ -388,7 +397,7 @@ Configuring USB in Host Mode
    Loading images from USB storage
    ===============================
 
-   For loading images from a FAT partition on a different media than mmc, replace
+   For loading images from a FAT partition on a different media than MMC, replace
    the :command:`mmc` command with the required media. For example, to load images
    from a FAT partition on a USB storage device connected to the zeroth instance
    of USB:
@@ -405,14 +414,14 @@ Flash and boot SPL from USB storage
 .. ifconfig:: CONFIG_part_variant not in ('J7200', 'J721E', 'AM64X', 'AM65X', 'J722S')
 
    Boot SPL from USB storage documentation is pending for |__PART_FAMILY_DEVICE_NAMES__|
-   please reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
+   reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
 
 .. ifconfig:: CONFIG_part_variant in ('J7200', 'J721E')
 
    .. note::
 
       The SoC does not support booting from USB mass storage, but USB can still be
-      accesed as storage device at U-Boot prompt.
+      accessed as storage device at U-Boot prompt.
 
 .. ifconfig:: CONFIG_part_variant in ('AM64X', 'AM65X', 'J722S')
 
@@ -421,15 +430,15 @@ Flash and boot SPL from USB storage
       Booting to U-Boot prompt from USB storage is supported. The following are the
       steps to be followed:
 
-      - Build the bootloader images using default "am64x_evm_r5_defconfig" and
+      - Build the boot loader images using default "am64x_evm_r5_defconfig" and
         "am64x_evm_a53_defconfig" configs files. For instructions to build the
-        bootloader images please refer to :ref:`Build-U-Boot-label`.
+        boot loader images, refer to :ref:`Build-U-Boot-label`.
       - Create a FAT32 partition with boot flag enabled on the USB storage device.
-      - Copy the bootloader images(tiboot3.bin, tispl.bin, u-boot.img) into the
+      - Copy the boot loader images(tiboot3.bin, tispl.bin, u-boot.img) into the
         above created partition.
       - Set the boot mode switches to usb host mode (For boot switch details refer to the
         **Initialization/Boot Mode Pins** chapter of TRM.)
-      - Connect the USB Mass storage device with the bootloader images and boot up
+      - Connect the USB Mass storage device with the boot loader images and boot up
         the board.
       - The board should now boot to u-boot prompt.
 
@@ -438,15 +447,15 @@ Flash and boot SPL from USB storage
       Booting to U-Boot prompt from USB storage is supported. The following are the
       steps to be followed:
 
-      - Build the bootloader images using the "am65x_evm_r5_usbmsc_defconfig"
+      - Build the boot loader images using the "am65x_evm_r5_usbmsc_defconfig"
         and "am65x_evm_a53_defconfig" configs files. For instructions to build the
-        bootloader images please refer to :ref:`Build-U-Boot-label`.
+        boot loader images, refer to :ref:`Build-U-Boot-label`.
       - Create a FAT32 partition with boot flag enabled on the USB storage device.
-      - Copy the bootloader images(tiboot3.bin, sysfw.itb, tispl.bin, u-boot.img)
+      - Copy the boot loader images(tiboot3.bin, sysfw.itb, tispl.bin, u-boot.img)
         into the above created partition.
       - Set the boot mode switches to usb host mode (For boot switch details refer to the
         **Initialization/Boot Mode Pins** chapter of TRM.)
-      - Connect the USB Mass storage device with the bootloader images and boot up
+      - Connect the USB Mass storage device with the boot loader images and boot up
         the board.
       - The board should now boot to u-boot prompt.
 
@@ -456,21 +465,21 @@ Flash and boot SPL from USB storage
       steps to be followed:
 
       - In U-Boot the USB controller can be used in either host or peripheral mode.
-        For booting to linux kernel from USB storage device, the USB port should be
+        For booting to Linux kernel from USB storage device, the USB port should be
         in host mode.
       - By default, USB0 is set to peripheral mode. Change this from peripheral to
         host mode.
-      - Build the bootloader images using the default "j722s_evm_r5_defconfig" and
+      - Build the boot loader images using the default "j722s_evm_r5_defconfig" and
         the config fragment "j722s_evm_r5_usbmsc.config" and "j722s_evm_a53_defconfig"
         configs files. The configs required for USB MSC boot are already enabled. For
-        instructions to build the bootloader images please refer to :ref:`Build-U-Boot-label`.
+        instructions to build the boot loader images, refer to :ref:`Build-U-Boot-label`.
       - Create a FAT32 partition with boot flag enabled on the USB storage device.
-      - Copy the bootloader images(tiboot3.bin, tispl.bin, u-boot.img) into the above
+      - Copy the boot loader images(tiboot3.bin, tispl.bin, u-boot.img) into the above
         created partition.
       - Set the boot mode switches to USB host boot mode (Refer to the **Initialization**
         chapter of TRM for boot switch details)
       - Make sure USB0 port in DRP mode: SW2[2:3] = 00
-      - Connect the USB Mass storage device with the bootloader images and boot up
+      - Connect the USB Mass storage device with the boot loader images and boot up
         the board.
 
    .. note::
@@ -487,8 +496,8 @@ Boot Linux from USB storage
 
 .. ifconfig:: CONFIG_part_family not in ('J7_family', 'AM62X_family', 'AM64X_family')
 
-   Booting Linux from USB storage documentation is pending for |__PART_FAMILY_DEVICE_NAMES__|
-   please reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
+   Booting Linux from USB storage documentation is pending for |__PART_FAMILY_DEVICE_NAMES__|,
+   reach out to:  `Help e2e <https://e2e.ti.com//>`__ for additional information.
 
 .. ifconfig:: CONFIG_part_family in ('J7_family')
 
@@ -504,7 +513,7 @@ Boot Linux from USB storage
       - U-Boot
 
          - In U-Boot, the USB controller can be used in either host or peripheral
-           mode. For booting to linux prompt. For USB storage device, the USB port has
+           mode. For booting to Linux prompt. For USB storage device, the USB port has
            to be set as host. By default, USB0 is set to peripheral mode. Change this
            from peripheral to host mode in u-boot DT.
 
@@ -557,12 +566,12 @@ Boot Linux from USB storage
    - U-Boot
 
       - In U-Boot the USB controller can be used in either host or peripheral mode. For
-        booting to linux kernel from USB storage device, the USB port is to be set as host.
+        booting to Linux kernel from USB storage device, the USB port is to be set as host.
       - By default, on AM625-SK board the zero instance of USB connected to the Type C
         port, is set to peripheral mode and the first instance of USB connected to the Type
         A port is set to host mode.
-      - Therefore, USB controller needs to be set host mode and custom bootloader images
-        are required to be built, if zeroth instance is used. Please refer to note in section
+      - Therefore, USB controller needs to be set host mode and custom boot loader images
+        are required to be built, if zeroth instance is used. Refer to note in section
         :ref:`uboot-configure-usb-in-host-mode`
 
    - Linux
@@ -613,13 +622,13 @@ Boot Linux from USB storage
    - U-Boot
 
       - In U-Boot the USB controller can be used in either host or peripheral mode. For
-        booting to linux kernel from USB storage device, the USB port is to be set as host.
+        booting to Linux kernel from USB storage device, the USB port is to be set as host.
       - By default, the USB controller is set in peripheral mode.
       - If the boot media used to boot to U-Boot is USB Host mode(:ref:`uboot-usb-msc-boot`)
         then, the USB controller is set to host mode during runtime. Therefore, no changes
         would be required in this case.
       - If a boot media other than USB Host is used, the USB controller needs to be set
-        host mode and custom bootloader images are required to be built. Please refer to note
+        host mode and custom boot loader images are required to be built. Refer to note
         in section :ref:`uboot-configure-usb-in-host-mode`
 
    - Linux
@@ -646,7 +655,7 @@ Boot Linux from USB storage
         file and modules. The USB Mass storage device should have two partitions:
 
       - boot
-         - For creating this parition please refer :ref:`uboot-usb-msc-boot`
+         - For creating this parition, refer to :ref:`uboot-usb-msc-boot`
       - rootfs
          - A partition with ext4 filesystem and the following images in /boot/ directory
             - Linux kernel **Image**
@@ -779,7 +788,7 @@ MMC support in u-boot
 Steps for working around SD card issues in u-boot
 =================================================
 
-In some cases, issues can be seen while using some SD cards, like:
+In some cases, issues can be seen while using some SD cards, such as:
 
 - Error while trying to initialize:
 

--- a/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
+++ b/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
@@ -201,9 +201,11 @@ possible to format a partition to ext4 in U-Boot, so the recommended process is 
 an SD card with TI SDK image, boot the device with SD card boot to Linux kernel prompt,
 and prepare eMMC UDA from Linux.
 
+Note that in the following examples the "root" partition is the second disk partition, in our
+case, "root" will be the first partition so replace :file:`/dev/mmcblk0p2` with :file:`/dev/mmcblk0p1`.
 First create a "root" partition to flash the rootfs as shown :ref:`here <mmc-create-root-partition-emmc-linux>`.
 The new disk partition should be formatted as ext4 type as shown :ref:`here <mmc-format-partition-ext4>`.
-Mount the new partition and flash the rootfs as shown  :ref:`here <mmc-flash-emmc-uda-root>`.
+Mount the new partition and flash the rootfs as shown :ref:`here <mmc-flash-emmc-uda-root>`.
 The Linux kernel :file:`Image` and DT file are expected to be in the /boot folder of the
 "root" partition in order for u-boot to find and load them.
 

--- a/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
+++ b/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
@@ -7,13 +7,13 @@ How to flash eMMC and boot with eMMC Boot
 Overview
 ========
 
-This how to guide allows to prepare and flash the eMMC device to boot using *eMMC boot*,
-that is, to boot from Boot0 or Boot1 eMMC hardware partitions and boot the rootfs from
-eMMC UDA.
+This how to guide allows to prepare and flash the embedded multimedia card (eMMC) device to
+boot using *eMMC boot*, that is, to boot from Boot0 or Boot1 eMMC hardware partitions and
+boot the root filesystem (rootfs) from eMMC user data area (UDA).
 
 .. note::
 
-   This process will require a working SD card that can boot the device to Linux kernel.
+   This process will require a working secure digital (SD) card that can boot the device to Linux kernel.
 
 .. _how-to-emmc-layout:
 
@@ -74,13 +74,13 @@ eMMC layout
       +----------------------------------+0x3E00   +-------------------------+
                    Boot0 (8 MB)                              UDA
 
-Flash bootloader binaries to eMMC
-=================================
+Flash boot loader binaries to eMMC
+==================================
 
 To boot with *eMMC boot* the eMMC needs to be prepared before hand. The recommended process
-is to flash an SD card with TI SDK image, copy the bootlader binaries that will be flashed to
+is to flash an SD card with TI SDK image, copy the boot loader binaries that will be flashed to
 eMMC in the SD card "boot" partition in emmc/ folder, boot the board with *MMCSD boot* from SD
-(FS mode), and proceed to flash the eMMC from either u-boot or linux.
+filesystem (FS) mode, and proceed to flash the eMMC from either u-boot or Linux.
 
 **Erase eMMC**
 
@@ -107,7 +107,7 @@ To erase boot1, replace ``mmc dev 0 1`` with ``mmc dev 0 2``.
 
 **Flash from u-boot**
 
-Stop at u-boot prompt and flash eMMC using :command:`fatload` and :command:`mmc write` commands
+Stop at u-boot prompt and flash eMMC by using :command:`fatload` and :command:`mmc write` commands
 to load binaries from SD card and flash them to eMMC Boot0.
 
 In this example, eMMC device is ``dev 0``, to find which device is eMMC, refer to
@@ -171,9 +171,9 @@ In this example, eMMC device is ``dev 0``, to find which device is eMMC, refer t
       => fatload mmc 1 ${loadaddr} emmc/sysfw.itb
       => mmc write ${loadaddr} 0x3600 0x800
 
-**Flash from linux**
+**Flash from Linux**
 
-At linux prompt, flash eMMC using :command:`cp` and :command:`dd` commands to load binaries
+At Linux prompt, flash eMMC by using :command:`cp` and :command:`dd` commands to load binaries
 from SD card and flash them to eMMC Boot0.
 
 In this example, eMMC is :file:`/dev/mmcblk0*` and SD :file:`/dev/mmcblk1*` to find which
@@ -191,15 +191,15 @@ eMMC Boot1 instead, replace ``mmcblk0boot0`` with ``mmcblk0boot1``.
 
 Where seek is the eMMC offset converted to decimal type. For example, for seek=1024, we are
 flashing to offset 0x400. Please refer :ref:`here <how-to-emmc-layout>` for the offsets in eMMC
-when flashing bootloader files.
+when flashing boot loader files.
 
 Flash rootfs to eMMC
 ====================
 
 To boot the rootfs from eMMC UDA, the eMMC needs to be prepared before hand. It is not
 possible to format a partition to ext4 in U-Boot, so the recommended process is to flash
-an SD card with TI SDK image, boot the device with SD card boot to linux kernel prompt,
-and prepre eMMC UDA from Linux.
+an SD card with TI SDK image, boot the device with SD card boot to Linux kernel prompt,
+and prepare eMMC UDA from Linux.
 
 First create a "root" partition to flash the rootfs as shown :ref:`here <mmc-create-root-partition-emmc-linux>`.
 The new disk partition should be formatted as ext4 type as shown :ref:`here <mmc-format-partition-ext4>`.
@@ -217,7 +217,7 @@ set configuration for *eMMC boot*.
 
 After flashing binaries to eMMC flash, the eMMC device Extended CSD register fields:
 BUS_WIDTH and PARTITION_CONFIG must be set so ROM will use the correct configuration
-for *eMMC boot*. Set using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
+for *eMMC boot*. Set by using the :command:`mmc bootbus` and :command:`mmc partconf` commands.
 Go to ``Boot from Boot0`` if booting for eMMC boot0. Alternatively, ``Boot from Boot1`` if
 booting from eMMC boot1.
 
@@ -230,9 +230,9 @@ booting from eMMC boot1.
 
    $ mmc partconf <dev> [[varname] | [<boot_ack> <boot_partition> <partition_access>]]
 
-Where <dev> is MMC device index.
+Where <dev> is mmc device index.
 
-- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
+- For more information on these commands, go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **Boot from Boot0**
 
@@ -253,7 +253,7 @@ Where <dev> is MMC device index.
    On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
    reset input signal will be ignored. Warm reset is required to be enabled in order
    for the eMMC to be in a "clean state" on power-on reset so that ROM can do
-   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
+   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and enter
    the following command:
 
 .. code-block:: console
@@ -262,7 +262,7 @@ Where <dev> is MMC device index.
 
 .. warning::
 
-   This is a write-once field. For more information, please refer to the u-boot
+   This is a write-once field. For more information, refer to the u-boot
    doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **U-boot environment**
@@ -299,12 +299,12 @@ First apply the following change in u-boot for any SoC.
     bootdir=/boot
     rd_spec=-
 
-Re-build bootloader binaries and copy build outputs to the SD card "boot" partition
+Re-build boot loader binaries and copy build outputs to the SD card "boot" partition
 and :file:`emmc/` folder. Proceed to flash eMMC with these binaries as shown in this
 step-by-step guide.
 
 Boot from eMMC boot partition
 =============================
 
-Finally we can proceed to change boot mode pins to *eMMC boot* as per specific TRM, under:
+Finally we can proceed to change boot mode pins to *eMMC boot* according to TRM, under:
 :file:`Initialization/Boot Mode Pins` and power cycle the board.

--- a/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
+++ b/source/linux/How_to_Guides/Target/How_to_emmc_boot.rst
@@ -232,7 +232,7 @@ booting from eMMC boot1.
 
 Where <dev> is MMC device index.
 
-- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **Boot from Boot0**
 
@@ -263,7 +263,7 @@ Where <dev> is MMC device index.
 .. warning::
 
    This is a write-once field. For more information, please refer to the u-boot
-   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **U-boot environment**
 

--- a/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
+++ b/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
@@ -91,7 +91,7 @@ Set using the :command:`mmc bootbus` and :command:`mmc partconf` commands. Go to
 
 Where <dev> is MMC device index.
 
-- For more information on these commands, please go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+- For more information on these commands, go `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **Boot from UDA**
 
@@ -115,7 +115,7 @@ Where <dev> is MMC device index.
 .. warning::
 
    This is a write-once field. For more information, please refer to the u-boot
-   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html//>`__.
+   doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **U-boot environment**
 

--- a/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
+++ b/source/linux/How_to_Guides/Target/How_to_mmcsd_boot_emmc_uda.rst
@@ -7,14 +7,14 @@ How to flash eMMC and boot from eMMC UDA
 Overview
 ========
 
-This how to guide allows to prepare and flash the eMMC device to boot using *MMCSD boot*,
-from eMMC UDA in fs mode.
+This how to guide allows to prepare and flash the embedded multimedia card (eMMC) device to boot using
+*MMCSD boot*, from eMMC UDA in filesystem (FS) mode.
 
 .. note::
 
-   This process will require a working SD card that can boot the device to Linux kernel.
+   This process will require a working (secure digital) SD card that can boot the device to Linux kernel.
 
-- To flash eMMC using a partitioned wic image from the SDK, go :ref:`here <how-to-flash-emmc-wic>`
+- To flash eMMC using a partitioned SD card image from the SDK, go :ref:`here <how-to-flash-emmc-wic>`
 - To flash eMMC manually, go :ref:`here <how-to-flash-emmc-manual>`
 
 .. _how-to-flash-emmc-wic:
@@ -23,7 +23,7 @@ Flash eMMC with disk image
 ==========================
 
 Copy the .wic formatted disk image from the SDK installer to target filesystem, boot the
-device via SD card boot and at linux prompt, find the eMMC block device as shown
+device via SD card boot and at Linux prompt, find the eMMC block device as shown
 :ref:`here <mmc-listing-mmc-devices-linux>` and flash the eMMC as shown below:
 
 .. code-block:: console
@@ -41,17 +41,17 @@ device via SD card boot and at linux prompt, find the eMMC block device as shown
 Manually flash eMMC device
 ==========================
 
-To boot with *MMCSD boot* from eMMC UDA in fs mode, the eMMC needs to be prepared before hand.
-The recommended process is to flash an SD card with TI SDK image, copy the bootlader binaries
+To boot with *MMCSD boot* from eMMC UDA in FS mode, the eMMC needs to be prepared before hand.
+The recommended process is to flash an SD card with TI SDK image, copy the boot loader binaries
 that will be flashed to eMMC in the SD card "boot" partition in :file:`emmc/` folder, boot the
 board with *MMCSD boot* from SD (FS mode), and proceed to create disk partitions and flash the
-eMMC from linux.
+eMMC from Linux.
 
 **Create disk partitions**
 
-In Linux, create a "boot" partition to store bootloader binaries as shown
+In Linux, create a "boot" partition to store boot loader binaries as shown
 :ref:`here <mmc-create-boot-partition-emmc-linux>` and
-a "root" partition partition for the rootfs: as shown
+a "root" partition for the foot filesystem (rootfs): as shown
 :ref:`here <mmc-create-root-partition-emmc-linux>`.
 
 **Format partitions**
@@ -61,9 +61,9 @@ and for the "root" partition, format as *ext4* type as shown :ref:`here <mmc-for
 
 **Flash eMMC UDA**
 
-Mount the new "boot" partition and copy the bootloader binaries to the new partition
+Mount the new "boot" partition and copy the boot loader binaries to the new partition
 as shown :ref:`here <mmc-flash-emmc-uda-boot>`. Mount the new "root" partition
-and copy the rootfs to the parititon as shown :ref:`here <mmc-flash-emmc-uda-root>`
+and copy the rootfs to the partition as shown :ref:`here <mmc-flash-emmc-uda-root>`
 
 MMCSD boot configuration from eMMC UDA
 ======================================
@@ -77,7 +77,7 @@ After flashing binaries to eMMC flash, the eMMC device Extended CSD register fie
 BUS_WIDTH and PARTITION_CONFIG must be set so ROM will use the correct configuration
 for *MMCSD boot* from UDA.
 
-Set using the :command:`mmc bootbus` and :command:`mmc partconf` commands. Go to
+Set by using the :command:`mmc bootbus` and :command:`mmc partconf` commands. Go to
 ``Boot from UDA``.
 
 - The :command:`mmc bootbus` command sets the BOOT_BUS_WIDTH field where ``mmc bootbus 0 2 0 0``
@@ -105,7 +105,7 @@ Where <dev> is MMC device index.
    On eMMC devices, warm reset will not work if EXT_CSD[162] bit is unset since the
    reset input signal will be ignored. Warm reset is required to be enabled in order
    for the eMMC to be in a "clean state" on power-on reset so that ROM can do
-   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and execute
+   a clean enumeration. To set the EXT_CSD[162] bit, stop at u-boot prompt and run
    the following command:
 
 .. code-block:: console
@@ -114,7 +114,7 @@ Where <dev> is MMC device index.
 
 .. warning::
 
-   This is a write-once field. For more information, please refer to the u-boot
+   This is a write-once field. For more information, refer to the u-boot
    doc found `here <https://docs.u-boot.org/en/latest/usage/cmd/mmc.html>`__.
 
 **U-boot environment**
@@ -151,13 +151,13 @@ First apply the following change in u-boot for any SoC.
     bootdir=/boot
     rd_spec=-
 
-Re-build bootloader binaries and copy build outputs to the SD card "boot" partition
+Re-build boot loader binaries and copy build outputs to the SD card "boot" partition
 and :file:`emmc/` folder. Proceed to flash eMMC with these binaries as shown in this
 step-by-step guide.
 
 Boot from eMMC UDA
 ==================
 
-Finally we can proceed to change boot mode pins to *MMCSD boot* from eMMC (port 0) in fs
-mode as per specific TRM, under: :file:`Initialization/Boot Mode Pins` and power cycle the
+Finally we can proceed to change boot mode pins to *MMCSD boot* from eMMC (port 0) in FS
+mode according to TRM, under: :file:`Initialization/Boot Mode Pins` and power cycle the
 board.


### PR DESCRIPTION
This fixes broken links in MMC docs and documents important information on MMC support

