### PR TITLE
fix(linux): Correct Buildsheet for AM62D

### DIFF
--- a/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
@@ -104,10 +104,10 @@ The support status is indicated by the following codes:
    ,,EndPoint,Yes,No,No,No
    ,,TSN,Yes,No,No,No
    ,,TSN - VLAN,Yes,No,No,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,Yes,No,No,No
-   ,,Device 3.1,Yes,No,No,No
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,No,No,No
+   ,,Device 3.1,NA,No,No,No
    ,,Host 2.0,Yes,No,No,No
-   ,,Device 2.0,No,No,No,No
+   ,,Device 2.0,Yes,No,No,No
    Memory Interfaces,Flash Subsystem (FSS),,No,No,No,No
    ,Quad Serial Peripheral Interface (QSPI),NOR,No,No,No,No
    ,,NAND,No,No,No,No


### PR DESCRIPTION
Correct USB module entries in buildsheet for AM62D 11.1 release. AM62D only has 2 x USB 2.0 and not USB 3.1.