### PR TITLE
fix: Fix oe-config name & yocto build steps

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -1,22 +1,25 @@
 .. _yocto-layer-configuration:
 
-**************************
+*************************
 Yocto Layer Configuration
-**************************
-
-.. http://processors.wiki.ti.com/index.php/Processor_SDK_Building_The_SDK#Layer_Configuration
+*************************
 
 Processor SDK uses the following oe-layersetup configs to configure the
 meta layers. These are the <config> used in the command:
 
-``$ ./oe-layertool-setup.sh -f <config>``
+.. code-block:: console
 
-The following config files are located in the **configs/processor-sdk-analytics**
+   $ ./oe-layertool-setup.sh -f <config>
+
+The following config files are located in the :file:`configs/processor-sdk-analytics`
 directory of the `oe-layersetup git repo <https://git.ti.com/cgit/arago-project/oe-layersetup/>`_.
 
-+----------------------------------------------------+------------------------------------------------+--------------------------------+
-|                    Description                     |      Config File                               | Supported yocto build machine  |
-+====================================================+================================================+================================+
-| |__SDK_FULL_NAME__| : 11_01_07_05 Release          | processor-sdk-analytics-11_01_07_05-config.txt | |__SDK_BUILD_MACHINE__|        |
-+----------------------------------------------------+------------------------------------------------+--------------------------------+
++-------------------------------------------------------------------+------------------------------------------------------+------------------------------+
+| Config File                                                       | Description                                          | Supported machines/platforms |
++===================================================================+======================================================+==============================+
+| processor-sdk-analytics-11.01.07.05-config.txt                    | Used for building EdgeAI filesystem                  | am62axx-evm                  |
++-------------------------------------------------------------------+------------------------------------------------------+------------------------------+
+| processor-sdk-analytics-selinux-11.01.07.05-config.txt            | Used for building SELinux enabled EdgeAI filesystem  | am62axx-evm                  |
++-------------------------------------------------------------------+------------------------------------------------------+------------------------------+
 
+The oe-layersetup configuration, as defined in :file:`processor-sdk-analytics-11.01.07.05-config.txt` is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.

--- a/source/linux/Overview/_Processor_SDK_Building_The_SDK.rst
+++ b/source/linux/Overview/_Processor_SDK_Building_The_SDK.rst
@@ -107,19 +107,32 @@ The MACHINE can be set to |__SDK_BUILD_MACHINE__|, for example.
       .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
          The final command below will build the **tisdk-edgeai-image**, which is the
-         Processor SDK image with arago + edge ai filesystem.  See `Build Options`_ for a list of
+         Processor SDK image with Arago + EdgeAI filesystem.  See `Build Options`_ for a list of
          additional targets.
 
-         .. code-block:: console
+         .. tabs::
 
-            $ git clone https://git.ti.com/git/arago-project/oe-layersetup.git tisdk
-            $ cd tisdk
-            $ ./oe-layertool-setup.sh -f configs/processor-sdk-analytics/processor-sdk-analytics-10.01.00-config.txt
-            $ cd build
-            $ . conf/setenv
-            $ MACHINE=am62axx-evm bitbake -k tisdk-edgeai-image
+            .. tab:: Build Linux SD card Image
 
-         Your tisdk-edgeai-image wic image will be generated in arago-tmp-[toolchain]/deploy directory. Use `Processor\_SDK\_Linux\_create\_SD\_card <Overview/Processor_SDK_Linux_create_SD_card.html>`__ to flash this image on the SD-Card.
+               .. code-block:: console
+
+                  $ git clone https://git.ti.com/git/arago-project/oe-layersetup.git tisdk
+                  $ cd tisdk
+                  $ ./oe-layertool-setup.sh -f configs/processor-sdk-analytics/<oeconfig-file>
+                  $ cd build
+                  $ . conf/setenv
+                  $ MACHINE=am62axx-evm bitbake -k tisdk-edgeai-image
+
+            .. tab:: Build RT-Linux SD card Image
+
+               .. code-block:: console
+
+                  $ git clone https://git.ti.com/git/arago-project/oe-layersetup.git tisdk
+                  $ cd tisdk
+                  $ ./oe-layertool-setup.sh -f configs/processor-sdk-analytics/<oeconfig-file>
+                  $ cd build
+                  $ . conf/setenv
+                  $ MACHINE=am62axx-evm ARAGO_RT_ENABLE=1 bitbake -k tisdk-edgeai-image
 
       .. ifconfig:: CONFIG_part_variant not in ('AM62AX')
 


### PR DESCRIPTION
fix(devices): Update config names for AM62A EdgeAI SDK 11.1

* Fix oe-config names for AM62A EdgeAI SDK 11.1 release.
While at it, also handle miscellaneous cleanups as per
processor-sdk-doc guidelines [0]

[0]: https://github.com/TexasInstruments/processor-sdk-doc/blob/master/CONTRIBUTING.md#indentation-and-whitespace

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>

<hr>

fix(linux): Update Yocto build steps for AM62A

* Use tabs to showcase both Linux & RT Linux build steps
for EdgeAI filesystem. This was added for other platforms
but was missing for AM62A.

* While at it, also fix the oe-config file name for AM62A
11.1 EdgeAI SDK release.

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
