### PR TITLE
AM62A: Updates in Release Notes & Fixes for SDK 11.1

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -1,8 +1,8 @@
 .. _Release-note-label:
 
-************************************
+#############
 Release Notes
-************************************
+#############
 
 Overview
 ========
@@ -32,13 +32,13 @@ Please refer to the software manifests, which outlines the licensing
 status for all packages included in this release. The manifest can be
 found on the SDK download page or in the installed directory as indicated below.
 
--  Linux Manifest:  "/docs/software_manifest.html"
+-  Linux Manifest: :file:`<PSDK_PATH>/manifest/software_manifest.htm`
 
 
 Release 11.01.07.05
 ===================
 
-Released on July 2025
+Released on Aug 2025
 
 What's new
 ----------
@@ -46,6 +46,13 @@ What's new
 **Processor SDK Linux AM62AX Release has following new features:**
 
   - First 2025 LTS Reference Release Including RT combined branch model
+  - Out-of-the-Box EdgeAI Gallery App powered by QT 6.9 for seamless AI experiences
+  - EdgeAI memory carveouts now supported via `k3-am62a7-sk-edgeai.dtso <https://git.ti.com/cgit/ti-linux-kernel/ti-linux-kernel/tree/arch/arm64/boot/dts/ti/k3-am62a7-sk-edgeai.dtso?h=11.01.07>`_ in ti-linux-kernel & applied by default in the AM62A board environment via the name_overlays variable in ti-u-boot as seen in `board/ti/am62ax/am62ax.env <https://git.ti.com/cgit/ti-u-boot/ti-u-boot/tree/board/ti/am62ax/am62ax.env?h=11.01.07#n22>`_
+  - Support for SELinux via meta-selinux with tisdk-edgeai-image
+  - EdgeAI DM R5 (:file:`dm_edgeai_mcu1_0_release_strip.out`) & C7x IPC (:file:`dsp_edgeai_c7x_1_release_strip.out`) firmwares delivered via `ti-linux-firmware <https://git.ti.com/cgit/processor-firmware/ti-linux-firmware/tree/?h=11.01.07>`_
+  - Linux Remoteproc driver now boots remote cores (MCU R5 & C7x) by default during Linux kernel boot time to support Low Power Mode (LPM) with EdgeAI firmwares.
+  - Simplified the Yocto build process for :file:`tisdk-edgeai-image` by eliminating the unnecessary edgeai branding step - :ref:`Building the SDK with Yocto <building-the-sdk-with-yocto>`
+  - EdgeAI DM R5 & C7x firmwares now default to remote endpoint 14 for consistency across Sitara AM6x platforms with Linux RPMsg userspace application - :ref:`IPC for AM62ax <foundational-components-ipc>`
   - Falcon mode through R5 SPL :ref:`U-Boot Falcon Mode <U-Boot-Falcon-Mode>`
   - Important Bug Fixes on top of Processor SDK 10.01.00.05 Release
   - Review Issue Tracker Section for the new fixes.

--- a/source/linux/Overview/_Processor_SDK_Building_The_SDK.rst
+++ b/source/linux/Overview/_Processor_SDK_Building_The_SDK.rst
@@ -317,21 +317,19 @@ The "Build Output" is given relative to the
 
    .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | Target                       | Build Output                                                  | Description                |
-      +==============================+===============================================================+============================+
-      | tisdk-core-bundle            | images/<machine>/processor-sdk-linux-bundle-<machine>.tar.xz  | Full SDK                   |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | tisdk-edgeai-image           | images/<machine>/tisdk-edgeai-image-<machine>.tar.xz          | Target Edge AI Filesystem  |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | tisdk-default-image          | images/<machine>/tisdk-default-image-<machine>.tar.xz         | Target Filesystem          |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | tisdk-base-image             | images/<machine>/tisdk-base-image-<machine>.tar.xz            | Minimal Target Filesytem   |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | meta-toolchain-arago-tisdk   | sdk/arago-<arago-version>-<architecture>.sh                   | Devkit                     |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
-      | mc:k3r5:meta-toolchain-arago | sdk/arago-<arago-version>-<architecture>.sh                   | K3R5 baremetal toolchain   |
-      +------------------------------+---------------------------------------------------------------+----------------------------+
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
+      | Target                       | Build Output                                                  | Description                   |
+      +==============================+===============================================================+===============================+
+      | tisdk-edgeai-image           | images/<machine>/tisdk-edgeai-image-<machine>.tar.xz          | Target Edge AI Filesystem     |
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
+      | tisdk-default-image          | images/<machine>/tisdk-default-image-<machine>.tar.xz         | Target Filesystem w/o EdgeAI  |
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
+      | tisdk-base-image             | images/<machine>/tisdk-base-image-<machine>.tar.xz            | Minimal Target Filesytem      |
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
+      | meta-toolchain-arago-tisdk   | sdk/arago-<arago-version>-<architecture>.sh                   | Devkit                        |
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
+      | mc:k3r5:meta-toolchain-arago | sdk/arago-<arago-version>-<architecture>.sh                   | K3R5 baremetal toolchain      |
+      +------------------------------+---------------------------------------------------------------+-------------------------------+
 
    .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 


### PR DESCRIPTION
feat(devices): Update What's New section in AM62A Release Notes

* Update "What's New" section in AM62A Release Notes for EdgeAI SDK 11.1.
While at it, also update the release month and handle few fixes & cleanups

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>

<hr>

fix(linux): Drop tisdk-core-bundle target from AM62A

* Similar to other AM6x, Drop tisdk-core-bundle target
from AM62A as well since it doesn't corresponds to a Full SDK
which is released on ti.com [0]

* While at it, also update the description for tisdk-default-image

[0]: https://www.ti.com/tool/download/PROCESSOR-SDK-LINUX-AM62A/10.01.00.05