### PR TITLE
fix(linux): Update Documentation Tarball Guide & include it in AM62A

### DIFF
--- a/source/devices/AM62AX/index.rst
+++ b/source/devices/AM62AX/index.rst
@@ -20,6 +20,7 @@ Processor SDK Linux Software Developer's Guide
    index_RTOS
    /linux/How_to_Guides
    /linux/Demo_User_Guides/index_Demos
+   /linux/Documentation_Tarball
 
 |
 

--- a/source/linux/Documentation_Tarball.rst
+++ b/source/linux/Documentation_Tarball.rst
@@ -1,10 +1,10 @@
 Documentation Tarball
 =====================
-.. ifconfig:: CONFIG_part_variant in ('AM62AX','J721E','J7200','J721S2','J784S4','AM68','AM69','J722S','AM67','J742S2','AM68A','AM67A','AM69A','TDA4VM')
+.. ifconfig:: CONFIG_part_variant in ('J721E','J7200','J721S2','J784S4','AM68','AM69','J722S','AM67','J742S2','AM68A','AM67A','AM69A','TDA4VM')
 
    Please download a snapshot of the entire documentation in HTML format from |__SDK_DOWNLOAD_URL__|.
 
-.. ifconfig:: CONFIG_part_variant not in ('AM62AX','J721E','J7200','J721S2','J784S4','AM68','AM69','J722S','AM67','J742S2','AM68A','AM67A','AM69A','TDA4VM')
+.. ifconfig:: CONFIG_part_variant not in ('J721E','J7200','J721S2','J784S4','AM68','AM69','J722S','AM67','J742S2','AM68A','AM67A','AM69A','TDA4VM')
 
    Please click the link below to download a snapshot of the entire documentation in HTML format.
 


### PR DESCRIPTION
* Correct and update the Documentation Tarball Guide, and include it in the AM62A index file.