### PR TITLE
fix(linux): Add Supported Colorimetries to Wave5

### DIFF
--- a/source/linux/Foundational_Components_Multimedia_wave5.rst
+++ b/source/linux/Foundational_Components_Multimedia_wave5.rst
@@ -394,6 +394,15 @@ apply to the input to encoder - decoder has no support for them. The formats inc
    NV12 H264/H265 encoded stream and output raw data to display in any of the formats
    mentioned above assuming the display has support.
 
+The V4L2 gstreamer plugins are only able to handle a subset of colorimetries. If the
+colorimetry is not supported, the gstreamer pipeline will fail to negotiate the format even
+if the pixel formats are compatible. Wave5 supports all the colorimetries supported by the
+V4L2 gstreamer elements. The supported colorimetries are:
+
+   - V4L2_COLORIMETRY_BT601
+   - V4L2_COLORIMETRY_BT709
+   - V4L2_COLORIMETRY_BT2020
+
 ********************************
 Encoder and Decoder Capabilities
 ********************************


### PR DESCRIPTION
There have been a few cases where pipelines fail to negotiate despite the resolutions and pixel formats being compatible with Wave5 requirements. The negotiation comes from gstreamer plugin not supporting the colorimetry the video was encoded with. Add the list of supported colorimetries the gstreamer V4L2 plugin can work with.