### PR TITLE
docs(feat): Add SECURITY guide

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+At TI, we set a high priority on the security of our products. However, as we all know, no matter how much effort is put into product security, no product or customer system can be 100% secure.
+TI wants to learn about any potential security issues impacting our products so that we can take the necessary steps to promptly address them.
+TI’s Product Security Incident Response Team (PSIRT) oversees the process of accepting and responding to reports of potential security vulnerabilities involving TI semiconductor products, including hardware, software and documentation.
+
+## Reporting a Vulnerability
+
+You can contact the TI PSIRT to report a potential security vulnerability at psirt@ti.com. Your report should be in English. TI will respond in a timely manner to confirm receipt of your email.
+Vulnerability information is extremely sensitive. The TI PSIRT strongly recommends that all submitted security vulnerability reports be sent encrypted, using the TI PSIRT PGP/GPG Key:
+
+    Fingerprint: 898C ECC3 451F 9438 D972  06B6 4C13 1A0F 9AF0 04D8
+    [Public Key File (ZIP, 3 KB)](https://www.ti.com/lit/zip/sszo046)
+
+Free software to read and author PGP/GPG encrypted messages may be obtained from:
+
+    [Gpg4win](https://www.gpg4win.org/)
+    [GnuPG](https://www.gnupg.org/)
+
+For more information, visit [ti.com/psirt](https://www.ti.com/support-quality/quality-policies-procedures/report-product-security-vulnerabilities.html)


### PR DESCRIPTION
* Add SECURITY guide which defines how users should report security vulnerabilities for this repository via TI PSIRT [0]

[0]: https://www.ti.com/support-quality/quality-policies-procedures/report-product-security-vulnerabilities.html