### PR TITLE
fix(linux): U-Boot: Falcon-Mode: fix atf address names

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/UG-Falcon-Mode.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Falcon-Mode.rst
@@ -39,8 +39,8 @@ ATF:
 ====
 
 To meet the 2MiB alignment requirement for the Linux kernel's load address,
-the ``K3_HW_CONFIG_BASE`` *(kernel address)* is modified to ``0x82000000``
-and ``PRELOADED_BL33_BASE`` *(DTB address)* is modified from the K3 default to
+the ``PRELOADED_BL33_BASE`` *(kernel address)* is modified to ``0x82000000``
+and ``K3_HW_CONFIG_BASE`` *(DTB address)* is modified from the K3 default to
 ``0x88000000``.
 
 TI-SPL:


### PR DESCRIPTION
A quick minor fix to the docs for falcon mode:

The ATF configs were incorrectly named in the documentation, PRELOADED_BL33_BASE is actually used for the kernel address and K3_HW_CONFIG_BASE for the DTB. They were described in the opposite manner in the docs.

Fixes: eb2c099d1b9b ("docs(linux): AM62AX, 62PX, 62X: add u-boot falcon mode")