### PR TITLE
fix(linux): Remove mentions of drm-tests from glsdk

### DIFF
--- a/source/common/Overview/_Processor_SDK_Technical_Support.rst
+++ b/source/common/Overview/_Processor_SDK_Technical_Support.rst
@@ -83,7 +83,6 @@ While TI integrates the FOSS in |__SDK_FULL_NAME__|, TI does not own, maintain a
         Example applications:
 
         - https://github.com/tomba/kmsxx
-        - https://git.ti.com/glsdk/example-applications/trees/master/drm-tests
         - http://git.ti.com/sitara-linux/dual-camera-demo/trees/master
         - The modetest tool is available inside git://anongit.freedesktop.org/git/mesa/drm
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/CAL.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/CAL.rst
@@ -306,15 +306,6 @@ When ti-cal is enabled, the capture device will appear as /dev/videoX.
 Standard V4L2 user space applications can be used as long as the
 capability of the application matches.
 
--  **dmabuftest example**
-
-   Use CAL to capture a 1280x800 YUYV video stream and display it on an
-   HDMI display using DMABUF buffers.
-
-::
-
-    dmabuftest -s 36:1920x1080 -c 1280x800@YUYV -d /dev/video1
-
 -  **yavta example**
 
    Capture 1280x800 YUYV video stream to file.
@@ -322,12 +313,6 @@ capability of the application matches.
 ::
 
     yavta -c60 -fYUYV -Fvout_1280x800_yuyv.yuv -s1280x800 /dev/video1
-
-dmabuftest can be found from:
-
-::
-
-    https://git.ti.com/glsdk/omapdrmtest
 
 yavta can be found from:
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/VIP.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Camera/VIP.rst
@@ -364,26 +364,12 @@ When ti-vip is enabled, the capture device will appear as /dev/videoX.
 Standard V4L2 user space applications can be used as long as the
 capability of the application matches.
 
--  **dmabuftest example**
-   Use VIP to capture a 1280x800 YUYV video stream and display it on an
-   HDMI display using DMABUF buffers.
-
-::
-
-    dmabuftest -s 36:1920x1080 -c 1280x800@YUYV -d /dev/video1
-
 -  **yavta example**
    Capture 800x600 YUYV video stream to file.
 
 ::
 
     yavta -c60 -fYUYV -Fvout_800x600_yuyv.yuv -s800x600 /dev/video1
-
-dmabuftest can be found from:
-
-::
-
-    https://git.ti.com/glsdk/omapdrmtest
 
 yavta can be found from:
 


### PR DESCRIPTION
The glsdk will not be supported moving forward with am57 11.1 release. Remove mentions of any drm-tests from the glsdk.