### PR TITLE
Chore/clean init

### DIFF
--- a/docker/root/init
+++ b/docker/root/init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024 Texas Instruments Incorporated - https://www.ti.com
@@ -13,8 +13,8 @@ get_build_gid() {
 
 if NEW_GID=$(get_build_gid) && NEW_UID=$(get_build_uid); then
 	# bypass everything if podman is remapping the id to root
-	if [ "${NEW_UID}" == "0" ]; then
-		if [ "$(id -u)" == "0" ]; then
+	if [ "${NEW_UID}" = "0" ]; then
+		if [ "$(id -u)" = "0" ]; then
 			exec dumb-init -- "$@"
 		else
 			echo "Unable to resolve ns mapping!"
@@ -28,7 +28,7 @@ else
 	echo "Not able to detect UID/GID for remapping!"
 fi
 
-if [ "$(id -u)" == "$(id -u abc)" ]; then
+if [ "$(id -u)" = "$(id -u abc)" ]; then
 	exec dumb-init -- "$@"
 else
 	exec dumb-init -- su-exec abc:abc "$@"

--- a/docker/root/init
+++ b/docker/root/init
@@ -3,23 +3,12 @@
 # SPDX-License-Identifier: MIT
 # Copyright (C) 2024 Texas Instruments Incorporated - https://www.ti.com
 
-get_attribs() {
-	local file_stats file_to_test useful_attribs
-	if file_to_test=$(realpath "$1") && [[ $2 =~ ^[0-9]+$ ]] ; then
-		useful_attribs=$(stat "$file_to_test" -t)
-		read -r -a file_stats <<< "${useful_attribs#"$file_to_test"}"
-		echo "${file_stats["$2"]}"
-	else
-		return 1
-	fi
-}
-
 get_build_uid() {
-	get_attribs /build 3
+	stat -c '%u' /build
 }
 
 get_build_gid() {
-	get_attribs /build 4
+	stat -c '%g' /build
 }
 
 if NEW_GID=$(get_build_gid) && NEW_UID=$(get_build_uid); then


### PR DESCRIPTION
- feat(init): reduce to posix shell

  Reduce script complexity to that of standard POSIX shells. Adjust shebang
  accordingly.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- chore(init): remove unnecessary parsing logic

  We can get the values we need directly from stat. No need to do goofy string
  parsing ourselves.

  Signed-off-by: Randolph Sapp <rs@ti.com>

