### PR TITLE
fix: Update AM62LX and AM62PX 11.01 Yocto layer configuration

### DIFF
--- a/source/devices/AM62LX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -17,6 +17,6 @@ directory of the `oe-layersetup git repo <https://git.ti.com/cgit/arago-project/
 +---------------------------------------------------------------+-----------------------------------+-------------------------------+
 | Config File                                                   | Description                       | Supported machines/platforms  |
 +===============================================================+===================================+===============================+
-|      processor-sdk-11.01.16.13-am62lxx-config.txt             | Processor SDK 11.01.16.13 Release |          am62lxx-evm          |
+|      processor-sdk-scarthgap-nonqt-11.01.16.13-config.txt     | Processor SDK 11.01.16.13 Release |  |__SDK_BUILD_MACHINE__|      |
 +---------------------------------------------------------------+-----------------------------------+-------------------------------+
 

--- a/source/devices/AM62PX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -17,6 +17,12 @@ directory of the `oe-layersetup git repo <https://git.ti.com/cgit/arago-project/
 +---------------------------------------------------------------+-----------------------------------+-------------------------------+
 | Config File                                                   | Description                       | Supported machines/platforms  |
 +===============================================================+===================================+===============================+
-| processor-sdk-scarthgap-chromium-11.01.16.13-config.txt       | Processor SDK 11.01.16.13 Release | am62pxx-evm                   |
+| processor-sdk-scarthgap-chromium-11.01.16.13-config.txt       | Processor SDK 11.01.16.13 Release | |__SDK_BUILD_MACHINE__|       |
 +---------------------------------------------------------------+-----------------------------------+-------------------------------+
+| processor-sdk-scarthgap-11.01.16.13-config.txt                | Processor SDK 11.01.16.13 Release | |__SDK_BUILD_MACHINE__|       |
++---------------------------------------------------------------+-----------------------------------+-------------------------------+
+| processor-sdk-scarthgap-selinux-11.01.16.13-config.txt        | Processor SDK 11.01.16.13 Release | |__SDK_BUILD_MACHINE__|       |
++---------------------------------------------------------------+-----------------------------------+-------------------------------+
+
+The oe-layersetup configuration, as defined in ``processor-sdk-scarthgap-chromium-11.01.16.13-config.txt``, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.
 


### PR DESCRIPTION
The name of the oe-configs used for building yocto images for AM62LX have changed. Hence update the same.
While at it, add the extra oe-configs supported for building AM62PX.