### PR TITLE
Build AM67A related documents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           - AM64X
           - AM65X
           - AM67
+          - AM67A
           - AM68
           - AM69
           - CORESDK


### PR DESCRIPTION
- chore(AM67A): build linux target

  Add the linux target for AM67A the build matrix.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- chore(AM67A): build android target

  Add the android target for AM67A to the build matrix.

  Signed-off-by: Randolph Sapp <rs@ti.com>