### PR TITLE
fix(android): update manifest file names for repo commands

### DIFF
--- a/source/android/Application_Notes_Android_Secure_Build.rst
+++ b/source/android/Application_Notes_Android_Secure_Build.rst
@@ -21,7 +21,7 @@ Fetching Bootloader, Kernel, and Android
 
       $ export YOUR_PATH=~/src/
       $ mkdir ${YOUR_PATH}/ti-bootloader-aosp/ && cd $_
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00_Bootloader.xml
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_Bootloader.xml
       $ repo sync
 
 - Kernel:
@@ -29,7 +29,7 @@ Fetching Bootloader, Kernel, and Android
    .. code-block:: console
 
       $ mkdir ${YOUR_PATH}/ti-kernel-aosp/ && cd $_
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00_Kernel.xml
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_Kernel.xml
       $ repo sync
 
 - Android:
@@ -38,7 +38,7 @@ Fetching Bootloader, Kernel, and Android
 
       $ export YOUR_PATH=~/src/
       $ mkdir ${YOUR_PATH}/ti-aosp-16 && cd $_
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00.xml
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00.xml
       $ repo sync
 
 Build Secure Bootloaders

--- a/source/android/Foundational_Components_Bootloaders.rst
+++ b/source/android/Foundational_Components_Bootloaders.rst
@@ -31,7 +31,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-bootloader-aosp/ && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00_Bootloader.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_Bootloader.xml
    $ repo sync
 
 For more information about ``repo``, visit `Android's official

--- a/source/android/Foundational_Components_Kernel.rst
+++ b/source/android/Foundational_Components_Kernel.rst
@@ -23,7 +23,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-kernel-aosp/ && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00_Kernel.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_Kernel.xml
    $ repo sync
 
 .. tip::
@@ -32,7 +32,7 @@ Fetch the code using ``repo``:
 
    .. code-block:: console
 
-      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00_Kernel.xml --depth=1
+      $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_Kernel.xml --depth=1
 
 .. _android-build-kernel:
 

--- a/source/android/Overview_Building_the_SDK.rst
+++ b/source/android/Overview_Building_the_SDK.rst
@@ -47,7 +47,7 @@ Fetch the code using ``repo``:
 .. code-block:: console
 
    $ mkdir ${YOUR_PATH}/ti-aosp-16 && cd $_
-   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00_00.xml
+   $ repo init -u https://git.ti.com/git/android/manifest.git -b android16-release -m releases/RLS_11_00.xml
    $ repo sync
 
 .. tip::


### PR DESCRIPTION
Remove the extra '_00' in the manifest file names listed for all 'repo init' commands.