### PR TITLE
TF-A: Documentation Updates and Fixes

### DIFF
--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -24,6 +24,44 @@ on to either the Linux kernel or U-Boot in the non-secure world.
    The SCMI IDs used in the AM62L TF-A implementation are documented in the
    `TF-A documentation <https://github.com/TexasInstruments/arm-trusted-firmware/blob/ti-master/docs/plat/ti-am62l.rst>`__.
 
+   .. rubric:: SCMI and TI SCI
+
+   The AM62Lx represents a transition in Texas Instruments' approach to system control
+   interfaces. In the previous K3 devices, the Texas Instruments System Controller Interface (TI SCI)
+   was the primary protocol used for power, clock, and resource management. SCMI now serves
+   as a replacement for newer devices like the AM62L, offering similar functionality through
+   an industry-standard ARM protocol. This transition is in part due to the absence of any Device
+   Management (R5 core) in the AM62Lx.
+
+   .. rubric:: Implementation Overview
+
+   The AM62L TF-A implementation runs a SCMI server that manages:
+
+   * **Power Domains**: Over 100 power domains are defined for various peripherals and subsystems
+   * **Clock Management**: Extensive clock control for all major peripherals including:
+
+        - Multiple clock sources (PLLs, oscillators, external clocks)
+        - Clock multiplexers for flexible clock routing
+        - Clock dividers for frequency scaling
+        - Support for dynamic clock rate configuration
+
+   .. rubric:: Clock Infrastructure
+
+   The clock management system supports:
+
+   * **Parent Clock Selection** - Multiple clock sources can be selected as parents for each peripheral
+   * **Clock Multiplexing** - Dynamic switching between different clock sources
+   * **Rate Configuration** - Flexible frequency configuration within supported ranges
+
+   .. rubric:: Usage in Linux
+
+   Linux kernel drivers can use standard SCMI client APIs to:
+
+   * Request power state changes for devices
+   * Configure clock rates and parents
+   * Query current power and clock states
+   * Implement dynamic power management policies
+
 |
 
 .. rubric:: Getting the TF-A Source Code


### PR DESCRIPTION
  Summary

This PR updates and improves the documentation related to Trusted Firmware-A (TF-A). The changes focus on standardizing terminology, fixing source code repository links, and improving overall readability.

   ---
  🔄 Changes

  ✅ Terminology Update

  - Replaced most instances of ATF with TF-A throughout the Foundational_Components_ATF to align with current recognized terminology
  - ATF (ARM Trusted Firmware) is no longer the recognized shorthand for Trusted Firmware-A

  🔗 Repository Link Corrections

  - Updated source code repository links for different device families:
    - For AM62LX: Use TI-specific fork at:
    https://github.com/TexasInstruments/arm-trusted-firmware.git
    - For all other devices (AM64X, AM62X, AM62AX, AM62PX, J721S2, etc.): Use the upstream repository at:
    https://review.trustedfirmware.org/TF-A/trusted-firmware-a.git
  - This ensures users clone the correct repository version for their specific device

  📝 Grammar and Readability Improvements

  - Fixed minor grammatical issues throughout the document
  - Improved clarity in the "Getting the TF-A Source Code" section
  - Added proper articles and prepositions for better readability
