### PR TITLE
feat(linux): crypto: Update algorithms supported in AM62L

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
@@ -17,7 +17,9 @@ devices:
 
 .. code-block:: text
 
-   * AM62LX             : AES-ECB, AES-CBC, MD5, SHA224, SHA256, SHA384, SHA512
+   * AM62LX    :  Encryption                      - AES-ECB, AES-CBC
+                  Encryption with Authentication  - AES-GCM
+                  Hashing                         - MD5, SHA224, SHA256, SHA384, SHA512, HMAC(MD5), HMAC(SHA224), HMAC(SHA256), HMAC(SHA384), HMAC(SHA512)
 
 ********************
 Building the Drivers


### PR DESCRIPTION
Update the docs to include new algorithms whose support has been added to AM62L DTHEv2 linux crypto driver. The new algorithms added in this commit are: AES-GCM, HMAC(MD5), HMAC(SHA224), HMAC(SHA256), HMAC(SHA384), and HMAC(SHA512).

To ease the visibility, the algorithms have been broken doen into multiple types according to their type.