### PR TITLE
fix(build-sheet): Remove references of RTOS features from Linux Docs

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Build_Sheet.rst
@@ -5,8 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
-The following table lists the supported features and modules for the corresponding category,
-along with the support status for Linux on A53, RTOS on MCU R5F, RTOS on WKUP R5F and RTOS on C7X.
+The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/11_01_00_16/exports/docs/build_sheet/am62a-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -17,161 +18,161 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU R5F", "RTOS on WKUP R5F", "RTOS on C7X"
-   :widths: 20, 20, 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   System Interconnect,Bandwidth regulator,,No,No,No,No
-   ,CBASS auto-clock gating,,No,No,No,No
-   Initialization,I2C Bootloader Operation,,No,No,No,No
-   ,SPI Bootloader Operation,,No,No,No,No
-   ,QSPI Bootloader Operation,NOR,No,NA,No,NA
-   ,,NAND,No,NA,No,NA
-   ,OSPI Bootloader Operation,NOR,Yes,NA,Yes,NA
-   ,,NAND (1-bit mode),Yes,NA,Yes,NA
-   ,,NAND (8-bit mode),Yes,NA,Yes,NA
-   ,GPMC Bootloader Operation,NOR,No,NA,No,NA
-   ,,NAND,Yes,NA,No,NA
-   ,Ethernet Bootloader Operation,,Yes,NA,No,NA
-   ,USB Bootloader Operation,Host,No,NA,No,NA
-   ,,Device,Yes,NA,No,NA
-   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,Yes,NA
-   ,,eMMC,Yes,NA,Yes,NA
-   ,UART Bootloader Operation,,Yes,NA,Yes,NA
-   Device Configuration,Power Supply Modules,POK,No,No,No,No
-   ,,POR,No,No,No,No
-   ,,PRG,No,No,No,No
-   ,,PGD,No,No,No,No
-   ,,VTM,Yes,Yes,No,No
-   Power MaNAgement,Deep Sleep Low Power Mode  ,,Yes,NA,No,No
-   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,NA,No,No
-   ,,GT Timers,No,NA,No,No
-   ,,WKUP UART,Yes,NA,No,No
-   ,,I2C,No,NA,No,No
-   ,,MCU GPIO,Yes,NA,No,No
-   ,,I/O Daisy Chain,Yes,NA,No,No
-   ,,USB Connect/Disconnect,Yes,NA,No,No
-   ,,USB Remote Wakeup,Yes,NA,No,No
-   ,MCU-Only Low Power Mode,,Yes,NA,No,No
-   ,Standby Low Power Mode,,SDK11.1,NA,No,No
-   ,Partial I/O Low Power Mode,,Yes,NA,No,No
-   ,IO + DDR low power mode,,Yes,NA,No,No
-   ,Boot-time OPP configurations,,Yes,No,No,No
-   ,Runtime Power MaNAgement,,Yes,NA,No,No
-   ,DFS/CPUFreq,,Yes,NA,No,No
-   ,CPUIdle (A53 WFI),,Yes,NA,No,No
-   ,CPUIdle (DDR in Self-Refresh),,No,NA,No,No
-   Interprocessor Communication,Mailbox,,Yes,Yes,Yes,Yes
-   ,Spinlock,,Yes,No,No,No
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,No,No,No
-   ,,LPDDR4,Yes,No,Yes,No
-   ,,Inline ECC (1bit err),Yes,No,Yes,No
-   ,,Inline ECC (mbit err),No,No,No,No
-   ,Region-based Address Translation,,No,Yes,Yes,NA
-   Time Sync,Time Sync Module (CPTS),,Yes,No,No,No
-   ,Timer MaNAger,,No,No,No,No
-   ,Time Sync and Compare Events,,No,No,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,Yes,Yes
-   ,Peripheral DMA (PDMA),,Yes,No,No,No
-   ,RingAcc,,Yes,No,No,No
-   ,BCDMA,,Yes,Yes,Yes,Yes
-   ,Packet Streaming Interface Link,,Yes,No,No,No
-   General Connectivity Peripherals,Multichannel Audio Serial Port (McASP),Input,Yes,NA,Yes,Yes
-   (MAIN domain),,Output,Yes,NA,Yes,Yes
-   ,,HDMI Output,Yes,NA,No,No
-   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,No,No
-   ,,Peripheral,No,Yes,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,Yes,NA,No,No
-   ,,IrDA,No,NA,No,No
-   General Connectivity Peripherals,General-Purpose Interface (GPIO),,Yes,Yes,Yes,No
-   (MCU domain),Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,No,No,No
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,No,No
-   ,,Peripheral,No,No,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,Yes,No,No,No
-   ,,IrDA,No,No,No,No
-   General Connectivity Peripherals,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,No
-   (WKUP domain),,Target,No,NA,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,NA,Yes,No
-   ,,RS-485,Yes,NA,No,No
-   ,,IrDA,No,NA,No,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No,No
-   ,,EndPoint,Yes,No,No,No
-   ,,TSN,Yes,No,No,No
-   ,,TSN - VLAN,Yes,No,No,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,NA,No,No
-   ,,Device 3.1,NA,NA,No,No
-   ,,Host 2.0,Yes,NA,No,No
-   ,,Device 2.0,Yes,NA,No,No
-   Memory Interfaces,Flash Subsystem (FSS),,No,NA,No,No
-   ,Quad Serial Peripheral Interface (QSPI),NOR,No,NA,No,No
-   ,,NAND,NA,NA,No,No
-   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,NA,No,No
-   ,,NAND,Yes,Yes,Yes,No
-   ,Expanded Serial Peripheral Interface (xSPI),,Yes,NA,No,No
-   ,General-Purpose Memory Controller (GPMC),FPGA,NA,NA,No,No
-   ,,NAND,Yes,NA,No,No
-   ,,NOR,No,NA,No,No
-   ,,etc.,No,NA,No,No
-   ,Error Location Module (ELM),,Yes,NA,No,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,NA,Yes,No
-   ,,eMMC,Yes,NA,Yes,No
-   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,NA,No,No
-   ,,CAN FD,Yes,NA,No,No
-   ,Controller Area Network (MCAN) - MCU domain,CAN,No,Yes,No,No
-   ,,CAN FD,No,Yes,No,No
-   ,Enhanced Capture (ECAP) Module,Capture,Yes,No,No,No
-   ,,PWM,Yes,No,Yes,Yes
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,No,Yes,Yes
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,No,No,No,No
-   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes,NA,No,No
-   ,MIPI D-PHY Receiver (DPHY_RX),,Yes,NA,No,No
-   ,Multiple Camera,,Yes,NA,No,No
-   ,OV2312 RGB + IR sensor,,Yes,NA,No,No
-   ,iMX219 sensor,,Yes,NA,No,No
-   Timer Modules,Global Timebase Cunter (GTC),,Yes,No,Yes,No
-   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No,No
-   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No,No
-   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No,No
-   ,Real-Time Clock (RTC),,Yes,No,No,No
-   ,Timers - MAIN domain,Timer,Yes,NA,No,Yes
-   ,,Capture,No,NA,No,No
-   ,,Compare,No,NA,No,No
-   ,,PWM,Yes,NA,No,No
-   ,Timers - MCU domain,Timer,No,Yes,No,No
-   ,,Capture,No,No,No,No
-   ,,Compare,No,No,No,No
-   ,,PWM,No,No,No,No
-   ,Timers - WKUP domain,Timer,Yes,NA,Yes,No
-   ,,Capture,No,NA,No,No
-   ,,Compare,No,NA,No,No
-   ,,PWM,No,NA,No,No
-   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,No,No
-   ,Error Signalling Module (ESM),,No,Yes,No,No
-   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes,Yes,No,No
-   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,No,No
-   ,RTI(WWDG),,No,Yes,No,No
-   ,Voltage and Thermal Management(VTM),,No,Yes,No,No
-   ,Interconnect Isolation Gasket(STOG),,No,Yes,No,No
-   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No,No
-   ,Power OK(POK),,No,Yes,No,No
-   ,PBIST(Built In Self Test),,No,Yes,No,No
-   ,ECC Aggregator,,No,Yes,No,No
-   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,NA,NA,No,No
-   ,DISPLAY Parallel Interface (DPI),,Yes,NA,No,No
-   ,Dual Display,,NA,NA,NA,NA
-   Video Processing Unit,,,Yes,NA,No,No
-   Image Encoder,JPEG Encoder E5010,,Yes,,,
-   On-Die Temperature sensor,,,Yes,NA,No,No
-   On-Chip Debug,,,Yes,NA,NA,NA
-   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,No,No
-   ,,AES-ECB,Yes,NA,No,No
-   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,No,No
-   ,,SHA-512,Yes,NA,No,No
-   ,True Random Number Generator (TRNG),,Yes,NA,No,No
-   ISP (Image SigNAl Processing),Hardware accelerated ISP for RGB and IR,,Yes,NA,No,No
-   Deep Learning,Hardware accelerated deep learning,,Yes,NA,No,No
+   System Interconnect,Bandwidth regulator,,No
+   ,CBASS auto-clock gating,,No
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,NOR,No
+   ,,NAND,No
+   ,OSPI Bootloader Operation,NOR,Yes
+   ,,NAND (1-bit mode),Yes
+   ,,NAND (8-bit mode),Yes
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,Yes
+   ,Ethernet Bootloader Operation,,Yes
+   ,USB Bootloader Operation,Host,No
+   ,,Device,Yes
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes
+   ,,eMMC,Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,Power Supply Modules,POK,No
+   ,,POR,No
+   ,,PRG,No
+   ,,PGD,No
+   ,,VTM,Yes
+   Power MaNAgement,Deep Sleep Low Power Mode  ,,Yes
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes
+   ,,GT Timers,No
+   ,,WKUP UART,Yes
+   ,,I2C,No
+   ,,MCU GPIO,Yes
+   ,,I/O Daisy Chain,Yes
+   ,,USB Connect/Disconnect,Yes
+   ,,USB Remote Wakeup,Yes
+   ,MCU-Only Low Power Mode,,Yes
+   ,Standby Low Power Mode,,SDK11.1
+   ,Partial I/O Low Power Mode,,Yes
+   ,IO + DDR low power mode,,Yes
+   ,Boot-time OPP configurations,,Yes
+   ,Runtime Power MaNAgement,,Yes
+   ,DFS/CPUFreq,,Yes
+   ,CPUIdle (A53 WFI),,Yes
+   ,CPUIdle (DDR in Self-Refresh),,No
+   Interprocessor Communication,Mailbox,,Yes
+   ,Spinlock,,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes
+   ,,LPDDR4,Yes
+   ,,Inline ECC (1bit err),Yes
+   ,,Inline ECC (mbit err),No
+   ,Region-based Address Translation,,No
+   Time Sync,Time Sync Module (CPTS),,Yes
+   ,Timer MaNAger,,No
+   ,Time Sync and Compare Events,,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,BCDMA,,Yes
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals,Multichannel Audio Serial Port (McASP),Input,Yes
+   (MAIN domain),,Output,Yes
+   ,,HDMI Output,Yes
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals,General-Purpose Interface (GPIO),,Yes
+   (MCU domain),Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals,Inter-Integrated Circuit (I2C),Controller,Yes
+   (WKUP domain),,Target,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes
+   ,,EndPoint,Yes
+   ,,TSN,Yes
+   ,,TSN - VLAN,Yes
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA
+   ,,Device 3.1,NA
+   ,,Host 2.0,Yes
+   ,,Device 2.0,Yes
+   Memory Interfaces,Flash Subsystem (FSS),,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,No
+   ,,NAND,NA
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes
+   ,,NAND,Yes
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,NA
+   ,,NAND,Yes
+   ,,NOR,No
+   ,,etc.,No
+   ,Error Location Module (ELM),,Yes
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes
+   ,,eMMC,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Controller Area Network (MCAN) - MCU domain,CAN,No
+   ,,CAN FD,No
+   ,Enhanced Capture (ECAP) Module,Capture,Yes
+   ,,PWM,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,No
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes
+   ,MIPI D-PHY Receiver (DPHY_RX),,Yes
+   ,Multiple Camera,,Yes
+   ,OV2312 RGB + IR sensor,,Yes
+   ,iMX219 sensor,,Yes
+   Timer Modules,Global Timebase Cunter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA
+   ,Real-Time Clock (RTC),,Yes
+   ,Timers - MAIN domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,Yes
+   ,Timers - MCU domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   ,Timers - WKUP domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No
+   ,Error Signalling Module (ESM),,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes
+   ,SDL Driver Porting Layer(SDL DPL),,No
+   ,RTI(WWDG),,No
+   ,Voltage and Thermal Management(VTM),,No
+   ,Interconnect Isolation Gasket(STOG),,No
+   ,Interconnect Isolation Gasket(MTOG),,No
+   ,Power OK(POK),,No
+   ,PBIST(Built In Self Test),,No
+   ,ECC Aggregator,,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,NA
+   ,DISPLAY Parallel Interface (DPI),,Yes
+   ,Dual Display,,NA
+   Video Processing Unit,,,Yes
+   Image Encoder,JPEG Encoder E5010,,Yes
+   On-Die Temperature sensor,,,Yes
+   On-Chip Debug,,,Yes
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes
+   ,,AES-ECB,Yes
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes
+   ,,SHA-512,Yes
+   ,True Random Number Generator (TRNG),,Yes
+   ISP (Image SigNAl Processing),Hardware accelerated ISP for RGB and IR,,Yes
+   Deep Learning,Hardware accelerated deep learning,,Yes

--- a/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62DX/linux/Release_Specific_Build_Sheet.rst
@@ -5,8 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
-The following table lists the supported features and modules for the corresponding category,
-along with the support status for Linux on A53, RTOS on MCU R5F, RTOS on WKUP R5, RTOS on C7X.
+The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62DX/11_01_00_16/exports/docs/build_sheet/am62d-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -17,164 +18,164 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU R5F", "RTOS on WKUP R5", "RTOS on C7X"
-   :widths: 20, 20, 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   System Interconnect,Bandwidth regulator,,No,No,No,No
-   ,CBASS auto-clock gating,,No,No,No,No
-   Initialization,I2C Bootloader Operation,,No,No,No,No
-   ,SPI Bootloader Operation,,No,No,No,No
-   ,QSPI Bootloader Operation,NOR,No,NA,No,NA
-   ,,NAND,No,NA,No,NA
-   ,OSPI Bootloader Operation,NOR,No,NA,Yes,NA
-   ,,NAND (1-bit mode),No,NA,No,NA
-   ,,NAND (8-bit mode),No,NA,No,NA
-   ,GPMC Bootloader Operation,NOR,No,NA,No,NA
-   ,,NAND,No,NA,No,NA
-   ,Ethernet Bootloader Operation,,No,NA,No,NA
-   ,USB Bootloader Operation,Host,No,NA,No,NA
-   ,,Device,Yes,NA,No,NA
-   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,Yes,NA
-   ,,eMMC,Yes,NA,Yes,NA
-   ,UART Bootloader Operation,,Yes,NA,Yes,NA
-   Device Configuration,Power Supply Modules,POK,No,No,No,No
-   ,,POR,No,No,No,No
-   ,,PRG,No,No,No,No
-   ,,PGD,No,No,No,No
-   ,,VTM,Yes,Yes,No,No
-   Power Management,Deep Sleep Low Power Mode  ,,No,NA,No,No
-   ,Deep Sleep LPM Wakeup Events,RTC Timer,No,NA,No,No
-   ,,GT Timers,No,NA,No,No
-   ,,WKUP UART,No,NA,No,No
-   ,,I2C,No,NA,No,No
-   ,,MCU GPIO,No,NA,No,No
-   ,,I/O Daisy Chain,No,NA,No,No
-   ,,USB Connect/Disconnect,No,NA,No,No
-   ,,USB Remote Wakeup,No,NA,No,No
-   ,MCU-Only Low Power Mode,,No,NA,No,No
-   ,Standby Low Power Mode,,No,NA,No,No
-   ,Partial I/O Low Power Mode,,No,NA,No,No
-   ,IO + DDR low power mode,,No,NA,No,No
-   ,Boot-time OPP configurations,,No,No,No,No
-   ,Runtime Power Management,,No,NA,No,No
-   ,DFS/CPUFreq,,No,NA,No,No
-   ,CPUIdle (A53 WFI),,No,NA,No,No
-   ,CPUIdle (DDR in Self-Refresh),,No,NA,No,No
-   Interprocessor Communication,Mailbox,,Yes,Yes,Yes,Yes
-   ,Spinlock,,No,No,No,No
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,No,No,No
-   ,,LPDDR4,Yes,No,Yes,No
-   ,,Inline ECC (1bit err),No,No,Yes,No
-   ,,Inline ECC (mbit err),No,No,No,No
-   ,Region-based Address Translation,,No,Yes,Yes,NA
-   Time Sync,Time Sync Module (CPTS),,No,No,No,No
-   ,Timer MaNAger,,No,No,No,No
-   ,Time Sync and Compare Events,,No,No,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,No,Yes,Yes,Yes
-   ,Peripheral DMA (PDMA),,Yes,No,No,No
-   ,RingAcc,,Yes,No,No,No
-   ,BCDMA,,Yes,Yes,Yes,Yes
-   ,DRU,,NA,NA,NA,Yes
-   ,Packet Streaming Interface Link,,Yes,No,No,No
-   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,No,NA,No,Yes
-   ,,Output,Yes,NA,No,Yes
-   ,,HDMI Output,NA,NA,No,No
-   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,No,Yes,No,No
-   ,,Peripheral,No,Yes,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,No,NA,No,No
-   ,,IrDA,No,NA,No,No
-   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,No,Yes,Yes,No
-   ,Inter-Integrated Circuit (I2C),Controller,No,Yes,Yes,Yes
-   ,,Target,No,No,No,No
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,No,Yes,No,No
-   ,,Peripheral,No,No,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,No,No,No,No
-   ,,IrDA,No,No,No,No
-   General Connectivity Peripherals (WKUP domain),Inter-Integrated Circuit (I2C),Controller,No,Yes,Yes,No
-   ,,Target,No,NA,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,NA,Yes,No
-   ,,RS-485,No,NA,No,No
-   ,,IrDA,No,NA,No,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No,No
-   ,,EndPoint,Yes,No,No,No
-   ,,TSN,Yes,No,No,No
-   ,,TSN - VLAN,Yes,No,No,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,No,No,No
-   ,,Device 3.1,NA,No,No,No
-   ,,Host 2.0,Yes,No,No,No
-   ,,Device 2.0,Yes,No,No,No
-   Memory Interfaces,Flash Subsystem (FSS),,No,No,No,No
-   ,Quad Serial Peripheral Interface (QSPI),NOR,No,No,No,No
-   ,,NAND,No,No,No,No
-   ,Octal Serial Peripheral Interface (OSPI),NOR,No,Yes,Yes,No
-   ,,NAND,No,No,No,No
-   ,Expanded Serial Peripheral Interface (xSPI),,No,No,No,No
-   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,No,No
-   ,,NAND,No,No,No,No
-   ,,NOR,No,No,No,No
-   ,,etc.,No,No,No,No
-   ,Error Location Module (ELM),,No,No,No,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,No,Yes,No
-   ,,eMMC,Yes,No,Yes,No
-   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,No,No,No,No
-   ,,CAN FD,No,No,No,No
-   ,Controller Area Network (MCAN) - MCU domain,CAN,No,Yes,No,No
-   ,,CAN FD,No,Yes,No,No
-   ,Enhanced Capture (ECAP) Module,Capture,No,No,No,No
-   ,,PWM,No,No,No,Yes
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,No,No,No,Yes
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,No,No,No,No
-   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,NA,NA,No,No
-   ,MIPI D-PHY Receiver (DPHY_RX),,NA,NA,No,No
-   ,Multiple Camera,,NA,NA,No,No
-   ,OV2312 RGB + IR sensor,,NA,NA,No,No
-   ,iMX219 sensor,,NA,NA,No,No
-   Timer Modules,Global Timebase Cunter (GTC),,Yes,No,No,No
-   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No,No
-   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No,No
-   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No,No
-   ,Real-Time Clock (RTC),,No,No,No,No
-   ,Timers - MAIN domain,Timer,No,NA,Yes,Yes
-   ,,Capture,No,NA,No,No
-   ,,Compare,No,NA,No,No
-   ,,PWM,Yes,NA,No,No
-   ,Timers - MCU domain,Timer,No,Yes,No,No
-   ,,Capture,No,No,No,No
-   ,,Compare,No,No,No,No
-   ,,PWM,No,No,No,No
-   ,Timers - WKUP domain,Timer,No,NA,Yes,No
-   ,,Capture,No,NA,No,No
-   ,,Compare,No,NA,No,No
-   ,,PWM,No,NA,No,No
-   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,No,No
-   ,Error Signalling Module (ESM),,No,Yes,No,No
-   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No,Yes,No,No
-   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,No,No
-   ,RTI(WWDG),,No,Yes,No,No
-   ,Voltage and Thermal Management(VTM),,No,Yes,No,No
-   ,Interconnect Isolation Gasket(STOG),,No,Yes,No,No
-   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No,No
-   ,Power OK(POK),,No,Yes,No,No
-   ,PBIST(Built In Self Test),,No,Yes,No,No
-   ,ECC Aggregator,,No,Yes,No,No
-   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,No,NA,No,No
-   ,DISPLAY Parallel Interface (DPI),,NA,NA,No,No
-   ,Dual Display,,NA,NA,NA,NA
-   Video Processing Unit,,,NA,NA,No,No
-   Image Encoder,JPEG Encoder E5010,,NA,,,
-   On-Die Temperature sensor,,,Yes,NA,No,No
-   On-Chip Debug,,,Yes,NA,NA,NA
-   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,No,No
-   ,,AES-ECB,Yes,NA,No,No
-   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,No,No
-   ,,SHA-512,Yes,NA,No,No
-   ,True Random Number Generator (TRNG),,No,NA,No,No
-   ISP (Image SigNAl Processing),Hardware accelerated ISP for RGB and IR,,NA,NA,No,No
-   Deep Learning,Hardware accelerated deep learning,,NA,NA,No,No
-   Board Specific (AM62D EVM),Audio Codec,DAC,Yes,NA,No,No
-   ,,ADC,No,NA,No,No
+   System Interconnect,Bandwidth regulator,,No
+   ,CBASS auto-clock gating,,No
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,NOR,No
+   ,,NAND,No
+   ,OSPI Bootloader Operation,NOR,No
+   ,,NAND (1-bit mode),No
+   ,,NAND (8-bit mode),No
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,No
+   ,Ethernet Bootloader Operation,,No
+   ,USB Bootloader Operation,Host,No
+   ,,Device,Yes
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes
+   ,,eMMC,Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,Power Supply Modules,POK,No
+   ,,POR,No
+   ,,PRG,No
+   ,,PGD,No
+   ,,VTM,Yes
+   Power Management,Deep Sleep Low Power Mode  ,,No
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,No
+   ,,GT Timers,No
+   ,,WKUP UART,No
+   ,,I2C,No
+   ,,MCU GPIO,No
+   ,,I/O Daisy Chain,No
+   ,,USB Connect/Disconnect,No
+   ,,USB Remote Wakeup,No
+   ,MCU-Only Low Power Mode,,No
+   ,Standby Low Power Mode,,No
+   ,Partial I/O Low Power Mode,,No
+   ,IO + DDR low power mode,,No
+   ,Boot-time OPP configurations,,No
+   ,Runtime Power Management,,No
+   ,DFS/CPUFreq,,No
+   ,CPUIdle (A53 WFI),,No
+   ,CPUIdle (DDR in Self-Refresh),,No
+   Interprocessor Communication,Mailbox,,Yes
+   ,Spinlock,,No
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes
+   ,,LPDDR4,Yes
+   ,,Inline ECC (1bit err),No
+   ,,Inline ECC (mbit err),No
+   ,Region-based Address Translation,,No
+   Time Sync,Time Sync Module (CPTS),,No
+   ,Timer MaNAger,,No
+   ,Time Sync and Compare Events,,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,No
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,BCDMA,,Yes
+   ,DRU,,NA
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,No
+   ,,Output,Yes
+   ,,HDMI Output,NA
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,No
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,No
+   ,,IrDA,No
+   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,No
+   ,Inter-Integrated Circuit (I2C),Controller,No
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,No
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,No
+   ,,IrDA,No
+   General Connectivity Peripherals (WKUP domain),Inter-Integrated Circuit (I2C),Controller,No
+   ,,Target,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,No
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes
+   ,,EndPoint,Yes
+   ,,TSN,Yes
+   ,,TSN - VLAN,Yes
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA
+   ,,Device 3.1,NA
+   ,,Host 2.0,Yes
+   ,,Device 2.0,Yes
+   Memory Interfaces,Flash Subsystem (FSS),,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,No
+   ,,NAND,No
+   ,Octal Serial Peripheral Interface (OSPI),NOR,No
+   ,,NAND,No
+   ,Expanded Serial Peripheral Interface (xSPI),,No
+   ,General-Purpose Memory Controller (GPMC),FPGA,No
+   ,,NAND,No
+   ,,NOR,No
+   ,,etc.,No
+   ,Error Location Module (ELM),,No
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes
+   ,,eMMC,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,No
+   ,,CAN FD,No
+   ,Controller Area Network (MCAN) - MCU domain,CAN,No
+   ,,CAN FD,No
+   ,Enhanced Capture (ECAP) Module,Capture,No
+   ,,PWM,No
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,No
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,No
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,NA
+   ,MIPI D-PHY Receiver (DPHY_RX),,NA
+   ,Multiple Camera,,NA
+   ,OV2312 RGB + IR sensor,,NA
+   ,iMX219 sensor,,NA
+   Timer Modules,Global Timebase Cunter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA
+   ,Real-Time Clock (RTC),,No
+   ,Timers - MAIN domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,Yes
+   ,Timers - MCU domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   ,Timers - WKUP domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No
+   ,Error Signalling Module (ESM),,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No
+   ,SDL Driver Porting Layer(SDL DPL),,No
+   ,RTI(WWDG),,No
+   ,Voltage and Thermal Management(VTM),,No
+   ,Interconnect Isolation Gasket(STOG),,No
+   ,Interconnect Isolation Gasket(MTOG),,No
+   ,Power OK(POK),,No
+   ,PBIST(Built In Self Test),,No
+   ,ECC Aggregator,,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,No
+   ,DISPLAY Parallel Interface (DPI),,NA
+   ,Dual Display,,NA
+   Video Processing Unit,,,NA
+   Image Encoder,JPEG Encoder E5010,,NA
+   On-Die Temperature sensor,,,Yes
+   On-Chip Debug,,,Yes
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes
+   ,,AES-ECB,Yes
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes
+   ,,SHA-512,Yes
+   ,True Random Number Generator (TRNG),,No
+   ISP (Image SigNAl Processing),Hardware accelerated ISP for RGB and IR,,NA
+   Deep Learning,Hardware accelerated deep learning,,NA
+   Board Specific (AM62D EVM),Audio Codec,DAC,Yes
+   ,,ADC,No

--- a/source/devices/AM62LX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Build_Sheet.rst
@@ -5,9 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__|
-Release. The following table lists the supported features and modules for the
-corresponding category, along with the support status for Linux on A53 and RTOS
-on A53.
+Release. The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/build_sheet/am62l-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -18,124 +18,124 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on A53"
-   :widths: 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   Initialization,I2C Bootloader Operation,,No,No
-   ,SPI Bootloader Operation,,No,No
-   ,QSPI Bootloader Operation,NOR,Yes,No
-   ,,NAND,No,SDK11.2
-   ,OSPI Bootloader Operation,NOR,Yes,SDK11.1
-   ,,NAND (1-bit mode),Yes,No
-   ,,NAND (8-bit mode),Yes,No
-   ,GPMC Bootloader Operation,NOR,No,No
-   ,,NAND,No,No
-   ,Ethernet Bootloader Operation,,NA,NA
-   ,USB Bootloader Operation,Host,No,No
-   ,,Device,Yes,No
-   ,MMC Bootloader Operation,SD Card,Yes,SDK11.1
-   ,,SD Card (UHS),Yes,SDK11.1
-   ,,eMMC,Yes,SDK11.1
-   ,,eMMC (UHS),Yes,SDK11.1
-   ,UART Bootloader Operation,,Yes,SDK11.1
-   Device Configuration,VTM,,Yes,SDK11.1
-   Power Management,Deep Sleep Low Power Mode,,Yes,SDK11.2
-   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,SDK11.2
-   ,,GT Timers,No,No
-   ,,I/O Daisy Chain,Yes,No
-   ,,I2C,No,No
-   ,,RTC,Yes,No
-   ,,USB Connect/Disconnect,No,No
-   ,,USB Remote Wakeup,Yes,No
-   ,,WKUP UART,No,No
-   ,Standby Low Power Mode,,Yes,SDK11.2
-   ,RTC Only,,SDK12.0,No
-   ,RTC + DDR,,Yes,No
-   ,Boot-time OPP configurations,,No,No
-   ,Runtime Power Management,,Yes,No
-   ,DFS/CPUFreq,,No,No
-   ,CPUIdle (A53 WFI),,No,No
-   ,CPUIdle (DDR in Self-Refresh),,No,No
-   Interprocessor Communication,Mailbox,,Yes,No
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,Yes
-   ,,LPDDR4,Yes,Yes
-   ,,Inline ECC (1bit err),No,No
-   ,,Inline ECC (mbit err),No,No
-   Time Sync,Time Sync Module (CPTS),,Yes,No
-   ,Timer Manager,,No,No
-   ,Time Sync and Compare Events,,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,March-End
-   ,Peripheral DMA (PDMA),,Yes,March-End
-   ,RingAcc,,Yes,March-End
-   ,BCDMA,,Yes,March-End
-   ,Packet Streaming Interface Link,,Yes,March-End
-   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,Yes,SDK11.1
-   ,,Output,Yes,SDK11.1
-   ,,HDMI Output,Yes,No
-   ,Analog to Digital Converter,ADC,Yes,March-End
-   ,General-Purpose Interface (GPIO),,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes
-   ,,Target,No,No
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes
-   ,,Peripheral,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes
-   ,,RS-485,Yes,No
-   ,,IrDA,No,No
-   General Connectivity Peripherals (WKUP domain),General-Purpose Interface (GPIO),,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes
-   ,,Target,No,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes
-   ,,RS-485,Yes,No
-   ,,IrDA,No,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,SDK11.1
-   ,,EndPoint,Yes,SDK11.1
-   ,,TSN,Yes,SDK11.1
-   ,,TSN - VLAN,Yes,SDK11.1
-   Universal Serial Bus Subsystem (USBSS),SuperSpeed+ (3.1),Host,NA,NA
-   ,,Device,NA,NA
-   ,High-Speed (2.0),Host,Yes,SDK12.0
-   ,,Device,Yes,SDK12.0
-   Memory Interfaces,Flash Subsystem (FSS),,No,No
-   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes,No
-   ,,NAND,NA,SDK11.2
-   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,Yes
-   ,,NAND,Yes,No
-   ,Expanded Serial Peripheral Interface (xSPI),,Yes,No
-   ,General-Purpose Memory Controller (GPMC),FPGA,No,SDK12.0
-   ,,NAND,Yes,SDK11.2
-   ,,NOR,No,No
-   ,,PSRAM,No,SDK11.2
-   ,Error Location Module (ELM),,Yes,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,Yes
-   ,,eMMC,Yes,Yes
-   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,Yes
-   ,,CAN FD,Yes,Yes
-   ,Enhanced Capture (ECAP) Module,Capture,Yes,Yes
-   ,,PWM,Yes,Yes
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,Yes
-   Timer Modules,Global Timebase Counter (GTC),,Yes,Yes
-   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,SDK11.1
-   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,NA
-   ,Real-Time Clock (RTC),,Yes,SDK11.1
-   ,Timers - MAIN domain,Timer,Yes,Yes
-   ,,Capture,No,No
-   ,,Compare,No,No
-   ,,PWM,Yes,No
-   ,Timers - WKUP domain,Timer,Yes,No
-   ,,Capture,No,No
-   ,,Compare,No,No
-   ,,PWM,No,No
-   CRC32,,,Yes,No
-   RTI(WWDG),,,No,No
-   Voltage and Thermal Management(VTM),,,Yes,No
-   Display Subsystem,DISPLAY Parallel Interface (DPI),,Yes,No
-   On-Die Temperature sensor,,,Yes,No
-   On-Chip Debug,,,Yes,Yes
-   Crypto Accelerator (DTHEv2),Advanced Encryption Standard (AES),AES-CBC,Yes,SDK11.1
-   ,,AES-ECB,Yes,SDK11.1
-   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,SDK11.1
-   ,,SHA-512,Yes,SDK11.1
-   ,True Random Number Generator (TRNG),,Yes,No
-   Board Specifics (AM62L EVM),WI-FI,CC3351 (connected via M.2),Yes,No
-   ,PMIC,TPS65214,Yes,No
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,NOR,Yes
+   ,,NAND,No
+   ,OSPI Bootloader Operation,NOR,Yes
+   ,,NAND (1-bit mode),Yes
+   ,,NAND (8-bit mode),Yes
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,No
+   ,Ethernet Bootloader Operation,,NA
+   ,USB Bootloader Operation,Host,No
+   ,,Device,Yes
+   ,MMC Bootloader Operation,SD Card,Yes
+   ,,SD Card (UHS),Yes
+   ,,eMMC,Yes
+   ,,eMMC (UHS),Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,VTM,,Yes
+   Power Management,Deep Sleep Low Power Mode,,Yes
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes
+   ,,GT Timers,No
+   ,,I/O Daisy Chain,Yes
+   ,,I2C,No
+   ,,RTC,Yes
+   ,,USB Connect/Disconnect,No
+   ,,USB Remote Wakeup,Yes
+   ,,WKUP UART,No
+   ,Standby Low Power Mode,,Yes
+   ,RTC Only,,SDK12.0
+   ,RTC + DDR,,Yes
+   ,Boot-time OPP configurations,,No
+   ,Runtime Power Management,,Yes
+   ,DFS/CPUFreq,,No
+   ,CPUIdle (A53 WFI),,No
+   ,CPUIdle (DDR in Self-Refresh),,No
+   Interprocessor Communication,Mailbox,,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes
+   ,,LPDDR4,Yes
+   ,,Inline ECC (1bit err),No
+   ,,Inline ECC (mbit err),No
+   Time Sync,Time Sync Module (CPTS),,Yes
+   ,Timer Manager,,No
+   ,Time Sync and Compare Events,,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,BCDMA,,Yes
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,Yes
+   ,,Output,Yes
+   ,,HDMI Output,Yes
+   ,Analog to Digital Converter,ADC,Yes
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals (WKUP domain),General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes
+   ,,EndPoint,Yes
+   ,,TSN,Yes
+   ,,TSN - VLAN,Yes
+   Universal Serial Bus Subsystem (USBSS),SuperSpeed+ (3.1),Host,NA
+   ,,Device,NA
+   ,High-Speed (2.0),Host,Yes
+   ,,Device,Yes
+   Memory Interfaces,Flash Subsystem (FSS),,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes
+   ,,NAND,NA
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes
+   ,,NAND,Yes
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,No
+   ,,NAND,Yes
+   ,,NOR,No
+   ,,PSRAM,No
+   ,Error Location Module (ELM),,Yes
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes
+   ,,eMMC,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Enhanced Capture (ECAP) Module,Capture,Yes
+   ,,PWM,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes
+   Timer Modules,Global Timebase Counter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA
+   ,Real-Time Clock (RTC),,Yes
+   ,Timers - MAIN domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,Yes
+   ,Timers - WKUP domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   CRC32,,,Yes
+   RTI(WWDG),,,No
+   Voltage and Thermal Management(VTM),,,Yes
+   Display Subsystem,DISPLAY Parallel Interface (DPI),,Yes
+   On-Die Temperature sensor,,,Yes
+   On-Chip Debug,,,Yes
+   Crypto Accelerator (DTHEv2),Advanced Encryption Standard (AES),AES-CBC,Yes
+   ,,AES-ECB,Yes
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes
+   ,,SHA-512,Yes
+   ,True Random Number Generator (TRNG),,Yes
+   Board Specifics (AM62L EVM),WI-FI,CC3351 (connected via M.2),Yes
+   ,PMIC,TPS65214,Yes

--- a/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
@@ -5,8 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
-The following table lists the supported features and modules for the corresponding category,
-along with the support status for Linux on A53, RTOS on MCU R5F, RTOS on WKUP R5F.
+The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/build_sheet/am62p-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -17,163 +18,163 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU R5F", "RTOS on WKUP R5F"
-   :widths: 20, 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   System Interconnect,Bandwidth regulator,,No,No,No
-   ,CBASS auto-clock gating,,No,No,No
-   Initialization,I2C Bootloader Operation,,No,No,No
-   ,SPI Bootloader Operation,,No,No,No
-   ,QSPI Bootloader Operation,NOR,Yes,NA,No
-   ,,NAND,No,NA,No
-   ,OSPI Bootloader Operation,NOR,Yes,NA,Yes
-   ,,NAND (1-bit mode),No,NA,No
-   ,,NAND (8-bit mode),No,NA,No
-   ,GPMC Bootloader Operation,NOR,No,NA,No
-   ,,NAND,No,NA,No
-   ,Ethernet Bootloader Operation,,No,NA,No
-   ,USB Bootloader Operation,Host,Yes,NA,No
-   ,,Device,Yes,NA,No
-   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,Yes
-   ,,eMMC,Yes,NA,Yes
-   ,UART Bootloader Operation,,Yes,NA,Yes
-   Device Configuration,Power Supply Modules,POK,No,No,Yes
-   ,,POR,No,No,No
-   ,,PRG,No,No,No
-   ,,PGD,No,No,No
-   ,,VTM,Yes,Yes,Yes
-   Power Management,Deep Sleep Low Power Mode,,Yes,NA,NA
-   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,NA,NA
-   ,,GT Timers,No,NA,NA
-   ,,WKUP UART,Yes,NA,NA
-   ,,I2C,No,NA,NA
-   ,,MCU GPIO,Yes,NA,NA
-   ,,I/O Daisy Chain,Yes,NA,NA
-   ,,USB Connect/Disconnect,Yes,NA,NA
-   ,,USB Remote Wakeup,Yes,NA,NA
-   ,MCU-Only Low Power Mode,,Yes,NA,NA
-   ,Standby Low Power Mode,,SDK11.1,NA,NA
-   ,IO + DDR Low power mode,,Yes,NA,NA
-   ,Partial I/O Low Power Mode,,Yes,NA,NA
-   ,Boot-time OPP configurations,,Yes,No,No
-   ,Runtime Power Management,,Yes,NA,NA
-   ,DFS/CPUFreq,,Yes,NA,NA
-   ,CPUIdle (A53 WFI),,Yes,NA,NA
-   ,CPUIdle (DDR in Self-Refresh),,No,NA,NA
-   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,NA,NA,NA
-   ,Communication Subsystem (PRUSS-M),,,,
-   ,,Industrial Protocols,NA,NA,NA
-   Interprocessor Communication,Mailbox,,Yes,Yes,Yes
-   ,Spinlock,,Yes,No,No
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,NA,No,No
-   ,,LPDDR4,Yes,No,Yes
-   ,,Inline ECC (1bit err),Yes,No,Yes
-   ,,Inline ECC (mbit err),Yes,No,Yes
-   ,Region-based Address Translation,,No,Yes,Yes
-   Time Sync,Time Sync Module (CPTS),,Yes,No,No
-   ,Timer Manager,,No,No,No
-   ,Time Sync and Compare Events,,No,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,Yes
-   ,Peripheral DMA (PDMA),,Yes,No,No
-   ,RingAcc,,Yes,Yes,Yes
-   ,BCDMA,,Yes,Yes,Yes
-   ,Packet Streaming Interface Link,,Yes,No,No
-   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,Yes,NA,Yes
-   ,,Output,Yes,NA,Yes
-   ,,HDMI Output,Yes,NA,NA
-   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes
-   ,,Peripheral,No,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes
-   ,,RS-485,Yes,No,No
-   ,,IrDA,No,No,No
-   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes
-   ,,Peripheral,No,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes
-   ,,RS-485,Yes,No,No
-   ,,IrDA,No,No,No
+   System Interconnect,Bandwidth regulator,,No
+   ,CBASS auto-clock gating,,No
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,NOR,Yes
+   ,,NAND,No
+   ,OSPI Bootloader Operation,NOR,Yes
+   ,,NAND (1-bit mode),No
+   ,,NAND (8-bit mode),No
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,No
+   ,Ethernet Bootloader Operation,,No
+   ,USB Bootloader Operation,Host,Yes
+   ,,Device,Yes
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes
+   ,,eMMC,Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,Power Supply Modules,POK,No
+   ,,POR,No
+   ,,PRG,No
+   ,,PGD,No
+   ,,VTM,Yes
+   Power Management,Deep Sleep Low Power Mode,,Yes
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes
+   ,,GT Timers,No
+   ,,WKUP UART,Yes
+   ,,I2C,No
+   ,,MCU GPIO,Yes
+   ,,I/O Daisy Chain,Yes
+   ,,USB Connect/Disconnect,Yes
+   ,,USB Remote Wakeup,Yes
+   ,MCU-Only Low Power Mode,,Yes
+   ,Standby Low Power Mode,,SDK11.1
+   ,IO + DDR Low power mode,,Yes
+   ,Partial I/O Low Power Mode,,Yes
+   ,Boot-time OPP configurations,,Yes
+   ,Runtime Power Management,,Yes
+   ,DFS/CPUFreq,,Yes
+   ,CPUIdle (A53 WFI),,Yes
+   ,CPUIdle (DDR in Self-Refresh),,No
+   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,NA
+   ,Communication Subsystem (PRUSS-M),,
+   ,,Industrial Protocols,NA
+   Interprocessor Communication,Mailbox,,Yes
+   ,Spinlock,,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,NA
+   ,,LPDDR4,Yes
+   ,,Inline ECC (1bit err),Yes
+   ,,Inline ECC (mbit err),Yes
+   ,Region-based Address Translation,,No
+   Time Sync,Time Sync Module (CPTS),,Yes
+   ,Timer Manager,,No
+   ,Time Sync and Compare Events,,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,BCDMA,,Yes
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals (MAIN domain),Multichannel Audio Serial Port (McASP),Input,Yes
+   ,,Output,Yes
+   ,,HDMI Output,Yes
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals (MCU domain),General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
    "General Connectivity Peripherals
-   (WKUP domain)",Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,No,Yes
-   ,,RS-485,Yes,No,No
-   ,,IrDA,No,No,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No
-   ,,EndPoint,Yes,No,No
-   ,,TSN,Yes,No,No
-   ,,TSN - VLAN,Yes,No,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,No,No
-   ,,Device 3.1,NA,No,No
-   ,,Host 2.0,Yes,No,No
-   ,,Device 2.0,Yes,No,No
-   Memory Interfaces,Flash Subsystem (FSS),,No,No,No
-   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes,No,No
-   ,,NAND,NA,No,No
-   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,No,Yes
-   ,,NAND,Yes,No,No
-   ,Expanded Serial Peripheral Interface (xSPI),,Yes,No,No
-   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,No
-   ,,NAND,Yes,No,No
-   ,,NOR,No,No,No
-   ,,etc.,No,No,No
-   ,Error Location Module (ELM),,Yes,No,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,No,Yes
-   ,,eMMC,Yes,Yes,Yes
-   ,,eMMC HS400 mode,Yes (SR1.2 only),Yes,Yes
-   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,No,Yes
-   ,,CAN FD,Yes,No,Yes
-   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes,Yes,No
-   ,,CAN FD,Yes,Yes,No
-   ,Enhanced Capture (ECAP) Module,Capture,Yes,No,No
-   ,,PWM,Yes,Yes,No
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,No
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,No,No
-   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes,NA,NA
-   ,MIPI D-PHY Receiver (DPHY_RX),,Yes,NA,NA
-   ,Multiple Camera,,Yes,NA,NA
-   Timer Modules,Global Timebase Cunter (GTC),,Yes,No,Yes
-   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No
-   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No
-   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No
-   ,Real-Time Clock (RTC),,Yes,Yes,No
-   ,Timers - MAIN domain,Timer,Yes,NA,NA
-   ,,Capture,No,NA,NA
-   ,,Compare,No,NA,NA
-   ,,PWM,Yes,NA,NA
-   ,Timers - MCU domain,Timer,No,Yes,NA
-   ,,Capture,No,No,NA
-   ,,Compare,No,No,NA
-   ,,PWM,No,No,NA
-   ,Timers - WKUP domain,Timer,Yes,NA,Yes
-   ,,Capture,No,NA,No
-   ,,Compare,No,NA,No
-   ,,PWM,No,NA,No
-   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,No
-   ,Error Signaling Module (ESM),,No,Yes,No
-   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No,Yes,No
-   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,No
-   ,RTI(WWDG),,No,Yes,No
-   ,Voltage and Thermal Management(VTM),,Yes,Yes,No
-   ,Interconnect Isolation Gasket(STOG),,No,Yes,No
-   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No
-   ,Power OK(POK),,No,Yes,No
-   ,PBIST(Built In Self Test),,No,Yes,No
-   ,ECC Aggregator,,No,Yes,No
-   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes,NA,Yes
-   ,DISPLAY Parallel Interface (DPI),,Yes,NA,Yes
-   ,DSI (display serial interface),,Yes,NA,No
-   ,Triple Display,,Yes,NA,No
-   Video Processing Unit,Cnm Wave521CL,,Yes,,
-   Graphics Processing Unit,IMG BXS,,Yes,NA,No
-   On-Die Temperature sensor,,,Yes,NA,NA
-   On-Chip Debug,,,Yes,NA,NA
-   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,NA
-   ,,AES-ECB,Yes,NA,NA
-   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,NA
-   ,,SHA-512,Yes,NA,NA
-   ,True Random Number Generator (TRNG),,SDK11.0,NA,NA
+   (WKUP domain)",Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes
+   ,,EndPoint,Yes
+   ,,TSN,Yes
+   ,,TSN - VLAN,Yes
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA
+   ,,Device 3.1,NA
+   ,,Host 2.0,Yes
+   ,,Device 2.0,Yes
+   Memory Interfaces,Flash Subsystem (FSS),,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes
+   ,,NAND,NA
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes
+   ,,NAND,Yes
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,No
+   ,,NAND,Yes
+   ,,NOR,No
+   ,,etc.,No
+   ,Error Location Module (ELM),,Yes
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes
+   ,,eMMC,Yes
+   ,,eMMC HS400 mode,Yes (SR1.2 only)
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Enhanced Capture (ECAP) Module,Capture,Yes
+   ,,PWM,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes
+   ,MIPI D-PHY Receiver (DPHY_RX),,Yes
+   ,Multiple Camera,,Yes
+   Timer Modules,Global Timebase Cunter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA
+   ,Real-Time Clock (RTC),,Yes
+   ,Timers - MAIN domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,Yes
+   ,Timers - MCU domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   ,Timers - WKUP domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No
+   ,Error Signaling Module (ESM),,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No
+   ,SDL Driver Porting Layer(SDL DPL),,No
+   ,RTI(WWDG),,No
+   ,Voltage and Thermal Management(VTM),,Yes
+   ,Interconnect Isolation Gasket(STOG),,No
+   ,Interconnect Isolation Gasket(MTOG),,No
+   ,Power OK(POK),,No
+   ,PBIST(Built In Self Test),,No
+   ,ECC Aggregator,,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes
+   ,DISPLAY Parallel Interface (DPI),,Yes
+   ,DSI (display serial interface),,Yes
+   ,Triple Display,,Yes
+   Video Processing Unit,Cnm Wave521CL,,Yes
+   Graphics Processing Unit,IMG BXS,,Yes
+   On-Die Temperature sensor,,,Yes
+   On-Chip Debug,,,Yes
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes
+   ,,AES-ECB,Yes
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes
+   ,,SHA-512,Yes
+   ,True Random Number Generator (TRNG),,SDK11.0

--- a/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
@@ -5,8 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
-The following table lists the supported features and modules for the corresponding category,
-along with the support status for Linux on A53, RTOS on MCU M4, RTOS on WKUP R5F, and RTOS on A53.
+The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/11_01_00_16/exports/docs/build_sheet/am62x-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -17,158 +18,158 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on MCU M4", "RTOS on WKUP R5F", "RTOS on A53"
-   :widths: 20, 20, 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   System Interconnect,Bandwidth regulator,,No,No,No,No
-   ,CBASS auto-clock gating,,No,No,No,No
-   Initialization,I2C Bootloader Operation,,No,No,No,No
-   ,SPI Bootloader Operation,,No,No,No,No
-   ,QSPI Bootloader Operation,NOR,Yes,NA,No,NA
-   ,,NAND,No,NA,No,NA
-   ,OSPI Bootloader Operation,NOR,Yes,NA,Yes,NA
-   ,,NAND (1-bit mode),Yes,NA,No,NA
-   ,,NAND (8-bit mode),Yes,NA,Yes,NA
-   ,GPMC Bootloader Operation,NOR,No,NA,No,NA
-   ,,NAND,Yes,NA,Yes,NA
-   ,Ethernet Bootloader Operation,,Yes,NA,No,NA
-   ,USB Bootloader Operation,Host,No,NA,No,NA
-   ,,Device,Yes,NA,No,NA
-   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes,NA,No,NA
-   ,,eMMC,Yes,NA,Yes,NA
-   ,UART Bootloader Operation,,Yes,NA,Yes,NA
-   Device Configuration,Power Supply Modules,POK,No,No,Yes,No
-   ,,POR,No,No,No,No
-   ,,PRG,No,No,No,No
-   ,,PGD,No,No,No,No
-   ,,VTM,Yes,Yes,Yes,No
-   Power Management,Deep Sleep Low Power Mode,,Yes,NA,NA,No
-   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes,NA,NA,No
-   ,,GT Timers,No,NA,NA,No
-   ,,WKUP UART,Yes,NA,NA,No
-   ,,I2C,No,NA,NA,No
-   ,,MCU GPIO,Yes,NA,NA,No
-   ,,I/O Daisy Chain,Yes,NA,NA,No
-   ,,USB Connect/Disconnect,Yes,NA,NA,No
-   ,,USB Remote Wakeup,Yes,NA,NA,No
-   ,MCU-Only Low Power Mode,,Yes,NA,NA,No
-   ,Standby Low Power Mode,,SDK11.1,NA,NA,No
-   ,Partial I/O Low Power Mode,,Yes,NA,NA,No
-   ,Boot-time OPP configurations,,Yes,No,No,No
-   ,Runtime Power Management,,Yes,NA,NA,No
-   ,DFS/CPUFreq,,Yes,NA,NA,No
-   ,CPUIdle (A53 WFI),,Yes,NA,NA,No
-   ,CPUIdle (DDR in Self-Refresh),,No,NA,NA,No
-   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,Yes,NA,NA,No
-   ,Communication Subsystem (PRUSS-M),,,,,
-   ,,Industrial Protocols,NA,NA,NA,NA
-   Interprocessor Communication,Mailbox,,Yes,Yes,Yes,Yes
-   ,Spinlock,,Yes,No,No,Yes
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,No,Yes,No
-   ,,LPDDR4,Yes,No,Yes,No
-   ,,Inline ECC (1bit err),Yes,No,Yes,No
-   ,,Inline ECC (mbit err),Yes,No,Yes,No
-   ,Region-based Address Translation,,No,Yes,Yes,No
-   Time Sync,Time Sync Module (CPTS),,Yes,No,No,No
-   ,Timer Manager,,No,No,No,No
-   ,Time Sync and Compare Events,,No,No,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,No,Yes,Yes
-   ,Peripheral DMA (PDMA),,Yes,No,Yes,Yes
-   ,RingAcc,,Yes,No,Yes,Yes
-   ,BCDMA,,Yes,No,Yes,Yes
-   ,Packet Streaming Interface Link,,Yes,No,No,No
-   General Connectivity Peripherals,Multichannel Audio Serial Port (McASP),Input,Yes,NA,NA,Yes
-   (MAIN domain),,Output,Yes,NA,NA,Yes
-   ,,HDMI Output,Yes,NA,NA,No
-   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes,Yes
-   ,,Peripheral,No,NA,NA,No
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,Yes,NA,NA,No
-   ,,IrDA,No,NA,NA,No
-   General Connectivity Peripherals,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
-   (MCU domain),Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,No,No,No
-   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes,Yes,Yes,Yes
-   ,,Peripheral,No,Yes,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,Yes,No,No,No
-   ,,IrDA,No,No,No,No
-   General Connectivity Peripherals,Inter-Integrated Circuit (I2C),Controller,Yes,Yes,Yes,Yes
-   (WKUP domain),,Target,No,Yes,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,NA,Yes,Yes
-   ,,RS-485,Yes,NA,NA,No
-   ,,IrDA,No,NA,NA,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes,No,No,No
-   ,,EndPoint,Yes,No,No,No
-   ,,TSN,Yes,No,No,No
-   ,,TSN - VLAN,Yes,No,No,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA,NA,No,No
-   ,,Device 3.1,NA,NA,No,No
-   ,,Host 2.0,Yes,NA,No,No
-   ,,Device 2.0,Yes,NA,No,No
-   Memory Interfaces,Flash Subsystem (FSS),,No,NA,No,No
-   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes,NA,No,No
-   ,,NAND,NA,NA,No,No
-   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes,NA,Yes,Yes
-   ,,NAND,Yes,NA,Yes,Yes
-   ,Expanded Serial Peripheral Interface (xSPI),,Yes,NA,No,No
-   ,General-Purpose Memory Controller (GPMC),FPGA,No,NA,No,No
-   ,,NAND,Yes,NA,Yes,Yes
-   ,,NOR,No,NA,No,No
-   ,,etc.,No,NA,No,No
-   ,Error Location Module (ELM),,Yes,NA,No,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes,NA,Yes,Yes
-   ,,eMMC,Yes,NA,Yes,Yes
-   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes,NA,Yes,Yes
-   ,,CAN FD,Yes,NA,Yes,Yes
-   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes,Yes,No,Yes
-   ,,CAN FD,Yes,Yes,No,Yes
-   ,Enhanced Capture (ECAP) Module,Capture,Yes,No,No,Yes
-   ,,PWM,Yes,No,No,Yes
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,No,Yes
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,No,No,Yes
-   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes,NA,No,No
-   ,MIPI D-PHY Receiver (DPHY_RX),,Yes,NA,No,No
-   ,Multiple Camera,,Yes,NA,No,No
-   Timer Modules,Global Timebase Counter (GTC),,Yes,No,Yes,Yes
-   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes,No,No,Yes
-   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA,No,No,NA
-   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA,No,No,NA
-   ,Real-Time Clock (RTC),,Yes,No,No,Yes
-   ,Timers - MAIN domain,Timer,Yes,NA,NA,Yes
-   ,,Capture,No,NA,NA,No
-   ,,Compare,No,NA,NA,No
-   ,,PWM,Yes,NA,NA,No
-   ,Timers - MCU domain,Timer,No,Yes,NA,No
-   ,,Capture,No,No,NA,No
-   ,,Compare,No,No,NA,No
-   ,,PWM,No,No,NA,No
-   ,Timers - WKUP domain,Timer,Yes,NA,Yes,No
-   ,,Capture,No,NA,No,No
-   ,,Compare,No,NA,No,No
-   ,,PWM,No,NA,No,No
-   Internal Diagnostic Modules,Dual Clock Comparator (DCC),,No,Yes,Yes,No
-   ,Error Signaling Module (ESM),,No,Yes,Yes,No
-   ,SDL Driver Porting Layer(SDL DPL),,No,Yes,Yes,No
-   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes,Yes,Yes,No
-   ,RTI(WWDG),,No,Yes,Yes,No
-   ,Voltage and Thermal Management(VTM),,No,Yes,Yes,No
-   ,Interconnect Isolation Gasket(STOG),,No,Yes,Yes,No
-   ,Interconnect Isolation Gasket(MTOG),,No,Yes,No,No
-   ,Power OK(POK),,No,Yes,Yes,No
-   ,PBIST(Built In Self Test),,No,Yes,Yes,No
-   ,ECC Aggregator,,No,Yes,Yes,No
-   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes,No,No,No
-   ,DISPLAY Parallel Interface (DPI),,Yes,No,No,No
-   ,Dual Display,,Yes,No,No,No
-   Graphics Processing Unit,,,Yes,NA,NA,No
-   On-Die Temperature sensor,,,Yes,NA,NA,No
-   On-Chip Debug,,,Yes,NA,NA,NA
-   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes,NA,NA,No
-   ,,AES-ECB,Yes,NA,NA,No
-   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes,NA,NA,No
-   ,,SHA-512,Yes,NA,NA,No
-   ,True Random Number Generator (TRNG),,Yes,NA,NA,No
+   System Interconnect,Bandwidth regulator,,No
+   ,CBASS auto-clock gating,,No
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,NOR,Yes
+   ,,NAND,No
+   ,OSPI Bootloader Operation,NOR,Yes
+   ,,NAND (1-bit mode),Yes
+   ,,NAND (8-bit mode),Yes
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,Yes
+   ,Ethernet Bootloader Operation,,Yes
+   ,USB Bootloader Operation,Host,No
+   ,,Device,Yes
+   ,MMCSD Bootloader Operation,SD Card (no UHS),Yes
+   ,,eMMC,Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,Power Supply Modules,POK,No
+   ,,POR,No
+   ,,PRG,No
+   ,,PGD,No
+   ,,VTM,Yes
+   Power Management,Deep Sleep Low Power Mode,,Yes
+   ,Deep Sleep LPM Wakeup Events,RTC Timer,Yes
+   ,,GT Timers,No
+   ,,WKUP UART,Yes
+   ,,I2C,No
+   ,,MCU GPIO,Yes
+   ,,I/O Daisy Chain,Yes
+   ,,USB Connect/Disconnect,Yes
+   ,,USB Remote Wakeup,Yes
+   ,MCU-Only Low Power Mode,,Yes
+   ,Standby Low Power Mode,,SDK11.1
+   ,Partial I/O Low Power Mode,,Yes
+   ,Boot-time OPP configurations,,Yes
+   ,Runtime Power Management,,Yes
+   ,DFS/CPUFreq,,Yes
+   ,CPUIdle (A53 WFI),,Yes
+   ,CPUIdle (DDR in Self-Refresh),,No
+   Processors & Accelerators,Programmable Real-Time Unit and Industrial,General PRU Use,Yes
+   ,Communication Subsystem (PRUSS-M),,
+   ,,Industrial Protocols,NA
+   Interprocessor Communication,Mailbox,,Yes
+   ,Spinlock,,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes
+   ,,LPDDR4,Yes
+   ,,Inline ECC (1bit err),Yes
+   ,,Inline ECC (mbit err),Yes
+   ,Region-based Address Translation,,No
+   Time Sync,Time Sync Module (CPTS),,Yes
+   ,Timer Manager,,No
+   ,Time Sync and Compare Events,,No
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,BCDMA,,Yes
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals,Multichannel Audio Serial Port (McASP),Input,Yes
+   (MAIN domain),,Output,Yes
+   ,,HDMI Output,Yes
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals,General-Purpose Interface (GPIO),,Yes
+   (MCU domain),Inter-Integrated Circuit (I2C),Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (McSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   General Connectivity Peripherals,Inter-Integrated Circuit (I2C),Controller,Yes
+   (WKUP domain),,Target,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW3G),Switch,Yes
+   ,,EndPoint,Yes
+   ,,TSN,Yes
+   ,,TSN - VLAN,Yes
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.1,NA
+   ,,Device 3.1,NA
+   ,,Host 2.0,Yes
+   ,,Device 2.0,Yes
+   Memory Interfaces,Flash Subsystem (FSS),,No
+   ,Quad Serial Peripheral Interface (QSPI),NOR,Yes
+   ,,NAND,NA
+   ,Octal Serial Peripheral Interface (OSPI),NOR,Yes
+   ,,NAND,Yes
+   ,Expanded Serial Peripheral Interface (xSPI),,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,No
+   ,,NAND,Yes
+   ,,NOR,No
+   ,,etc.,
+   ,Error Location Module (ELM),,Yes
+   ,Multimedia Card Secure Digital (MMCSD) Interface,SD Card,Yes
+   ,,eMMC,Yes
+   Industrial & Control Interfaces,Controller Area Network (MCAN) - MAIN domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Controller Area Network (MCAN) - MCU domain,CAN,Yes
+   ,,CAN FD,Yes
+   ,Enhanced Capture (ECAP) Module,Capture,Yes
+   ,,PWM,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes
+   Camera Subsystem,Camera Streaming Interface Receiver (CSI_RX_IF),,Yes
+   ,MIPI D-PHY Receiver (DPHY_RX),,Yes
+   ,Multiple Camera,,Yes
+   Timer Modules,Global Timebase Counter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT) - MAIN domain,,Yes
+   ,Windowed Watchdog Timer (WWDT) - MCU domain,,NA
+   ,Windowed Watchdog Timer (WWDT) - WKUP domain,,NA
+   ,Real-Time Clock (RTC),,Yes
+   ,Timers - MAIN domain,Timer,Yes
+   ,,Capture
+   ,,Compare,No
+   ,,PWM,Yes
+   ,Timers - MCU domain,Timer,No
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   ,Timers - WKUP domain,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   Internal Diagnostic Modules,Dual Clock Comparator (DCC),,No
+   ,Error Signaling Module (ESM),,No
+   ,SDL Driver Porting Layer(SDL DPL),,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,Yes
+   ,RTI(WWDG),,No
+   ,Voltage and Thermal Management(VTM),,No
+   ,Interconnect Isolation Gasket(STOG),,No
+   ,Interconnect Isolation Gasket(MTOG),,No
+   ,Power OK(POK),,No
+   ,PBIST(Built In Self Test),,No
+   ,ECC Aggregator,,No
+   DISPLAY Subsystem,Open LVDS Display Interface Transmitter (OLDITX),,Yes
+   ,DISPLAY Parallel Interface (DPI),,Yes
+   ,Dual Display,,Yes
+   Graphics Processing Unit,,,Yes
+   On-Die Temperature sensor,,,Yes
+   On-Chip Debug,,,Yes
+   Crypto Accelerator (SA3UL),Advanced Encryption Standard (AES),AES-CBC,Yes
+   ,,AES-ECB,Yes
+   ,SHA/MD5 Crypto Hardware-Accelerated Module (SHA/MD5),SHA-256,Yes
+   ,,SHA-512,Yes
+   ,True Random Number Generator (TRNG),,Yes

--- a/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
@@ -5,8 +5,9 @@ Software Build Sheet
 ====================
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
-The following table lists the supported features and modules for the corresponding category,
-along with the support status for Linux on A53, RTOS on R5F, RTOS on M4, RTOS on A53.
+The following table lists the supported features and modules with the support status
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/build_sheet/am64x-sw-buildsheet.html>`__
+for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:
 
@@ -17,111 +18,111 @@ The support status is indicated by the following codes:
    - "ANY": The feature or module is a new update in this revision of the SDK.
 
 .. csv-table:: Software Build Sheet
-   :header: "Category", "Module", "SubModule", "Linux on A53", "RTOS on R5F", "RTOS on M4", "RTOS on A53"
-   :widths: 20, 20, 20, 20, 20, 20, 20
+   :header: "Category", "Module", "SubModule", "Linux on A53"
+   :widths: 20, 20, 20, 20
 
-   Memory Map,MAIN Domain Memory Map,,Yes,Yes,Yes,No
-   ,MCU Domain Memory Map,,Yes,Yes,Yes,No
-   ,Processors View Memory Map,,Yes,N/A,N/A,No
-   ,Region-based Address Translation,,No,Yes,Yes,No
-   System Interconnect,,,Yes,N/A,N/A,N/A
-   Initialization,I2C Bootloader Operation,,No,N/A,N/A,N/A
-   ,SPI Bootloader Operation,,No,N/A,N/A,N/A
-   ,QSPI Bootloader Operation,,Yes,Yes,N/A,N/A
-   ,OSPI Bootloader Operation,,Yes,Yes,N/A,N/A
-   ,PCIe Bootloader Operation,,No,N/A,N/A,N/A
-   ,GPMC Bootloader Operation,NOR,No,No,N/A,N/A
-   ,,NAND,Yes,No,N/A,N/A
-   ,Ethernet Bootloader Operation,,Yes,No,N/A,N/A
-   ,USB Bootloader Operation,Host,Yes,No,N/A,N/A
-   ,,Device,Yes,No,N/A,N/A
-   ,MMCSD Bootloader Operation,SD Card (4 bit),Yes,Yes,N/A,N/A
-   ,,SD Card (8 bit),No,No,N/A,N/A
-   ,,eMMC,Yes,Yes,N/A,N/A
-   ,UART Bootloader Operation,,Yes,Yes,N/A,N/A
-   Device Configuration,Power,,Yes,Yes,Yes,No
-   ,Reset,,Yes,Yes,Yes,Yes
-   ,Clocking,,Yes,Yes,Yes,Yes
-   Processors and Accelerators,Dual-R5F MCU Subsystem,,Yes,Yes,N/A,N/A
-   ,Dual-A53 MPU Subsystem,,Yes,N/A,N/A,Yes
-   ,Cortex-M4F Subsystem,,No,N/A,Yes,N/A
-   ,Programmable Real-Time Unit and Industrial Communication Subsystem - Gigabit,General PRU Use,Yes,Yes,No,No
-   ,,EtherCAT Device,No,Yes,No,No
-   ,,Profinet RT Device,No,Yes,No,No
-   ,,Profinet IRT Device,No,Yes,No,No
-   ,,EtherNet/IP adapter,No,Yes,No,No
-   ,,Ethernet Endpoint (EMAC),Yes,Yes,No,No
-   ,,Ethernet Switch,Yes,No,No,No
-   ,,Ethernet HSR,Yes,No,No,No
-   ,,IO Link Primary,No,Yes,No,No
-   ,,"HDSL, EnDat 2.2",No,Yes,No,No
-   Interprocessor Communication (IPC),Mailbox,,Yes,Yes,Yes,Yes
-   ,Spinlock,,Yes,Yes,Yes,Yes
-   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes,Yes,N/A,N/A
-   ,,LPDDR4,Yes,No,N/A,N/A
-   ,,Inline ECC,Yes,Yes,N/A,N/A
-   ,Region-based Address Translation (RAT) Module,,No,Yes,Yes,No
-   Interrupts,MCU Domain Interrupt Maps,,Yes,Yes,Yes,Yes
-   ,MAIN Domain Interrupt Maps,,Yes,Yes,N/A,Yes
-   Time Sync,Time Sync Module (CPTS),,Yes,Yes,No,No
-   ,Timer Manager,,No,No,No,No
-   ,Time Sync and Compare Events,,Yes,No,No,No
-   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes,Yes,N/A,Yes
-   ,Peripheral DMA (PDMA),,Yes,Yes,N/A,No
-   ,RingAcc,,Yes,Yes,N/A,No
-   ,Secure Proxy,,Yes,Yes,N/A,No
-   ,Interrup Aggregator,,Yes,Yes,N/A,No
-   ,Packet Streaming Interface Link,,Yes,Yes,N/A,No
-   General Connectivity Peripherals,Analog-to-Digital Converter (ADC),,Yes,Yes,No,Yes
-   ,General-Purpose Interface (GPIO),,Yes,Yes,Yes,Yes
-   ,Inter-Integrated Circuit (I2C) Interface,Controller,Yes,Yes,Yes,Yes
-   ,,Target,No,Yes,Yes,Yes
-   ,Multichannel Serial Peripheral Interface (MCSPI),Controller,Yes,Yes,Yes,Yes
-   ,,Peripheral,No,Yes,Yes,Yes
-   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes,Yes,Yes,Yes
-   ,,RS-485,Yes,No,No,No
-   ,,IrDA,No,No,No,No
-   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW0),Switch,Yes,Yes,N/A,No
-   ,,EndPoint,Yes,Yes,N/A,No
-   ,Peripheral Component Interconnect Express (PCIe) Subsystem,Root Complex,Yes,Yes,N/A,No
-   ,,EndPoint,Yes,Yes,N/A,No
-   ,Universal Serial Bus Subsystem (USBSS),Host 3.0,N/A,No,N/A,No
-   ,,Device 3.0,N/A,No,N/A,No
-   ,,Host 2.0,Yes,No,N/A,No
-   ,,Device 2.0,Yes,Yes,N/A,No
-   ,Serializer/Deserializer (SerDes),,Yes,Yes,N/A,No
-   Memory Interfaces,Flash Subsystem (FSS) ,,No,No,N/A,No
-   ,Octal Serial Peripheral Interface (OSPI),,Yes,Yes,N/A,Yes
-   ,General-Purpose Memory Controller (GPMC),FPGA,No,No,N/A,No
-   ,,NAND,Yes,No,N/A,No
-   ,,NOR,No,No,N/A,No
-   ,,etc.,No,No,N/A,No
-   ,Error Location Module (ELM),,Yes,No,N/A,No
-   ,Multimedia Card Secure Digital (MMCSD) Interface,4-bit,Yes,Yes,N/A,Yes
-   ,,8-bit,Yes,Yes,N/A,Yes
-   Industrial and Control Interfaces,Enhanced Capture (ECAP) Module,Capture,No,Yes,N/A,Yes
-   ,,PWM,Yes,No,N/A,Yes
-   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes,Yes,N/A,Yes
-   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes,Yes,N/A,Yes
-   ,Controller Area Network (MCAN),Classic CAN,Yes,Yes,N/A,Yes
-   ,,Classic CAN FD,Yes,Yes,N/A,Yes
-   ,FSI,Receiver,No,Yes,N/A,No
-   ,,Transmitter,No,Yes,N/A,No
-   Timer Modules,Global Timebase Counter (GTC),,Yes,Yes,Yes,Yes
-   ,Windowed Watchdog Timer (WWDT),,Yes,Yes,No,Yes
-   ,Timers,Timer,Yes,Yes,Yes,Yes
-   ,,Capture,No,No,No,No
-   ,,Compare,No,No,No,No
-   ,,PWM,No,No,No,No
-   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No,Yes,Yes,No
-   ,Error Signaling Module (ESM),,No,Yes,Yes,No
-   ,RTI(WWDG)	,,No,Yes,Yes,No
-   ,Voltage and Thermal Management(VTM)	,,No,Yes,Yes,No
-   ,Interconnect Isolation Gasket(STOG)	,,No,Yes,Yes,No
-   ,Interconnect Isolation Gasket(MTOG)	,,No,No,Yes,No
-   ,Power OK(POK)	,,No,Yes,Yes,No
-   ,PBIST(Built In Self Test)	,,No,Yes,Yes,No
-   ,LBIST(Built In Self Test)	,,No,No,Yes,No
-   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No,Yes,Yes,No
-   ,ECC AggrB70:B117egator,,No,Yes,Yes,No
-    On-Chip Debug,,,Yes,Yes,Yes,No
+   Memory Map,MAIN Domain Memory Map,,Yes
+   ,MCU Domain Memory Map,,Yes
+   ,Processors View Memory Map,,Yes
+   ,Region-based Address Translation,,No
+   System Interconnect,,,Yes
+   Initialization,I2C Bootloader Operation,,No
+   ,SPI Bootloader Operation,,No
+   ,QSPI Bootloader Operation,,Yes
+   ,OSPI Bootloader Operation,,Yes
+   ,PCIe Bootloader Operation,,No
+   ,GPMC Bootloader Operation,NOR,No
+   ,,NAND,Yes
+   ,Ethernet Bootloader Operation,,Yes
+   ,USB Bootloader Operation,Host,Yes
+   ,,Device,Yes
+   ,MMCSD Bootloader Operation,SD Card (4 bit),Yes
+   ,,SD Card (8 bit),No
+   ,,eMMC,Yes
+   ,UART Bootloader Operation,,Yes
+   Device Configuration,Power,,Yes
+   ,Reset,,Yes
+   ,Clocking,,Yes
+   Processors and Accelerators,Dual-R5F MCU Subsystem,,Yes
+   ,Dual-A53 MPU Subsystem,,Yes
+   ,Cortex-M4F Subsystem,,No
+   ,Programmable Real-Time Unit and Industrial Communication Subsystem - Gigabit,General PRU Use,Yes
+   ,,EtherCAT Device,No
+   ,,Profinet RT Device,No
+   ,,Profinet IRT Device,No
+   ,,EtherNet/IP adapter,No
+   ,,Ethernet Endpoint (EMAC),Yes
+   ,,Ethernet Switch,Yes
+   ,,Ethernet HSR,Yes
+   ,,IO Link Primary,No
+   ,,"HDSL, EnDat 2.2",No
+   Interprocessor Communication (IPC),Mailbox,,Yes
+   ,Spinlock,,Yes
+   Memory Controllers,DDR Subsystem (DDRSS),DDR4,Yes
+   ,,LPDDR4,Yes
+   ,,Inline ECC,Yes
+   ,Region-based Address Translation (RAT) Module,,No
+   Interrupts,MCU Domain Interrupt Maps,,Yes
+   ,MAIN Domain Interrupt Maps,,Yes
+   Time Sync,Time Sync Module (CPTS),,Yes
+   ,Timer Manager,,No
+   ,Time Sync and Compare Events,,Yes
+   Data Movement Architecture (DMA),Data Movement Subsystem (DMSS),,Yes
+   ,Peripheral DMA (PDMA),,Yes
+   ,RingAcc,,Yes
+   ,Secure Proxy,,Yes
+   ,Interrup Aggregator,,Yes
+   ,Packet Streaming Interface Link,,Yes
+   General Connectivity Peripherals,Analog-to-Digital Converter (ADC),,Yes
+   ,General-Purpose Interface (GPIO),,Yes
+   ,Inter-Integrated Circuit (I2C) Interface,Controller,Yes
+   ,,Target,No
+   ,Multichannel Serial Peripheral Interface (MCSPI),Controller,Yes
+   ,,Peripheral,No
+   ,Universal Asynchronous Receiver/Transmitter (UART),UART,Yes
+   ,,RS-485,Yes
+   ,,IrDA,No
+   High-speed Serial Interfaces,Gigabit Ethernet Switch (CPSW0),Switch,Yes
+   ,,EndPoint,Yes
+   ,Peripheral Component Interconnect Express (PCIe) Subsystem,Root Complex,Yes
+   ,,EndPoint,Yes
+   ,Universal Serial Bus Subsystem (USBSS),Host 3.0,N/A
+   ,,Device 3.0,N/A
+   ,,Host 2.0,Yes
+   ,,Device 2.0,Yes
+   ,Serializer/Deserializer (SerDes),,Yes
+   Memory Interfaces,Flash Subsystem (FSS) ,,No
+   ,Octal Serial Peripheral Interface (OSPI),,Yes
+   ,General-Purpose Memory Controller (GPMC),FPGA,No
+   ,,NAND,Yes
+   ,,NOR,No
+   ,,etc.,No
+   ,Error Location Module (ELM),,Yes
+   ,Multimedia Card Secure Digital (MMCSD) Interface,4-bit,Yes
+   ,,8-bit,Yes
+   Industrial and Control Interfaces,Enhanced Capture (ECAP) Module,Capture,No
+   ,,PWM,Yes
+   ,Enhanced Pulse Width Modulation (EPWM) Module,,Yes
+   ,Enhanced Quadrature Encoder Pulse (EQEP) Module,,Yes
+   ,Controller Area Network (MCAN),Classic CAN,Yes
+   ,,Classic CAN FD,Yes
+   ,FSI,Receiver,No
+   ,,Transmitter,No
+   Timer Modules,Global Timebase Counter (GTC),,Yes
+   ,Windowed Watchdog Timer (WWDT),,Yes
+   ,Timers,Timer,Yes
+   ,,Capture,No
+   ,,Compare,No
+   ,,PWM,No
+   Internal Diagnostics Modules,Dual Clock Comparator (DCC),,No
+   ,Error Signaling Module (ESM),,No
+   ,RTI(WWDG) ,,No
+   ,Voltage and Thermal Management(VTM) ,,No
+   ,Interconnect Isolation Gasket(STOG) ,,No
+   ,Interconnect Isolation Gasket(MTOG) ,,No
+   ,Power OK(POK) ,,No
+   ,PBIST(Built In Self Test) ,,No
+   ,LBIST(Built In Self Test) ,,No
+   ,Memory Cyclic Redundancy Check (MCRC) Controller,,No
+   ,ECC AggrB70:B117egator,,No
+   On-Chip Debug,,,Yes


### PR DESCRIPTION
RTOS features are not updated in this documentation and are instead maintained separately. 

This commit removes references to RTOS features from the build-sheet and points users to the MCU+ SDK url for information on RTOS features for AM62AX, AM62DX, AM62LX, AM62PX, AM62X, and AM64X.

Preview:
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM64X/esd/docs/11_01_05_03/devices/AM64X/linux/Release_Specific_Build_Sheet.html
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM62PX/esd/docs/11_01_16_13/devices/AM62PX/linux/Release_Specific_Build_Sheet.html
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM62X/esd/docs/11_01_05_03/devices/AM62X/linux/Release_Specific_Build_Sheet.html
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM62LX/esd/docs/11_01_16_13/devices/AM62LX/linux/Release_Specific_Build_Sheet.html
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM62DX/esd/docs/11_01_05_03/devices/AM62DX/linux/Release_Specific_Build_Sheet.html
https://jeevantelukula.github.io/processor-sdk-doc-fork/processor-sdk-linux-AM62AX/esd/docs/11_01_07_05/devices/AM62AX/linux/Release_Specific_Build_Sheet.html