### PR TITLE
fix(android): fix code block indentation

### DIFF
--- a/source/android/Application_Notes_Camera.rst
+++ b/source/android/Application_Notes_Camera.rst
@@ -89,7 +89,7 @@ After flashing, make sure to halt in the U-Boot shell and run
 
 .. ifconfig:: CONFIG_part_variant in ('AM67A')
 
-.. code-block:: console
+   .. code-block:: console
 
       => env set adtbo_idx 16
       => saveenv


### PR DESCRIPTION
The indentation caused the specific code block for the AM67A board to be displayed even if the another board was selected. This caused the wrong dtbo index being displayed.