### PR TITLE
ci: clamp permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
     outputs:
       build-matrix: "${{ steps.matrix.outputs.matrix }}"
     steps:
@@ -36,6 +38,8 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
     needs: collect
     strategy:
       matrix:

--- a/.github/workflows/check_toc_txt.yml
+++ b/.github/workflows/check_toc_txt.yml
@@ -19,6 +19,8 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -15,6 +15,8 @@ jobs:
     name: Comment
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Download artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -18,6 +18,8 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -14,6 +14,8 @@ jobs:
     container:
       image: ghcr.io/staticrocket/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
+    permissions:
+      contents: read
 
     steps:
       - name: Prepare GitHub workdir


### PR DESCRIPTION
We don't need all of these operating with the default permissions right now.