### PR TITLE
ci(build): apply version override

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Build ${{ matrix.device }}
         run: |
-          make DEVFAMILY=${{ matrix.device }} OS=${{ matrix.os }}
+          make DEVFAMILY=${{ matrix.device }} OS=${{ matrix.os }} \
+          VERSION=${{ github.ref_name }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Override the document version using the ref name (master at the moment). Back by popular demand. People want to quickly navigate between platform previews here. As such we need consistent versioning.

This reverts commit 4477c7d5d1f051cfc168c13c150d51c89fe85670.

Preview at: https://staticrocket.github.io/processor-sdk-doc/