### PR TITLE
fix: update AM62LX/AM62PX mcu-plus-sdk links

### DIFF
--- a/source/devices/AM62LX/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62LX/linux/Overview/Download_and_Install_the_SDK.rst
@@ -85,8 +85,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    AM62L Linux SDK contains only the Linux specific source and application intended
    to run on A53/Linux core. For A53 based FreeRTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/latest/exports/docs/api_guide_am62lx/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/api_guide_am62lx/index.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/latest/exports/docs/api_guide_am62lx/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/api_guide_am62lx/CCS_SETUP_PAGE.html>`__

--- a/source/devices/AM62PX/index_RTOS.rst
+++ b/source/devices/AM62PX/index_RTOS.rst
@@ -8,4 +8,4 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_00_16/exports/docs/api_guide_am62px/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/index.html>`__

--- a/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
@@ -85,8 +85,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    Processor SDK Linux AM62Px contains only the Linux specific source and application intended
    to runs on A53/Linux core. For R5F and RTOS/NO-RTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/index.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/CCS_SETUP_PAGE.html>`__

--- a/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
+++ b/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
@@ -84,6 +84,6 @@ Building the Linux Demo binary from sources
 Building the MCU Firmware from sources
 --------------------------------------
 
-    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/group__DRV__DSS__MODULE.html>`__
+    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/group__DRV__DSS__MODULE.html>`__
 
 

--- a/source/linux/Foundational_Components/Tools/Flash_via_UART.rst
+++ b/source/linux/Foundational_Components/Tools/Flash_via_UART.rst
@@ -18,4 +18,4 @@ Detailed instructions on using the tool can be found in MCU+SDK docs.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-   `MCU+SDK Flash Tools Documentation  <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62x/TOOLS_FLASH.html>`__.
+   `MCU+SDK Flash Tools Documentation  <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`__.

--- a/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
+++ b/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
@@ -135,7 +135,7 @@ Reducing bootloader time
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/DATASHEET_AM62PX_EVM.html#autotoc_md119>`_
+    You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/DATASHEET_AM62PX_EVM.html#autotoc_md119>`_
 
 
 - Flashing binaries:
@@ -158,7 +158,7 @@ Reducing bootloader time
 
     .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-        - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
+        - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
 
         - U-Boot eMMC flashing tool AM62PX: :ref:`u-boot-build-guide-environment-k3`
 
@@ -176,7 +176,7 @@ Secondary Boot Loader (SBL)
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/EXAMPLES_DRIVERS_SBL.html>`_.
+    The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/EXAMPLES_DRIVERS_SBL.html>`_.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
@@ -188,7 +188,7 @@ Secondary Boot Loader (SBL)
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-    - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/latest/exports/docs/api_guide_am62px/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
+    - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
 
 - Removing unnecessary prints
 


### PR DESCRIPTION
Update the references of mcu-plus-sdk documentation links to point to latest release url's for AM62PX and AM62LX devices.