### PR TITLE
fix(linux): AM62AX: Update the DM version info

### DIFF
--- a/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62AX/linux/Release_Specific_Release_Notes.rst
@@ -84,7 +84,7 @@ What's new
   - ATF 2.13+
   - OPTEE 4.6.0
   - TIFS Firmware / SYSFW `v11.01.05 <https://software-dl.ti.com/tisci/esd/11_01_05/release_notes/release_notes.html>`__ (Click on the link for more information)
-  - DM Firmware 11.01.00.05
+  - DM Firmware `MSDK.11.01.00.16+ <https://github.com/TexasInstruments/mcupsdk-core-k3/tree/REL.MCUSDK.K3.11.01.00.16>`__ (Click on the link for more information)
   - Yocto scarthgap 5.0
 
 .. _release-specific-build-information:


### PR DESCRIPTION
Update the correct DM version info for AM62AX SDK 11.1