### PR TITLE
Bugfix/qt

### DIFF
--- a/source/linux/Foundational_Components/Graphics/Common/QT_Graphics_Framework.rst
+++ b/source/linux/Foundational_Components/Graphics/Common/QT_Graphics_Framework.rst
@@ -19,8 +19,8 @@ The PSDK target file system includes the pre-built Qt libraries under
 Demos
 *****
 
-Qt provides demos for the Null Window System / KMS / DRM / EGL Full Screen
-(EGLFS) backends. By default EGLFS will use the ``eglfs_kms`` backend.
+Qt provides demos for the Wayland, Linux framebuffer (LINUXFB), and EGL Full
+Screen (EGLFS) backends. By default EGLFS will use the ``eglfs_kms`` backend.
 
 .. code-block:: console
 


### PR DESCRIPTION
- fix(qt): fix list of supported backends

  We should focus more on the platform listing here.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- fix(qt): clarify deprecation notice

  The linuxfb platform isn't being deprecated but the default rendering mode is.
  Right now this requires defining an additional environment variable to work
  around.

  Signed-off-by: Randolph Sapp <rs@ti.com>

