### PR TITLE
fix(linux): Drop the limitation on AM62A

### DIFF
--- a/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_low_power_modes.rst
@@ -395,18 +395,6 @@ before running the Suspend-to-RAM command:
 
    root@<machine>:@~# modprobe -r optee_rng
 
-.. ifconfig:: CONFIG_part_variant in ('AM62AX')
-
-   .. attention::
-
-      Linux SDK for edge AI applications has a known issue that breaks
-      Deep Sleep and MCU Only modes. To test these modes, the DSP module
-      has to be unloaded before attempting LPM:
-
-      .. code-block:: console
-
-         root@am62axx-evm:@~# modprobe -rf ti_k3_dsp_remoteproc
-
 Compatibility
 =============
 


### PR DESCRIPTION
* With SDK 11.1, The EdgeAI SDK for AM62A supports Deep Sleep & MCU only modes on C7x [0]
Hence, the limitation to remove ti_k3_dsp_remoteproc is no longer required & can be safely removed

[0] - https://software-dl.ti.com/processor-sdk-linux/esd/AM62AX/11_01_07_05/exports/docs/devices/AM62AX/linux/Release_Specific_Release_Notes.html#what-s-new