### PR TITLE
docs(linux): J784S4: Add the PCIe boot documentation

### DIFF
--- a/configs/J784S4/J784S4_linux_toc.txt
+++ b/configs/J784S4/J784S4_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-UFS
 linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
+linux/Foundational_Components/U-Boot/UG-PCIeBoot
 linux/Foundational_Components/U-Boot/UG-HSM
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD


### PR DESCRIPTION
Add PCIe boot documentation for J784S4. While at it also add more details to PCIe boot procedure.