### PR TITLE
Add Docs Version Switcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 # vale configs and intermediary data
 .github/styles/*
 !.github/styles/config
+/.venv
+.DS_Store

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,24 +1,34 @@
 {% extends "!layout.html" %}
-{%- block extrahead %} 
-  <script src="https://www.ti.com/assets/js/headerfooter/analytics.js" type="text/javascript" charset="utf-8"></script>
-  {{ super() }}
+{%- block extrahead %}
+<script src="https://www.ti.com/assets/js/headerfooter/analytics.js" type="text/javascript" charset="utf-8"></script>
+{{ super() }}
 {% endblock %}
 {%- block sidebartitle %}
-  {# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
-  {# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
-  {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
-  {%- set _root_doc = root_doc|default(master_doc) %}
-  <a href="{{ pathto(_root_doc) }}"{% if not theme_logo_only %} class="icon icon-home"{% endif %}>
-    {% if not theme_logo_only %}{{ project }}{% endif %}
-    {%- if logo or logo_url %}
-      <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
-    {%- endif %}
-  </a>
-  {%- set nav_version = version %}
-  {%- if nav_version %}
-    <div class="version">
-      {{ nav_version }}
-    </div>
+{# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}
+{# the master_doc variable was renamed to root_doc in Sphinx 4 (master_doc still exists in later Sphinx versions) #}
+{%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+{%- set _root_doc = root_doc|default(master_doc) %}
+<a href="{{ pathto(_root_doc) }}" {% if not theme_logo_only %} class="icon icon-home" {% endif %}>
+  {% if not theme_logo_only %}{{ project }}{% endif %}
+  {%- if logo or logo_url %}
+  <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}" />
   {%- endif %}
-  {%- include "searchbox.html" %}
+</a>
+{%- set nav_version = version %}
+{%- if nav_version and versions %}
+<div class="version">
+  <select id="version-selector"
+    onchange="location.href = location.href.replace(/\/docs\/[^\/]+\//, '/docs/' + this.value + '/');"
+    style="background-color: white; color: black; border: 1px solid #d9d9d9; padding: 5px; border-radius: 3px;">
+    {% for v in versions %}
+    <option value="{{ v }}" {% if v==nav_version %}selected{% endif %}>{{ v }}</option>
+    {% endfor %}
+  </select>
+</div>
+{%- elif nav_version %}
+<div class="version">
+  {{ nav_version }}
+</div>
+{%- endif %}
+{%- include "searchbox.html" %}
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -16,6 +16,7 @@
 import sys
 import os
 import importlib
+import subprocess
 from datetime import datetime
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -204,7 +205,33 @@ html_context = {
     "github_repo": "processor-sdk-doc",
     "github_version": "master",
     "conf_py_path": "/source/",
+    "versions": [],
 }
+
+def get_versions():
+    versions = ["master"]
+    try:
+        cmd = ["git", "ls-remote", "--tags", "--heads", "https://github.com/TexasInstruments/processor-sdk-doc"]
+        output = subprocess.check_output(cmd).decode('utf-8').splitlines()
+        tags = []
+        for line in output:
+            parts = line.split()
+            if len(parts) == 2:
+                ref = parts[1]
+                if ref.startswith("refs/tags/"):
+                    tag = ref.replace("refs/tags/", "")
+                    tags.append(tag)
+
+        # Sort tags descending
+        tags.sort(reverse=True)
+        versions.extend(tags)
+    except Exception as e:
+        print(f"Error fetching versions: {e}")
+        # Fallback
+        versions = ["master"]
+    return versions
+
+html_context["versions"] = get_versions()
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
Google usually only indexes "some" version of the SDK docs so you end up with situations where you don't know what the latest version is. This lets you switch versions based on what Tags exist on Github. 

I'm not sure this is ideal because older versions obviously don't have this built (but we can just re-generate everything once) 

<img width="293" height="225" alt="Screenshot 2025-11-25 at 9 43 22 AM" src="https://github.com/user-attachments/assets/15e9fd6d-237a-4fb9-aea7-ae52ff83fd8d" />

<img width="318" height="318" alt="Screenshot 2025-11-25 at 9 43 27 AM" src="https://github.com/user-attachments/assets/875956de-735b-4ab8-a16c-730ab7fa23c3" />

Example script to rebuild everything  locally - 
[build_versions.sh](https://github.com/user-attachments/files/23751826/build_versions.sh)

