### PR TITLE
feat(linux): crypto: Update list of algorithms supported in DTHEv2

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
@@ -19,7 +19,8 @@ devices:
 
    * AM62LX    :  Encryption                      - AES-ECB, AES-CBC, AES-XTS, AES-CTR
                   Encryption with Authentication  - AES-GCM, AES-CCM
-                  Hashing                         - MD5, SHA224, SHA256, SHA384, SHA512, HMAC(MD5), HMAC(SHA224), HMAC(SHA256), HMAC(SHA384), HMAC(SHA512)
+                  Hashing                         - MD5, SHA224, SHA256, SHA384, SHA512
+                  Message Authentication          - HMAC(MD5), HMAC(SHA224), HMAC(SHA256), HMAC(SHA384), HMAC(SHA512)
 
 ********************
 Building the Drivers


### PR DESCRIPTION
Added new algorithms in the documentation whose support was added in DTHEv2 Linux driver in SDK 11.2
Also updated the categorization of the crypto algorithms to match that of SA2UL_OMAP documentation, by separating message authentication algorithms from hashing algorithms.

Preview of the algorithms list:
<img width="1590" height="235" alt="image" src="https://github.com/user-attachments/assets/e1fdccea-bbff-4ac0-b4aa-a70345e919c0" />
