### PR TITLE
fix: linux: Fix BL1 and BL31 path in U-Boot command for AM62L

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -463,8 +463,8 @@ Go :ref:`here <download-and-install-sdk>` to download and install the SDK.
       $ cd $UBOOT_DIR
       $ make CROSS_COMPILE="$CROSS_COMPILE_64" am62lx_evm_defconfig
       $ make CROSS_COMPILE="$CROSS_COMPILE_64" \
-         BL1=$TFA_DIR/build/k3/lite/release/bl1.bin \
-         BL31=$TFA_DIR/build/k3/lite/release/bl31.bin \
+         BL1=$TFA_DIR/build/k3/am62l/release/bl1.bin \
+         BL31=$TFA_DIR/build/k3/am62l/release/bl31.bin \
          BINMAN_INDIRS=$TI_LINUX_FW_DIR
 
 .. ifconfig:: CONFIG_part_variant not in ('AM64X', 'AM62X', 'AM62AX', 'AM62LX')


### PR DESCRIPTION
The TARGET_BOARD in the ATF `make` command is `am62l`, not `lite`. But in U-Boot build command for AM62L, BL1 and BL31 paths contain "lite", not "am62l". Fix this.