### PR TITLE
fix(cpsw): Clarify switch mode requirements and remove QSGMII limitation

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSWng-Native-Ethernet.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSWng-Native-Ethernet.rst
@@ -84,7 +84,10 @@ for utilizing the MAC mode features.
 Switch Mode
 """""""""""
 
-All the SoCs listed above support Switch Mode when configured in QSGMII mode.
+.. note::
+
+   Switch mode functionality requires at least two external ethernet ports to work, it is
+   independent of the MAC interface modes.
 
 The Switch mode can be enabled by configuring devlink driver parameter
 "switch_mode" to 1/true::


### PR DESCRIPTION
Replace incorrect QSGMII-only restriction with the explaination that switch mode requires two external ethernet ports and works independently of MAC interface modes.

This corrects misleading documentation that could confuse users about switch mode capabilities across different interface configurations.