### PR TITLE
feat(linux): Update CPSW PTP switch mode documentation

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-PTP.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-PTP.rst
@@ -1068,3 +1068,9 @@ On J7VCL:
    ptp4l[447.707]: master offset      15459 s2 freq   -2401 path delay    180152
    ptp4l[448.707]: master offset        256 s2 freq  -12966 path delay    180152
    ptp4l[449.707]: master offset      -4951 s2 freq  -18096 path delay    180152
+
+.. note::
+
+   You can also test switch mode in a configuration where the device configured as
+   a switch is acting as a master and devices connected to it act as client devices.
+   The setup and commands are the same as it is used here: :ref:`icssg_ptp_switch`.

--- a/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_Switch.rst
+++ b/source/linux/Foundational_Components/PRU-ICSS/Linux_Drivers/PRU_ICSSG_Ethernet_Switch.rst
@@ -167,6 +167,8 @@ To disable cut through on all queues
     expected cut through value. Setting up switch mode will automatically stop and start
     the firmware so no need to bring links down and back up again.
 
+.. _icssg_ptp_switch:
+
 PTP
 """
 PTP can be run during switch mode. To run PTP in switch mode, 3 AM64x EVMs need to be connected with middle EVM acting as the switch. Use the following ptp config file on all slave EVMs. For Master EVM, priority1 filed needs to be changed.


### PR DESCRIPTION
CPSW Switch mode can also be tested where DUT acting as a Switch can be a master of DUTs connected to it. Update the documentation to include that.