### PR TITLE
fix(optee): Document CFLAGS for SDK toolchain

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -447,6 +447,7 @@ Go :ref:`here <download-and-install-sdk>` to download and install the SDK.
       $ export UBOOT_DIR=<path-to-ti-u-boot>
       $ export TI_LINUX_FW_DIR=<path-to-ti-linux-firmware>
       $ export TFA_DIR=<path-to-arm-trusted-firmware>
+      $ export OPTEE_DIR=<path-to-ti-optee-os>
 
    .. note::
 
@@ -465,7 +466,8 @@ Go :ref:`here <download-and-install-sdk>` to download and install the SDK.
       $ make CROSS_COMPILE="$CROSS_COMPILE_64" \
          BL1=$TFA_DIR/build/k3/am62l/release/bl1.bin \
          BL31=$TFA_DIR/build/k3/am62l/release/bl31.bin \
-         BINMAN_INDIRS=$TI_LINUX_FW_DIR
+         BINMAN_INDIRS=$TI_LINUX_FW_DIR \
+         TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin
 
 .. ifconfig:: CONFIG_part_variant not in ('AM64X', 'AM62X', 'AM62AX', 'AM62LX')
 

--- a/source/linux/Foundational_Components_OPTEE.rst
+++ b/source/linux/Foundational_Components_OPTEE.rst
@@ -24,8 +24,8 @@ If it is not possible to use pre-build binary, use the following:
 
 .. code-block:: console
 
-    $ git clone https://github.com/OP-TEE/optee_os.git
-    $ git checkout <hash>
+   $ git clone https://github.com/OP-TEE/optee_os.git
+   $ git checkout <hash>
 
 Where <hash> is the OPTEE commit shown in :ref:`release-specific-build-information`.
 
@@ -43,23 +43,39 @@ Building OP-TEE OS
 
 .. ifconfig:: CONFIG_part_variant in ('J721S2', 'J784S4','J742S2')
 
-    .. code-block:: console
+   .. code-block:: console
 
-        $ export CFG_CONSOLE_UART=0x8
+      $ export CFG_CONSOLE_UART=0x8
 
 Building the OP-TEE image
 *************************
 
-  .. parsed-literal::
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
 
-     $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_USER_TA_TARGETS=ta_arm64
 
 Building the OP-TEE image with debug parameters
 ***********************************************
 
-  .. parsed-literal::
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
 
-     $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 CFG_TEE_CORE_DEBUG=y
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 CFG_TEE_CORE_DEBUG=y
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_TEE_CORE_LOG_LEVEL=2 CFG_TEE_CORE_DEBUG=y CFG_USER_TA_TARGETS=ta_arm64
 
 .. _building-optee-with-prng:
 
@@ -71,9 +87,17 @@ detrimental effect to the overall system latency. Using the
 ``CFG_WITH_SOFTWARE_PRNG`` flag to use OP-TEE's Pseudo RNG drivers as a source
 of entropy can work around these issues.
 
-.. parsed-literal::
+.. ifconfig:: CONFIG_part_variant not in ('AM62LX')
 
-   $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=k3-|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_WITH_SOFTWARE_PRNG=y
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE="$CROSS_COMPILE_32" CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=k3-|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_WITH_SOFTWARE_PRNG=y
+
+.. ifconfig:: CONFIG_part_variant in ('AM62LX')
+
+   .. parsed-literal::
+
+      $ make CROSS_COMPILE64="$CROSS_COMPILE_64" PLATFORM=k3-|__OPTEE_PLATFORM_FLAVOR__| CFG_ARM64_core=y CFG_WITH_SOFTWARE_PRNG=y CFG_USER_TA_TARGETS=ta_arm64
 
 .. _secure-storage-with-rpmb:
 
@@ -151,7 +175,7 @@ To get optee_client source code, do:
 
 .. code-block:: console
 
-  $ git clone https://github.com/OP-TEE/optee_client
+   $ git clone https://github.com/OP-TEE/optee_client
 
 .. rubric:: Building OP-TEE Client with RPMB support
 
@@ -162,7 +186,7 @@ instead of the emulated one.
 
 .. code-block:: console
 
-  $ make CROSS_COMPILE="$CROSS_COMPILE_64" PLATFORM=k3 CFG_TEE_SUPP_LOG_LEVEL=2 RPMB_EMU=0 CFG_ARM64_core=y
+   $ make CROSS_COMPILE="$CROSS_COMPILE_64" PLATFORM=k3 CFG_TEE_SUPP_LOG_LEVEL=2 RPMB_EMU=0 CFG_ARM64_core=y
 
 Now update optee-client binary and libraries on your SD card with the generated ones
 in `out/export/usr` folder
@@ -188,7 +212,7 @@ Integrate binary output into U-boot
 
 .. note::
 
-    tee-pager_v2.bin may be called bl32.bin in other documentation.
+   tee-pager_v2.bin may be called bl32.bin in other documentation.
 
 |
 

--- a/source/linux/Overview/GCC_ToolChain.rst
+++ b/source/linux/Overview/GCC_ToolChain.rst
@@ -23,7 +23,17 @@ Before compiling any of the sources referenced in this document, set the cross c
       host# export CROSS_COMPILE_64="${SDK_INSTALL_DIR}/linux-devkit/sysroots/x86_64-arago-linux/usr/bin/aarch64-oe-linux/aarch64-oe-linux-"
       host# export SYSROOT_64="${SDK_INSTALL_DIR}/linux-devkit/sysroots/aarch64-oe-linux"
       host# export CC_64="${CROSS_COMPILE_64}gcc --sysroot=${SYSROOT_64}"
+      host# export CFLAGS64="--sysroot=${SYSROOT_64}"
+      host# export KCFLAGS="--sysroot=${SYSROOT_64}"
+      host# export LDFLAGS="--sysroot=${SYSROOT_64}"
+
+.. ifconfig:: CONFIG_part_variant not in ('AM335X', 'AM437X', 'AM57X', 'AM62LX')
+
+   .. code-block:: console
+
       host# export CROSS_COMPILE_32="${SDK_INSTALL_DIR}/k3r5-devkit/sysroots/x86_64-arago-linux/usr/bin/arm-oe-eabi/arm-oe-eabi-"
+      host# export SYSROOT_32="${SDK_INSTALL_DIR}/k3r5-devkit/sysroots/armv7at2hf-vfp-oe-eabi"
+      host# export CFLAGS32="--sysroot=${SYSROOT_32}"
 
 If the Processor SDK is not installed, the Arm GNU toolchains can be downloaded and setup. Refer to :ref:`external-arm-toolchain` section for more details on usage.
 


### PR DESCRIPTION
While building OP-TEE with the SDK's Yocto-generated toolchain, the build fails with 'cannot find libgcc.a' linker error. This occurs because the toolchain requires explicit sysroot configuration.

OP-TEE's mk/gcc.mk uses CFLAGS64 and CFLAGS32 while querying gcc for library locations ensuring the compiler returns full paths. Add documentation instructing users to export CFLAGS64 and CFLAGS32 with --sysroot flags before building OP-TEE.