### PR TITLE
PCIe: Update documentation and platform support

### DIFF
--- a/.github/styles/config/vocabularies/PSDK/accept.txt
+++ b/.github/styles/config/vocabularies/PSDK/accept.txt
@@ -22,6 +22,7 @@ Vulkan
 Weston
 Yocto
 Zink
+[Bb]ackplane
 [Cc]odec
 [Dd]unfell
 [Ee]thernet

--- a/configs/AM68/AM68_linux_toc.txt
+++ b/configs/AM68/AM68_linux_toc.txt
@@ -65,8 +65,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-EST
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/configs/AM68A/AM68A_linux_toc.txt
+++ b/configs/AM68A/AM68A_linux_toc.txt
@@ -65,8 +65,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-EST
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/configs/AM69/AM69_linux_toc.txt
+++ b/configs/AM69/AM69_linux_toc.txt
@@ -66,7 +66,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/configs/AM69A/AM69A_linux_toc.txt
+++ b/configs/AM69A/AM69A_linux_toc.txt
@@ -66,7 +66,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/configs/J721S2/J721S2_linux_toc.txt
+++ b/configs/J721S2/J721S2_linux_toc.txt
@@ -69,7 +69,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/configs/TDA4VM/TDA4VM_linux_toc.txt
+++ b/configs/TDA4VM/TDA4VM_linux_toc.txt
@@ -67,8 +67,6 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-EST
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-CBS
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_End_Point
-linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane
 linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex
 linux/Foundational_Components/Kernel/Kernel_Drivers/PMIC/pmic_tps6594
 linux/Foundational_Components_Power_Management

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Backplane.rst
@@ -14,11 +14,11 @@ endpoint controller. Each host should be connected to a separate endpoint
 controller instance and each host will enumerate the other host as an
 independent function.
 
-PCIe uses NTB (non transparent bridge) for two hosts to communicate with each
-other. Though J721E doesn't have an explicit NTB controller, NTB functionality
-can be achieved using multiple endpoint controller instances. And for PCIe
-backplane (to connect more than 2 hosts), aggregation of NTB controllers
-can be modeled using multiple instances of multi-function endpoint controller.
+PCIe uses Non Transparent Bridge (NTB) for two hosts to communicate with each
+other. Though |__PART_FAMILY_DEVICE_NAMES__| does not have an explicit NTB
+controller, multiple endpoint controller instances offer NTB functionality.
+For PCIe backplane (to connect more than 2 hosts), multiple instances of
+multi-function endpoint controller create the aggregation of NTB controllers.
 
 In the below diagram, PCI NTB function configures the SoC with multiple
 PCIe Endpoint (EP) instances in such a way that transaction from one EP
@@ -63,6 +63,12 @@ the endpoint side NTB architecture.
 The following picture shows J721E EVM connected to two DRA7 EVMs. Here the two
 DRA7x boards communicate with each other using J721E as backplane.
 
+.. ifconfig:: CONFIG_part_variant in ('J784S4','J742S2')
+
+   Similarly, you can connect |__PART_FAMILY_DEVICE_NAMES__| to two hosts, who
+   can communicate with each other using |__PART_FAMILY_DEVICE_NAMES__|
+   as backplane.
+
 .. Image:: /images/j721e-backplane.jpg
 
 
@@ -71,21 +77,33 @@ DRA7x boards communicate with each other using J721E as backplane.
 
 .. rubric:: *Backplane DTS Overlay File*
 
-The following DTS overlay file configures the PCIe controller in EP mode and
-also contains a device tree node to create a NTB function device:
+The following device tree overlay files configure both the PCIe controller in EP mode
+required for NTB functionality:
 
-::
+.. ifconfig:: CONFIG_part_variant in ('J784S4','J742S2')
 
-  arch/arm64/boot/dts/ti/k3-j721e-pcie-backplane.dtso
+   * :file:`arch/arm64/boot/dts/ti/k3-j784s4-evm-pcie0-pcie1-ep.dtso`
 
-In order to apply the dts overlay file, the following command should be given
-in u-boot prompt:
+.. ifconfig:: CONFIG_part_variant not in ('J784S4','J742S2')
 
-::
+   * :file:`arch/arm64/boot/dts/ti/k3-j721e-evm-pcie0-ep.dtso`
+   * :file:`arch/arm64/boot/dts/ti/k3-j721e-evm-pcie1-ep.dtso`
 
-  #setenv name_overlays ti/k3-j721e-pcie-backplane.dtbo
+To apply the device tree overlay files, run the following command in the u-boot prompt:
 
-.. rubric:: *EP Side Configuration (J721E Backplane)*
+.. ifconfig:: CONFIG_part_variant in ('J784S4','J742S2')
+
+   .. code-block:: console
+
+      setenv name_overlays ti/k3-j784s4-evm-pcie0-pcie1-ep.dtbo
+
+.. ifconfig:: CONFIG_part_variant not in ('J784S4','J742S2')
+
+   .. code-block:: console
+
+      setenv name_overlays ti/k3-j721e-evm-pcie0-ep.dtbo ti/k3-j721e-evm-pcie1-ep.dtbo
+
+.. rubric:: *EP Side Configuration (Backplane)*
    :name: ep-side-configuration
 
 .. rubric:: **Dip switch settings**
@@ -100,9 +118,9 @@ in u-boot prompt:
   Both PCIe instances should be configured in EP mode by setting
   PCIE_1L_MODE_SEL (switch 5) and PCIE_2L_MODE_SEL (switch 6) in sw3 to '1'.
 
-.. rubric:: **8.x SDK (5.10 Kernel)**
+.. rubric:: **EP Backplane Configuration Steps**
 
-The following set of steps is required only for 5.10 Kernel
+Follow these steps to configure the PCIe endpoints as a backplane:
 
     .. rubric:: Creating pci-epf-ntb device
 
@@ -111,6 +129,7 @@ The following set of steps is required only for 5.10 Kernel
 
     ::
 
+        # modprobe pci_epf_ntb
         # mount -t configfs none /sys/kernel/config
         # cd /sys/kernel/config/pci_ep/
         # mkdir functions/pci_epf_ntb/func1
@@ -151,15 +170,8 @@ The following set of steps is required only for 5.10 Kernel
         # echo 0x104c > functions/pci_epf_ntb/func1/vendorid
         # echo 0xb00d > functions/pci_epf_ntb/func1/deviceid
 
-    In order to configure NTB specific attributes, a new sub-directory to func1
-    should be created
-
-    ::
-
-        # mkdir functions/pci_epf_ntb/func1/pci_epf_ntb.0/
-
-    The NTB function driver will populate this directory with various attributes
-    that can be configured by the user
+    The NTB function driver also populates :file:`func1/pci_epf_ntb.0` directory with
+    various attributes that can be configured by the user
 
     ::
 
@@ -188,13 +200,13 @@ The following set of steps is required only for 5.10 Kernel
 
     ::
 
-        # ln -s controllers/2900000.pcie-ep/ functions/pci-epf-ntb/func1/primary
-        # ln -s controllers/2910000.pcie-ep/ functions/pci-epf-ntb/func1/secondary
+        # ln -s controllers/2900000.pcie-ep/ functions/pci_epf_ntb/func1/primary
+        # ln -s controllers/2910000.pcie-ep/ functions/pci_epf_ntb/func1/secondary
 
     Once the above step is completed, both the PCI endpoint controllers are ready to
     establish a link with the host.
 
-    .. rubric:: Start the Link: 7.x and 8.x SDK (5.4 and 5.10 Kernel)
+    .. rubric:: Start the Link:
 
     In order for the endpoint device to establish a link with the host, the _start_
     field should be populated with '1'. For NTB, both the PCI endpoint controllers
@@ -204,9 +216,6 @@ The following set of steps is required only for 5.10 Kernel
 
         # echo 1 > controllers/2900000.pcie-ep/start
         # echo 1 > controllers/2910000.pcie-ep/start
-
-(PCIe2 can also be configured for NTB, but that is not
-tested yet).
 
 .. rubric:: *RC Side Configuration*
    :name: rc-side-configuration
@@ -221,6 +230,7 @@ existing driver.
 
 ::
 
+  modprobe ntb_hw_epf
   echo 0000:01:00.0 > /sys/bus/pci/devices/0000\:01\:00.0/driver/unbind
 
 After unbinding from existing driver, it should be bound to ntb_hw_epf driver.
@@ -241,14 +251,14 @@ hosts.
 .. rubric:: **Kernel Configs**
    :name: kernel-configs
 
-.. rubric:: *EP Side (J721E Backplane)*
+.. rubric:: *EP Side (Backplane)*
    :name: ep-side-configs
 
 ::
 
   CONFIG_PCI_ENDPOINT=y
   CONFIG_PCI_ENDPOINT_CONFIGFS=y
-  CONFIG_PCI_EPF_NTB=y
+  CONFIG_PCI_EPF_NTB=m
   CONFIG_PCI_J721E=y
   CONFIG_PCIE_CADENCE=y
   CONFIG_PCIE_CADENCE_EP=y
@@ -274,5 +284,5 @@ For additional information, please refer to:
 
 ::
 
-  <Processor_SDK_install_dir>/board-support/linux-[ver]/Documentation/PCI/endpoint/pci-test-ntb.txt
+  <Processor_SDK_install_dir>/board-support/linux-[ver]/Documentation/PCI/endpoint/pci-ntb-function.rst
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/PCIe/PCIe_Root_Complex.rst
@@ -146,70 +146,84 @@ Following is a brief explanation of layers shown in the diagram:
 
 .. ifconfig:: CONFIG_part_family in ('AM64X_family','J7_family')
 
-    .. rubric:: **RC Device Configuration**
-       :name: rc-device-configuration
+   .. rubric:: **RC Device Configuration**
+      :name: rc-device-configuration
 
-    .. rubric:: *DTS Modification*
-       :name: rc-dts-modification
+   .. rubric:: *DTS Modification*
+      :name: rc-dts-modification
 
-    The default dts for |__PART_FAMILY_DEVICE_NAMES__| is configured to be used in
-    root complex mode.
+   The default dts for |__PART_FAMILY_DEVICE_NAMES__| is configured to be used in
+   root complex mode.
 
-    .. rubric:: *Linux Driver Configuration*
-       :name: linux-driver-configuration
+   .. rubric:: *Linux Driver Configuration*
+      :name: linux-driver-configuration
 
-    The following config options have to be enabled in order to configure the
-    PCI controller to be used in Root Complex mode.
+   The following config options have to be enabled in order to configure the
+   PCI controller to be used in Root Complex mode.
 
-    ::
+   ::
 
-        CONFIG_SOCIONEXT_SYNQUACER_PREITS=y
-        CONFIG_PCI=y
-        CONFIG_PCI_MSI=y
-        CONFIG_PCI_J721E=y
-        CONFIG_PCIE_CADENCE=y
-        CONFIG_PCIE_CADENCE_HOST=y
+      CONFIG_SOCIONEXT_SYNQUACER_PREITS=y
+      CONFIG_PCI=y
+      CONFIG_PCI_MSI=y
+      CONFIG_PCI_J721E=y
+      CONFIG_PCIE_CADENCE=y
+      CONFIG_PCIE_CADENCE_HOST=y
 
-    .. rubric:: **Compliance Mode**
-        :name: compliance-mode
+   .. rubric:: **Compliance Mode**
+      :name: compliance-mode
 
-    In RC mode of operation, the Endpoint device can be forced to enter
-    Compliance Mode for PCIe compliance testing by setting the "EC" bit
-    in the LINK_CTRL_STATUS_2 register of the respective PCIe RC instance.
-    Setting "EC" to 1 initiates a hot reset thereby forcing the Endpoint
-    device into Compliance mode. The "EC" bit can be set from command-line
-    by using devmem2 utility as follows:
+   In RC mode of operation, the Endpoint device can be forced to enter
+   Compliance Mode for PCIe compliance testing by setting the "EC" bit
+   in the LINK_CTRL_STATUS_2 register of the respective PCIe RC instance.
+   Setting "EC" to 1 initiates a hot reset thereby forcing the Endpoint
+   device into Compliance mode. The "EC" bit can be set from command-line
+   by using devmem2 utility as follows:
 
-        devmem2 <address> w <value>
+      devmem2 <address> w <value>
 
-    where <address> is the address of LINK_CTRL_STATUS_2 register and
-    <value> is the resulting value to be written with "EC" bit of the
-    register set.
+   where <address> is the address of LINK_CTRL_STATUS_2 register and
+   <value> is the resulting value to be written with "EC" bit of the
+   register set.
 
-    .. rubric:: **64-Bit Address Space with 4 GB Size**
-       :name: 64-bit-address-space
+   .. rubric:: **64-Bit Address Space with 4 GB Size**
+      :name: 64-bit-address-space
 
-    The PCIe Controller support for 64-Bit addressing in the System's
-    Address Space with 4 GB Size is enabled in the device-tree.
-    The 4 GB region is split as:
+   The PCIe Controller support for 64-Bit addressing in the System's
+   Address Space with 4 GB Size is enabled in the device-tree.
+   The 4 GB region is split as:
 
-    1. 4 KB ECAM region for Configuration Accesses
-    2. 1 MB IO region
-    3. Remaining region (4 GB - 1 MB - 4 KB) as 32-bit Non-Prefetchable MEM
+   1. 4 KB ECAM region for Configuration Accesses
+   2. 1 MB IO region
+   3. Remaining region (4 GB - 1 MB - 4 KB) as 32-bit Non-Prefetchable MEM
 
-    .. rubric:: **Testing Details**
-       :name: testing-details
+   .. note::
 
-    The RC should enumerate any off-the-shelf PCIe cards. It has been tested
-    with Ethernet cards, NVMe cards, PCIe USB card, PCIe WiFi card, PCIe SATA
-    card and also to |__PART_FAMILY_DEVICE_NAMES__| in loopback mode.
+      If the root complex is connected to an endpoint with virtual functions,
+      and the kernel panics during enumeration, add ``pci=realloc`` to ``optargs``
+      at the U-Boot prompt using the following command:
 
-    In order to see if the connected card is detected, lspci utility should be
-    used. Different utilities can be used depending on the cards.
+      .. code-block:: console
 
-    Following are the outputs for some of them:
+         setenv optargs 'pci=realloc'
 
-    - Loopback mode (|__PART_FAMILY_DEVICE_NAMES__| EVM to |__PART_FAMILY_DEVICE_NAMES__| EVM)
+      The ``pci=realloc`` parameter instructs the Linux kernel to reallocate PCI
+      bridge resources. This helps resolve resource conflicts during enumeration
+      of PCIe devices by allowing the kernel to reassign memory and I/O addresses.
+
+   .. rubric:: **Testing Details**
+      :name: testing-details
+
+   The RC should enumerate any off-the-shelf PCIe cards. It has been tested
+   with Ethernet cards, NVMe cards, PCIe USB card, PCIe WiFi card, PCIe SATA
+   card and also to |__PART_FAMILY_DEVICE_NAMES__| in loopback mode.
+
+   In order to see if the connected card is detected, lspci utility should be
+   used. Different utilities can be used depending on the cards.
+
+   Following are the outputs for some of them:
+
+   - Loopback mode (|__PART_FAMILY_DEVICE_NAMES__| EVM to |__PART_FAMILY_DEVICE_NAMES__| EVM)
 
       Two |__PART_FAMILY_DEVICE_NAMES__| EVMs can be connected in loopback mode by following
       the steps explained in


### PR DESCRIPTION
Update PCIe Backplane documentation to support J721E, J784S4, and J742S2 SoCs while removing unsupported platforms.