### PR TITLE
docs(linux): Add PTP support documentation for HSR and PRP offload

### DIFF
--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -64,6 +64,7 @@ linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-IET
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-TSN-Tuning
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/NETCONF-YANG
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_Non_Offload
+linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_Offload
 linux/Foundational_Components/Kernel/Kernel_Drivers/Network/PRP_Offload
 linux/Foundational_Components/Kernel/Kernel_Drivers/SPI

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_Offload.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_Offload.rst
@@ -339,6 +339,12 @@ Example:
 
    # ip maddr del 01:80:c4:00:00:0e dev hsr0.5
 
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+   .. rubric:: *PTP Support*
+
+   For PTP support over HSR, see :ref:`hsr-prp-ptp`.
+
 .. rubric:: Performance
 
 This section describes the throughput and CPU usage metrics in the offload case

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP.rst
@@ -1,0 +1,69 @@
+.. _hsr-prp-ptp:
+
+=======================
+HSR and PRP PTP support
+=======================
+
+The `linuxptp-hsr <https://git.kernel.org/pub/scm/linux/kernel/git/bigeasy/linuxptp-hsr.git>`_
+implementation on the ``hsr_prp_v2_plus`` branch supports PTP (Precision Time Protocol)
+synchronization over High-availability Seamless Redundancy (HSR) and Parallel Redundancy
+Protocol (PRP) interfaces.
+
+In the following commands, replace ``<proto>`` with ``hsr`` or ``prp`` as appropriate.
+
+.. rubric:: Prerequisites
+
+Complete the following steps on each node.
+
+Clone linuxptp-hsr:
+
+.. code-block:: console
+
+   git clone https://git.kernel.org/pub/scm/linux/kernel/git/bigeasy/linuxptp-hsr.git
+   cd linuxptp-hsr
+   git checkout hsr_prp_v2_plus
+
+Patch the config files with the actual interface names and the P2P destination MAC
+address. The config files use INI-style sections where ``[eth1]`` and ``[eth2]``
+denote the two physical interfaces. The first command appends the ``p2p_dst_mac``
+key (destination MAC for P2P delay-request messages) into the ``[global]``
+section just after the ``delay_mechanism`` key. The second command replaces the
+``[eth1]`` and ``[eth2]`` section headers with the actual interface names:
+
+.. code-block:: console
+
+   sed -i '/^delay_mechanism/a p2p_dst_mac 01:1B:19:00:00:01' configs/<proto>-master.cfg configs/<proto>-slave.cfg
+   sed -i 's/^\[eth1\]/[<INTF_A>]/; s/^\[eth2\]/[<INTF_B>]/' configs/<proto>-master.cfg configs/<proto>-slave.cfg
+
+Build and install:
+
+.. code-block:: console
+
+   make && make install
+
+.. rubric:: Running PTP
+
+Set up the HSR or PRP interface as described in the respective offload documentation.
+On the PTP primary node:
+
+.. code-block:: console
+
+   ./ptp4l -f configs/<proto>-master.cfg
+
+On each PTP secondary node:
+
+.. code-block:: console
+
+   ./ptp4l -f configs/<proto>-slave.cfg
+
+.. rubric:: Verifying PTP synchronization
+
+Inspect the ``master offset`` values in the ptp4l log output to verify PTP synchronization.
+
+Sample ptp4l output showing a synchronized secondary node:
+
+.. code-block:: text
+
+   ptp4l[xx.xxx]: master offset   -123 s2 freq  +4321 path delay   543
+   ptp4l[xx.xxx]: master offset     45 s2 freq  +4290 path delay   541
+   ptp4l[xx.xxx]: master offset    -78 s2 freq  +4310 path delay   544

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/PRP_Offload.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/PRP_Offload.rst
@@ -309,6 +309,12 @@ Example:
 
    # ip maddr del 01:80:c4:00:00:0e dev prp0.5
 
+.. ifconfig:: CONFIG_part_variant in ('AM64X')
+
+   .. rubric:: *PTP Support*
+
+   For PTP support over PRP, see :ref:`hsr-prp-ptp`.
+
 .. rubric:: Performance
 
 This section describes the throughput and CPU usage metrics in the offload case

--- a/source/linux/Foundational_Components_Kernel_Drivers.rst
+++ b/source/linux/Foundational_Components_Kernel_Drivers.rst
@@ -29,6 +29,7 @@ Kernel Drivers
    Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_Non_Offload
    Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_Offload
    Foundational_Components/Kernel/Kernel_Drivers/Network/PRP_Offload
+   Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP
    Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW-Ethernet
    Foundational_Components/Kernel/Kernel_Drivers/Network/CPSW2g
    Foundational_Components/Kernel/Kernel_Drivers/Network/NETCONF-YANG


### PR DESCRIPTION
Document PTP synchronization support over HSR and PRP interfaces using the linuxptp-hsr implementation (hsr_prp_v2_plus branch).

Add Prerequisites, Running PTP, and Verifying PTP Synchronization subsections to both HSR_Offload.rst and PRP_Offload.rst covering:
- Cloning and building linuxptp-hsr
- Patching config files with interface names and p2p_dst_mac
- Running ptp4l with master/slave configs
- Verifying sync via master offset values