### PR TITLE
perf(linux): Update Ethernet performance data for 12.00.00.07

### DIFF
--- a/source/devices/AM62DX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62DX/linux/Linux_Performance_Guide.rst
@@ -443,17 +443,20 @@ UDP Throughput
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am62dxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62dxx_evm-fs: THROUGHPUT (Mbits/sec)","am62dxx_evm-fs: Packets Per Second (kPPS)","am62dxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","46.03 (min 45.82, max 46.24)","89.50 (min 89.00, max 90.00)","38.12 (min 38.01, max 38.23)"
-    "128","","91.09 (min 90.84, max 91.34)","89.00","38.04 (min 37.99, max 38.09)"
+    "64","","45.45","89","37.6"
+    "128","","90.47","88","37.6"
+    "256","","181.31","89","37.7"
+    "1024","","704.12","86","37.1"
+    "1518","","716.61","61","29.8"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am62dxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62dxx_evm-fs: THROUGHPUT (Mbits/sec)","am62dxx_evm-fs: Packets Per Second (kPPS)","am62dxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","1.97 (min 1.54, max 2.15)","3.75 (min 3.00, max 4.00)","2.24 (min 1.52, max 3.73)"
-    "128","","5.15 (min 5.12, max 5.22)","5.00","2.97 (min 2.13, max 4.33)"
-    "256","","9.78 (min 9.01, max 10.65)","4.75 (min 4.00, max 5.00)","2.84 (min 1.03, max 5.42)"
-    "1024","","43.09 (min 38.50, max 51.61)","5.20 (min 5.00, max 6.00)","3.78 (min 2.73, max 6.02)"
-    "1518","","60.76 (min 55.35, max 64.77)","5.20 (min 5.00, max 6.00)","3.50 (min 2.30, max 5.87)"
+    "64","","33.69","66","11.8"
+    "128","","80.87","79","20.9"
+    "256","","154.01","75","14.0"
+    "1024","","617.87","75","23.8"
+    "1518","","726.36","62","29.2"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am62dxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62dxx_evm-fs: THROUGHPUT (Mbits/sec)","am62dxx_evm-fs: Packets Per Second (kPPS)","am62dxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)","am62dxx_evm-fs: Packet Loss %"

--- a/source/devices/AM62LX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62LX/linux/Linux_Performance_Guide.rst
@@ -499,7 +499,7 @@ TCP Bidirectional Throughput
 .. csv-table:: CPSW2g TCP Bidirectional Throughput
     :header: "Command Used","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1048.02 (min 1035.65, max 1060.38)","99.10 (min 98.47, max 99.72)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1064.14","100.0"
 
 TCP Bidirectional Throughput Interrupt Pacing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -507,7 +507,7 @@ TCP Bidirectional Throughput Interrupt Pacing
 .. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1182.95 (min 1179.68, max 1186.21)","95.50 (min 95.39, max 95.60)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","988.33","96.5"
 
 UDP Throughput
 ^^^^^^^^^^^^^^
@@ -515,20 +515,20 @@ UDP Throughput
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am62lxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: Packets Per Second (kPPS)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","36.89 (min 36.82, max 36.96)","72.00","75.48 (min 75.29, max 75.67)"
-    "128","","80.20","78.00","77.85"
-    "256","","145.24","71.00","75.58"
-    "1024","","355.15 (min 137.62, max 572.68)","43.50 (min 17.00, max 70.00)","49.89 (min 24.19, max 75.58)"
-    "1518","","623.50 (min 619.61, max 627.38)","51.50 (min 51.00, max 52.00)","72.61 (min 71.63, max 73.58)"
+    "64","","39.22","77","77.1"
+    "128","","80.94","79","77.3"
+    "256","","158.35","77","76.7"
+    "1024","","569.25","69","74.3"
+    "1518","","769.98","65","73.8"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am62lxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: Packets Per Second (kPPS)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","1.54 (min 1.48, max 1.59)","3.00","1.97 (min 1.84, max 2.10)"
-    "128","","4.46 (min 4.40, max 4.51)","4.00","3.70 (min 2.67, max 4.73)"
-    "256","","10.14 (min 10.04, max 10.24)","5.00","3.06 (min 3.00, max 3.11)"
-    "1024","","42.19 (min 41.78, max 42.60)","5.00","3.49 (min 3.40, max 3.57)"
-    "1518","","34.74 (min 8.24, max 61.23)","3.00 (min 1.00, max 5.00)","3.65 (min 1.02, max 6.27)"
+    "64","","29.44","58","34.9"
+    "128","","79.46","78","45.3"
+    "256","","144.79","71","44.6"
+    "1024","","587.36","72","64.1"
+    "1518","","804.28","68","73.4"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am62lxx_evm-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: Packets Per Second (kPPS)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)","am62lxx_evm-fs: Packet Loss %"

--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -527,7 +527,7 @@ TCP Bidirectional Throughput
 .. csv-table:: CPSW2g TCP Bidirectional Throughput
     :header: "Command Used","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1553.15 (min 1176.25, max 1811.29)","54.49 (min 39.05, max 70.68)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1861.06","64.5"
 
 TCP Bidirectional Throughput Interrupt Pacing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -535,7 +535,7 @@ TCP Bidirectional Throughput Interrupt Pacing
 .. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1849.66 (min 1825.39, max 1875.16)","38.86 (min 32.01, max 45.30)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1868.75","43.3"
 
 UDP Throughput
 ^^^^^^^^^^^^^^
@@ -543,16 +543,20 @@ UDP Throughput
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am62pxx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: Packets Per Second (kPPS)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","51.17 (min 41.42, max 63.85)","100.00 (min 81.00, max 125.00)","40.18 (min 37.30, max 43.08)"
-    "128","","101.30 (min 81.62, max 127.24)","99.00 (min 80.00, max 124.00)","39.93 (min 37.23, max 42.60)"
-    "256","","199.81 (min 162.14, max 250.72)","97.25 (min 79.00, max 122.00)","39.74 (min 36.74, max 42.59)"
-    "1024","","768.11 (min 634.77, max 935.43)","93.50 (min 77.00, max 114.00)","40.08 (min 36.82, max 45.20)"
-    "1518","","759.63 (min 622.71, max 917.85)","62.75 (min 51.00, max 76.00)","37.32 (min 34.57, max 41.16)"
+    "64","","45.23","88","37.1"
+    "128","","91.87","90","37.1"
+    "256","","181.86","89","37.3"
+    "1024","","695.24","85","36.4"
+    "1518","","956.34","81","39.1"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am62pxx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: Packets Per Second (kPPS)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "128","","4.37 (min 3.89, max 5.02)","4.33 (min 4.00, max 5.00)","1.36 (min 0.83, max 2.25)"
+    "64","","30.41","59","12.2"
+    "128","","74.95","73","16.2"
+    "256","","158.31","77","16.8"
+    "1024","","645.51","79","24.2"
+    "1518","","953.67","81","39.0"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am62pxx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: Packets Per Second (kPPS)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62pxx_sk-fs: Packet Loss %"

--- a/source/devices/AM62X/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62X/linux/Linux_Performance_Guide.rst
@@ -535,7 +535,7 @@ TCP Bidirectional Throughput
 .. csv-table:: CPSW2g TCP Bidirectional Throughput
     :header: "Command Used","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1606.03 (min 1303.43, max 1816.77)","60.01 (min 39.33, max 71.84)","1540.48 (min 1283.30, max 1773.53)","52.49 (min 40.80, max 68.45)","1673.91 (min 1656.34, max 1691.48)","64.30 (min 62.64, max 65.95)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1720.59","65.0","1740.81","68.7","1843.31","68.7"
 
 TCP Bidirectional Throughput Interrupt Pacing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -543,7 +543,7 @@ TCP Bidirectional Throughput Interrupt Pacing
 .. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1641.49 (min 1549.80, max 1756.23)","51.62 (min 39.44, max 63.10)","1563.91 (min 1444.87, max 1707.72)","39.79 (min 33.68, max 47.59)","1731.44 (min 1694.58, max 1768.29)","50.23 (min 42.61, max 57.85)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1815.63","65.8","1835.76","60.1","1835.81","51.6"
 
 UDP Throughput
 ^^^^^^^^^^^^^^
@@ -551,20 +551,20 @@ UDP Throughput
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am62xx_lp_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: Packets Per Second (kPPS)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: Packets Per Second (kPPS)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: Packets Per Second (kPPS)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","46.06 (min 37.80, max 54.51)","90.00 (min 74.00, max 106.00)","39.08 (min 36.43, max 42.06)","","53.38 (min 42.81, max 62.88)","104.40 (min 84.00, max 123.00)","39.68 (min 36.73, max 42.59)","","44.24 (min 43.33, max 45.15)","86.50 (min 85.00, max 88.00)","37.12 (min 36.93, max 37.30)"
-    "128","","85.61 (min 73.61, max 109.51)","83.67 (min 72.00, max 107.00)","38.00 (min 36.03, max 41.81)","","104.87 (min 82.30, max 121.26)","102.20 (min 80.00, max 118.00)","39.45 (min 36.24, max 41.89)","","90.28 (min 89.44, max 91.11)","88.00 (min 87.00, max 89.00)","37.38 (min 37.37, max 37.38)"
-    "256","","179.15 (min 147.10, max 213.03)","87.50 (min 72.00, max 104.00)","38.96 (min 36.23, max 42.27)","","127.26 (min 53.04, max 239.91)","62.00 (min 26.00, max 117.00)","24.61 (min 8.86, max 41.07)","","174.19 (min 171.67, max 176.70)","85.00 (min 84.00, max 86.00)","36.85 (min 36.54, max 37.16)"
-    "1024","","662.53 (min 586.81, max 812.44)","81.00 (min 72.00, max 99.00)","37.83 (min 35.95, max 40.50)","","395.91 (min 163.01, max 663.99)","48.40 (min 20.00, max 81.00)","20.92 (min 8.11, max 36.34)","","645.78 (min 634.74, max 656.81)","78.50 (min 77.00, max 80.00)","36.08 (min 35.77, max 36.38)"
-    "1518","","700.49 (min 612.17, max 810.09)","57.75 (min 50.00, max 67.00)","36.31 (min 34.89, max 37.94)","","606.38 (min 537.43, max 675.32)","50.00 (min 44.00, max 56.00)","32.91 (min 30.89, max 34.93)","","699.12 (min 692.68, max 705.56)","57.50 (min 57.00, max 58.00)","35.18 (min 35.07, max 35.28)"
+    "64","","38.06","74","36.2","","45.82","89","37.4","","43.00","84","36.6"
+    "128","","76.00","74","36.4","","84.91","83","36.6","","91.06","89","37.7"
+    "256","","151.70","74","36.3","","173.88","85","36.6","","177.19","87","37.1"
+    "1024","","593.77","72","36.2","","691.51","84","36.6","","652.59","80","36.1"
+    "1518","","832.97","71","35.7","","136.59","12","6.6","","936.62","80","37.6"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am62xx_lp_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: Packets Per Second (kPPS)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: Packets Per Second (kPPS)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: Packets Per Second (kPPS)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","1.82 (min 1.38, max 2.10)","3.75 (min 3.00, max 4.00)","2.15 (min 1.69, max 2.84)","","1.72 (min 1.43, max 2.10)","3.40 (min 3.00, max 4.00)","1.42 (min 0.53, max 2.65)","","2.18 (min 2.10, max 2.25)","4.00","1.24 (min 1.04, max 1.43)"
-    "128","","4.07 (min 3.69, max 5.02)","4.25 (min 4.00, max 5.00)","2.53 (min 1.33, max 4.89)","","4.55 (min 4.10, max 5.22)","4.40 (min 4.00, max 5.00)","2.22 (min 0.81, max 4.32)","","4.86 (min 4.40, max 5.32)","4.50 (min 4.00, max 5.00)","1.28 (min 0.97, max 1.58)"
-    "256","","9.73 (min 9.22, max 10.24)","5.00","3.26 (min 2.02, max 4.50)","","9.63 (min 9.01, max 10.24)","4.67 (min 4.00, max 5.00)","1.47 (min 1.21, max 1.89)","","10.04 (min 9.83, max 10.24)","5.00","1.66 (min 1.21, max 2.11)"
-    "1024","","41.78","5.00","2.92 (min 2.18, max 4.20)","","41.78","5.00","1.58 (min 1.40, max 1.90)","","41.78","5.00","2.82"
-    "1518","","61.23","5.00","3.88 (min 3.72, max 4.08)","","70.26 (min 60.06, max 89.50)","6.00 (min 5.00, max 8.00)","4.64 (min 4.27, max 5.26)"
+    "64","","36.15","71","20.2","","35.58","69","19.1","","29.70","58","11.2"
+    "128","","72.91","71","20.8","","76.08","74","22.0","","71.99","70","17.9"
+    "256","","170.60","83","24.6","","160.11","78","23.1","","150.70","74","16.3"
+    "1024","","532.48","65","30.0","","703.56","86","28.5","","722.42","88","29.1"
+    "1518","","954.19","81","39.9","","956.87","81","39.9","","934.99","79","38.6"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am62xx_lp_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: Packets Per Second (kPPS)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_lp_sk-fs: Packet Loss %","am62xx_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: Packets Per Second (kPPS)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: Packet Loss %","am62xxsip_sk-fs: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: Packets Per Second (kPPS)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: Packet Loss %"

--- a/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
+++ b/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
@@ -349,7 +349,7 @@ TCP Bidirectional Throughput
 .. csv-table:: CPSW2g TCP Bidirectional Throughput
     :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1100.48 (min 1064.93, max 1125.49)","99.80 (min 99.68, max 99.87)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1051.83","98.0"
 
 TCP Bidirectional Throughput Interrupt Pacing
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -357,7 +357,7 @@ TCP Bidirectional Throughput Interrupt Pacing
 .. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1129.68 (min 1104.10, max 1180.26)","92.57 (min 77.95, max 98.21)"
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1141.56","98.7"
 
 UDP Throughput
 ^^^^^^^^^^^^^^
@@ -365,19 +365,20 @@ UDP Throughput
 .. csv-table:: CPSW2g UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am64xx-hsevm: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: Packets Per Second (kPPS)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","31.91 (min 16.92, max 46.99)","62.25 (min 33.00, max 92.00)","71.14 (min 54.01, max 87.52)"
-    "128","","62.77 (min 33.94, max 92.73)","61.50 (min 33.00, max 91.00)","69.80 (min 52.96, max 86.37)"
-    "256","","91.10 (min 53.10, max 171.91)","44.50 (min 26.00, max 84.00)","56.55 (min 31.44, max 87.70)"
-    "1024","","420.23 (min 273.76, max 655.96)","51.00 (min 33.00, max 80.00)","66.26 (min 53.48, max 89.14)"
-    "1518","","443.96 (min 254.51, max 628.95)","36.50 (min 21.00, max 52.00)","71.19 (min 53.13, max 89.29)"
+    "64","","44.26","86","87.2"
+    "128","","84.74","83","87.4"
+    "256","","168.40","82","90.2"
+    "1024","","612.56","75","89.4"
+    "1518","","864.47","73","89.6"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am64xx-hsevm: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: Packets Per Second (kPPS)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "128","","4.89 (min 4.40, max 5.43)","4.50 (min 4.00, max 5.00)","2.05 (min 0.20, max 7.47)"
-    "256","","10.60 (min 10.24, max 11.06)","5.00","1.86 (min 0.13, max 6.88)"
-    "1024","","42.05 (min 41.78, max 42.60)","5.00","3.74 (min 0.94, max 7.58)"
-    "1518","","63.29 (min 62.41, max 64.76)","5.00","7.24 (min 7.04, max 7.31)"
+    "64","","30.77","60","35.0"
+    "128","","74.65","73","43.7"
+    "256","","150.12","73","44.4"
+    "1024","","566.07","69","48.6"
+    "1518","","876.13","74","66.7"
 
 .. csv-table:: CPSW2g UDP Ingress Throughput possible loss
     :header: "Frame Size(bytes)","am64xx-hsevm: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: Packets Per Second (kPPS)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)","am64xx-hsevm: Packet Loss %"
@@ -390,21 +391,21 @@ UDP Throughput
 ICSSG Ethernet
 --------------
 
-TCP Bidirectional Throughput
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ICSSG TCP Bidirectional Throughput
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table:: ICSSG TCP Bidirectional Throughput
     :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","812.01 (min 355.31, max 1121.74)","83.12 (min 74.78, max 99.72)"
+    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","1073.37","95.6"
 
-TCP Bidirectional Throughput Interrupt Pacing
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ICSSG TCP Bidirectional Throughput Interrupt Pacing
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. csv-table:: ICSSG TCP Bidirectional Throughput Interrupt Pacing
     :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","528.47 (min 363.92, max 1021.70)","50.15 (min 38.53, max 84.08)"
+    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","1039.79","83.8"
 
 UDP Egress Throughput
 ^^^^^^^^^^^^^^^^^^^^^
@@ -412,11 +413,11 @@ UDP Egress Throughput
 .. csv-table:: ICSSG UDP Egress Throughput 0 loss
     :header: "Frame Size(bytes)","am64xx-hsevm: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: Packets Per Second (kPPS)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
 
-    "64","","18.70 (min 16.63, max 19.65)","36.25 (min 32.00, max 38.00)","53.66 (min 53.49, max 53.81)"
-    "128","","37.99 (min 35.64, max 39.58)","37.25 (min 35.00, max 39.00)","53.92 (min 53.64, max 54.23)"
-    "256","","122.26 (min 70.86, max 173.65)","59.75 (min 35.00, max 85.00)","71.04 (min 53.56, max 89.45)"
-    "1024","","421.89 (min 20.48, max 646.48)","51.67 (min 3.00, max 79.00)","59.85 (min 0.95, max 89.47)"
-    "1472","","225.95 (min 9.42, max 866.11)","19.25 (min 1.00, max 74.00)","23.84 (min 0.19, max 88.88)"
+    "64","","45.31","88","87.5"
+    "128","","87.49","85","88.4"
+    "256","","166.04","81","89.2"
+    "1024","","610.00","74","89.3"
+    "1472","","855.64","73","90.1"
 
 UDP Ingress Throughput
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -424,11 +425,11 @@ UDP Ingress Throughput
 .. csv-table:: ICSSG UDP Ingress Throughput 0 loss
     :header: "Frame Size(bytes)","am64xx-hsevm: UDP Datagram Size(bytes) (LOCAL_SEND_SIZE)","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: Packets Per Second (kPPS)","am64xx-hsevm: CPU Load %"
 
-    "64","","1.55 (min 1.43, max 1.64)","3.00","2.63 (min 0.19, max 6.18)"
-    "128","","4.43 (min 4.30, max 4.71)","4.25 (min 4.00, max 5.00)","1.16 (min 0.22, max 2.30)"
-    "256","","10.14 (min 9.63, max 10.65)","5.00","4.54 (min 0.32, max 6.49)"
-    "1024","","43.22 (min 42.60, max 43.42)","5.00","6.99 (min 5.41, max 9.72)"
-    "1472","","99.50 (min 61.23, max 181.34)","8.25 (min 5.00, max 15.00)","11.03 (min 6.91, max 20.94)"
+    "64","","36.35","71","44.2"
+    "128","","70.25","69","47.0"
+    "256","","138.03","67","45.5"
+    "1024","","530.84","65","52.5"
+    "1472","","626.48","53","48.6"
 
 |
 


### PR DESCRIPTION
Update TCP Bidir, TCP Bidir Interrupt Pacing, UDP Egress (0-loss) and UDP Ingress (0-loss) performance tables for the following platforms:
- AM62X (CPSW3g: am62xx_sk-fs, am62xx_lp_sk-fs, am62xxsip_sk-fs)
- AM62PX (CPSW3g: am62pxx_sk-fs)
- AM62LX (CPSW3g: am62lxx_evm-fs)
- AM62DX (CPSW3g: am62dxx_evm-fs)
- AM64X RT (CPSW2G + ICSSG: am64xx-hsevm)

UDP Ingress numbers are reported from the 0-loss test cases only.