### PR TITLE
fix(linux): Increase the required default size of the microSD card

### DIFF
--- a/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
+++ b/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
@@ -17,7 +17,7 @@ Hardware Prerequisites
 
   - Microtips LVDS Panel
 
-  - SD card (minimum 16GB)
+  - SD card (minimum 32GB)
 
   - PC (Windows or Linux) to flash wic image onto an SD Card
 

--- a/source/linux/Demo_User_Guides/Seva_Store.rst
+++ b/source/linux/Demo_User_Guides/Seva_Store.rst
@@ -31,7 +31,7 @@ Hardware Prerequisites
 
 -  Mouse (to control the Demo)
 
--  SD card (minimum 16GB)
+-  SD card (minimum 32GB)
 
 .. _How-to-Launch-Seva-Store-via-TI-Apps-Launcher:
 
@@ -61,7 +61,7 @@ The TI Apps Launcher demo launches on Linux startup. To Launch Seva Store via TI
 .. caution::
 
     If you have connected the SK-EVM to a proxy network, then before launching Seva Store you need to configure Docker and System proxies once per SD Card.
-    
+
     **To set proxy settings you can click on the Settings button from the Left Hand Side Menu and provide the necessary HTTPS & NO PROXY inputs and click Set Proxy button**. Then, continue with Step 3.
 
     .. Image:: /images/webproxy-settings.jpg

--- a/source/linux/Demo_User_Guides/TI_Apps_Launcher_User_Guide.rst
+++ b/source/linux/Demo_User_Guides/TI_Apps_Launcher_User_Guide.rst
@@ -61,7 +61,7 @@ Hardware Prerequisites
 
 -  Keyboard & Mouse (to control the TI Apps Launcher)
 
--  SD card (minimum 16GB)
+-  SD card (minimum 32GB)
 
 Launching and Using the TI Apps Launcher
 ----------------------------------------

--- a/source/linux/Demo_User_Guides/TI_LVGL_Demo_User_Guide.rst
+++ b/source/linux/Demo_User_Guides/TI_LVGL_Demo_User_Guide.rst
@@ -125,7 +125,7 @@ Hardware Prerequisites
 
 -  Mouse or Touch Input from HDMI monitor (to control the TI LVGL Demo)
 
--  SD card (minimum 16GB)
+-  SD card (minimum 32GB)
 
 -  Aux cable connected to earphone/speaker
 

--- a/source/linux/Overview/Processor_SDK_Linux_create_SD_card.rst
+++ b/source/linux/Overview/Processor_SDK_Linux_create_SD_card.rst
@@ -168,9 +168,9 @@ Create SD Card using bmap-tools
             sudo bmaptool copy --bmap tisdk-|__IMAGE_TYPE__|-image-<machine>-<version>.rootfs.bmap tisdk-|__IMAGE_TYPE__|-image-<machine>-<version>.rootfs.wic /dev/sdc
 
 .. ifconfig:: CONFIG_image_type in ('adas')
-   
+
    .. note::
-   
+
       We do not release WIC images for J7 platforms (J784S4, J742S2, J722S, J721E, J721S2).
       Please refer to :ref:`Create SD Card with custom images <processor-sdk-linux-sd-card-with-default-images>` for flashing image.
 
@@ -384,7 +384,7 @@ The |__SDK_FULL_NAME__| can be installed either on host or inside a Docker conta
 
 **Steps to follow inside a Docker Container**
 
-- The SD card you wish to create is inserted into the host system and has a size sufficiently large (16GB or larger) to hold at least the bootloaders, kernel and root file system.
+- The SD card you wish to create is inserted into the host system and has a size sufficiently large (32GB or larger) to hold at least the bootloaders, kernel and root file system.
 - Refer `Steps to Run SDK Installer inside a Container <https://github.com/TexasInstruments/ti-docker-images?tab=readme-ov-file#steps-to-run-sdk-installer-inside-container>`__
 - Start running the script as mentioned in steps 1-4 of :ref:`Create SD card with custom images <processor-sdk-linux-create-sd-card-with-custom-images>` section above.
 - Refer :ref:`Install the Pre-built Images from SDK <choose-install-pre-built-images>`
@@ -396,7 +396,7 @@ The |__SDK_FULL_NAME__| can be installed either on host or inside a Docker conta
 
 #. The |__SDK_FULL_NAME__| package is installed on your host system.
 #. The SD card you wish to create is inserted into the host system and
-   has a size sufficiently large (16GB or larger) to hold at least the bootloaders,
+   has a size sufficiently large (32GB or larger) to hold at least the bootloaders,
    kernel, and root file system.
 #. You have started running the script as detailed in steps 1-4 of
    :ref:`Create SD card with custom images <processor-sdk-linux-create-sd-card-with-custom-images>`

--- a/source/linux/Overview/Top_Level_Makefile.rst
+++ b/source/linux/Overview/Top_Level_Makefile.rst
@@ -82,7 +82,7 @@ The following sections cover the Makefile found in the top-level of the |__SDK_F
 Steps to follow inside a Docker Container
 -----------------------------------------
 
-- The SD card you wish to create is inserted into the host system and has a size sufficiently large (16GB or larger) to hold at least the bootloaders, kernel and root file system.
+- The SD card you wish to create is inserted into the host system and has a size sufficiently large (32GB or larger) to hold at least the bootloaders, kernel and root file system.
 - Refer `Steps to Run SDK Installer inside a Container <https://github.com/TexasInstruments/ti-docker-images?tab=readme-ov-file#steps-to-run-sdk-installer-inside-container>`__.
 - Follow :ref:`this <usage-examples>` to understand the Makefile usage.
 


### PR DESCRIPTION
Yocto images for 12.00.00 have increased in size and have crossed the 16GB mark.