### PR TITLE
fix(linux): Update Yocto layer configuration information

### DIFF
--- a/source/devices/AM62DX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62DX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -23,6 +23,6 @@ has the following configuration files in the :file:`configs/processor-sdk` direc
    * - Config File
      - Description
      - Supported machines/platforms
-   * - :file:`processor-sdk-master-nonqt-12.00.00.07.04-config.txt`
+   * - :file:`processor-sdk-master-nonui-12.00.00.07.04-config.txt`
      - Used for building Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|

--- a/source/devices/AM62LX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -23,9 +23,11 @@ has the following configuration files in the :file:`configs/processor-sdk` direc
    * - Config File
      - Description
      - Supported machines/platforms
-   * - :file:`processor-sdk-master-nonqt-12.00.00.07.04-config.txt`
+   * - :file:`processor-sdk-master-nonui-12.00.00.07.04-config.txt`
      - Used for building Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|
-   * - :file:`processor-sdk-master-evse-12.00.00.07.04-config.txt`
-     - Used for building Yocto based filesystem with `AM62L-EVSE-DEV-EVM <https://www.ti.com/lit/ug/slvudn0/slvudn0.pdf>`_ support (for EV charging Use cases)
+   * - :file:`processor-sdk-master-selinux-12.00.00.07.04-config.txt`
+     - Used for building SELinux enabled Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|
+
+The oe-layersetup configuration, as defined in :file:`processor-sdk-master-nonui-12.00.00.07.04-config.txt`, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.

--- a/source/devices/AM62PX/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -33,4 +33,4 @@ has the following configuration files in the :file:`configs/processor-sdk` direc
      - Used for building SELinux enabled Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|
 
-The oe-layersetup configuration, as defined in ``processor-sdk-master-chromium-12.00.00.07.04-config.txt``, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.
+The oe-layersetup configuration, as defined in :file:`processor-sdk-master-chromium-12.00.00.07.04-config.txt`, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.

--- a/source/devices/AM62X/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -33,4 +33,4 @@ has the following configuration files in the :file:`configs/processor-sdk` direc
      - Used for building SELinux enabled Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|, am62xx-lp-evm, am62xxsip-evm, beagleplay-ti
 
-The oe-layersetup configuration, as defined in ``processor-sdk-master-chromium-12.00.00.07.04-config.txt``, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.
+The oe-layersetup configuration, as defined in :file:`processor-sdk-master-chromium-12.00.00.07.04-config.txt`, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.

--- a/source/devices/AM64X/linux/Release_Specific_Yocto_layer_Configuration.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Yocto_layer_Configuration.rst
@@ -23,6 +23,11 @@ has the following configuration files in the :file:`configs/processor-sdk` direc
    * - Config File
      - Description
      - Supported machines/platforms
-   * - :file:`processor-sdk-master-nonqt-12.00.00.07.04-config.txt`
+   * - :file:`processor-sdk-master-nonui-12.00.00.07.04-config.txt`
      - Used for building Yocto based filesystem
      - |__SDK_BUILD_MACHINE__|
+   * - :file:`processor-sdk-master-selinux-12.00.00.07.04-config.txt`
+     - Used for building SELinux enabled Yocto based filesystem
+     - |__SDK_BUILD_MACHINE__|
+
+The oe-layersetup configuration, as defined in :file:`processor-sdk-master-nonui-12.00.00.07.04-config.txt`, is used for configuring the meta layers in the yocto SD card image available on |__SDK_DOWNLOAD_URL__|.


### PR DESCRIPTION
Update the yocto layer configuration used to build the default image for AM62D/AM62Lx/AM64x.

Also, remove the EVSE configs for AM62L for this release and add the selinux enabled yocto layer configuration for AM62Lx/AM64x.