### PR TITLE
feat(build): Update TF-A build command paths

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -19,11 +19,11 @@ Build
 
       $ cd <path to tf-a dir>
 
-      $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=am62l am62l_bl1
+      $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3low TARGET_BOARD=am62lx am62l_bl1
 
       <or to build bl-1 and bl-31 binaries from TF-A repo>
 
-	   $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3 TARGET_BOARD=am62l
+	   $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3low TARGET_BOARD=am62lx
 
 .. _Build-U-Boot-label:
 
@@ -453,8 +453,8 @@ All of these binaries are available in the SDK at :file:`<path to tisdk>/board-s
       $ cd $UBOOT_DIR
       $ make CROSS_COMPILE="$CROSS_COMPILE_64" am62lx_evm_defconfig
       $ make CROSS_COMPILE="$CROSS_COMPILE_64" \
-         BL1=$TFA_DIR/build/k3/am62l/release/bl1.bin \
-         BL31=$TFA_DIR/build/k3/am62l/release/bl31.bin \
+         BL1=$TFA_DIR/build/k3low/am62lx/release/bl1.bin \
+         BL31=$TFA_DIR/build/k3low/am62lx/release/bl31.bin \
          BINMAN_INDIRS=$TI_LINUX_FW_DIR \
          TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin
 

--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -121,7 +121,7 @@ Where <hash> is the commit shown in :ref:`release-specific-build-information`.
 
                $ export TFA_DIR=<path-to-arm-trusted-firmware>
                $ cd $TFA_DIR
-               $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3 TARGET_BOARD=am62l
+               $ make ARCH=aarch64 CROSS_COMPILE="$CROSS_COMPILE_64" PLAT=k3low TARGET_BOARD=am62lx
 
 .. ifconfig:: CONFIG_part_variant in ('J721S2')
 


### PR DESCRIPTION
Earlier, in TF-A, AM62L code was in plat/ti/k3/am62l/. But on ti-tfa-2.14.y, this is in plat/ti/k3low/am62lx/. This causes the existing build commands to fail for obvious reasons. Update the paths in these commands.