### PR TITLE
feat(debian): Fix latest debian software manifest links for 11.x

### DIFF
--- a/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Release_Notes.rst
@@ -34,8 +34,8 @@ status for all packages included in this release. The manifest can be
 found on the SDK download page or in the installed directory as indicated below.
 
 -  Linux Manifest:  :file:`<PSDK_PATH>/manifest/software_manifest.htm`
--  Debian Manifest: `TI debian software manifest 11.01.16.13
-   <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-YjEeNKJJjt/11.01.16.13/software_manifest_debian_am62lxx-evm_am62lxx-evm.htm>`__
+-  Debian Manifest: `AM62Lx 11.02.08.02
+   <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-YjEeNKJJjt/11.02.08.02/software_manifest_debian_tmds62levm_tmds62levm.htm>`__
 
 Release 11.02.08.02
 ===================

--- a/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Release_Notes.rst
@@ -34,8 +34,8 @@ status for all packages included in this release. The manifest can be
 found on the SDK download page or in the installed directory as indicated below.
 
 -  Linux Manifest:  :file:`<PSDK_PATH>/manifest/software_manifest.htm`
--  Debian Manifest: `TI debian software manifest 11.01.16.13
-   <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-9ti3Ig9hNi/11.01.16.13/software_manifest_debian_am62pxx-evm_am62pxx-evm.htm>`__
+-  Debian Manifest: `AM62Px 11.02.08.02
+   <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-9ti3Ig9hNi/11.02.08.02/software_manifest_debian_sk-am62p_sk-am62p.htm>`__
 
 
 Release 11.02.08.02

--- a/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Release_Notes.rst
@@ -34,6 +34,12 @@ status for all packages included in this release. The manifest can be
 found on the SDK download page or in the installed directory as indicated below.
 
 -  Linux Manifest:  :file:`<PSDK_PATH>/manifest/software_manifest.htm`
+-  Debian Manifest:
+
+   -  `AM62x 11.02.08.02
+      <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-PvdSyIiioq/11.02.08.02/software_manifest_debian_sk-am62b_sk-am62b.htm>`__
+   -  `AM62x-SIP 11.02.08.02
+      <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-PvdSyIiioq/11.02.08.02/software_manifest_debian_sk-am62-sip_sk-am62-sip.htm>`__
 
 Release 11.02.08.02
 ===================

--- a/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Release_Notes.rst
@@ -34,6 +34,8 @@ status for all packages included in this release. The manifest can be
 found on the SDK download page or in the installed directory as indicated below.
 
 -  Linux Manifest:  :file:`<PSDK_PATH>/manifest/software_manifest.htm`
+-  Debian Manifest: `AM64x 11.02.08.02
+   <https://dr-download.ti.com/software-development/software-development-kit-sdk/MD-yXgchBCk98/11.02.08.02/software_manifest_debian_sk-am64b_sk-am64b.htm>`__
 
 
 Release 11.02.08.02


### PR DESCRIPTION
Extends https://github.com/TexasInstruments/processor-sdk-doc/pull/688 for SDK 11.x