### PR TITLE
Ci/zizmor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,15 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   collect:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
     outputs:
       build-matrix: "${{ steps.matrix.outputs.matrix }}"
     steps:
@@ -40,8 +41,6 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
     needs: collect
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build ${{ matrix.device }}
         run: |
           make DEVFAMILY=${{ matrix.device }} OS=${{ matrix.os }} \
-          VERSION=${{ github.ref_name }}
+          VERSION=${GITHUB_REF_NAME}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   collect:
+    name: Collect DEVFAMILY and OS combinations
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Create build matrix
         id: matrix
@@ -48,6 +50,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Add directory to safe dir overrides
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,11 @@ jobs:
           git config --global --add safe.directory "$PWD"
 
       - name: Build ${{ matrix.device }}
+        env:
+          DEVFAMILY: ${{ matrix.device }}
+          OS: ${{ matrix.os }}
         run: |
-          make DEVFAMILY=${{ matrix.device }} OS=${{ matrix.os }} \
-          VERSION=${GITHUB_REF_NAME}
+          make VERSION=${GITHUB_REF_NAME}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -36,6 +36,8 @@ jobs:
           git switch master
 
       - name: Run check_files.py
+        env:
+          EVENT_NUMBER: ${{ github.event.number }}
         run: |
           # Disable color output
           export NO_COLOR=true
@@ -56,7 +58,7 @@ jobs:
 
           # Prepare the artifacts
           mkdir -p ./results
-          echo "${{ github.event.number }}" > ./results/id
+          echo "$EVENT_NUMBER" > ./results/id
           cp "$GITHUB_STEP_SUMMARY" ./results/summary
           echo "$(wc -l < _new-warn.log)" > ./results/problem-count
 

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update refs and settings
         run: |

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -18,8 +21,6 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-files.yml
+++ b/.github/workflows/check-files.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - 'source/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/check_toc_txt.yml
+++ b/.github/workflows/check_toc_txt.yml
@@ -12,6 +12,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -19,8 +22,6 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check_toc_txt.yml
+++ b/.github/workflows/check_toc_txt.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update refs and settings
         run: |

--- a/.github/workflows/check_toc_txt.yml
+++ b/.github/workflows/check_toc_txt.yml
@@ -37,6 +37,8 @@ jobs:
           git switch master
 
       - name: Run rstcheck
+        env:
+          EVENT_NUMBER: ${{ github.event.number }}
         run: |
           # Disable color output
           export NO_COLOR=true
@@ -57,7 +59,7 @@ jobs:
 
           # Prepare the artifacts
           mkdir -p ./results
-          echo "${{ github.event.number }}" > ./results/id
+          echo "$EVENT_NUMBER" > ./results/id
           cp "$GITHUB_STEP_SUMMARY" ./results/summary
           echo "$(wc -l < _new-warn.log)" > ./results/problem-count
 

--- a/.github/workflows/check_toc_txt.yml
+++ b/.github/workflows/check_toc_txt.yml
@@ -8,6 +8,10 @@ on:  # yamllint disable-line rule:truthy
       - 'source/**'
       - 'configs/*/*_toc.txt'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -10,13 +10,14 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment:
     name: Comment
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
-    permissions:
-      pull-requests: write
 
     steps:
       - name: Download artifact

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -11,7 +11,7 @@ on:  # yamllint disable-line rule:truthy
       - completed
 
 permissions:
-  pull-requests: write
+  pull-requests: write  # Required to leave a comment on a review
 
 jobs:
   comment:

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,8 +1,6 @@
 ---
 name: Commit Check
-on:  # yamllint disable-line rule:truthy
-  pull_request:
-    branches: ['master']
+on: [pull_request]  # yamllint disable-line rule:truthy
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -4,6 +4,10 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: ['master']
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - name: Check commit
         uses: commit-check/commit-check-action@v2

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -4,14 +4,15 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: ['master']
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   commit-check:
     name: Commit Check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -6,8 +6,6 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   commit-check:

--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,5 +1,6 @@
 ---
-name: Commit Check
+name: "commit-check"
+
 on: [pull_request]  # yamllint disable-line rule:truthy
 
 concurrency:

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -1,13 +1,11 @@
 ---
 name: "component-owners"
 
-on:  # yamllint disable-line rule:truthy
-  # It's insecure to use pull_request_target if you intend to check out code
-  # from that PR. This just reads the config file in the pull request base, and
-  # is not an issue currently. We will need to use this to comment on PRs coming
-  # from forked repositories.
-  pull_request_target:
-    branches: [master]
+# It's insecure to use pull_request_target if you intend to check out code
+# from that PR. This just reads the config file in the pull request base, and
+# is not an issue currently. We will need to use this to comment on PRs coming
+# from forked repositories.
+on: [pull_request_target]  # yamllint disable-line rule:truthy
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -10,16 +10,15 @@ on:  # yamllint disable-line rule:truthy
     branches: [master]
 
 permissions:
-  # Clamp permissions since pull_request_target workflows granted full
-  # read/write repository permission by default
   contents: read
-  issues: write
-  pull-requests: write
 
 jobs:
   component-owners:
     name: Assign component owners
     runs-on: ubuntu-latest
+
+    permissions:
+      pull-requests: write  # Required to set reviewers
 
     steps:
       - name: Assign component owners

--- a/.github/workflows/component-owners.yml
+++ b/.github/workflows/component-owners.yml
@@ -9,6 +9,10 @@ on:  # yamllint disable-line rule:truthy
   pull_request_target:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   agregate:
     name: Agregate build artifacts
@@ -16,8 +19,6 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Add directory to safe dir overrides
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,8 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: agregate
     permissions:
-      pages: write
-      id-token: write
+      pages: write  # Required for deployment to GitHub Pages
+      id-token: write  # Required for deployment to GitHub Pages
 
     steps:
       - name: Update github page deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,10 @@ on:  # yamllint disable-line rule:truthy
     types:
       - completed
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,13 +11,14 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,6 @@
 ---
-name: Docker Workflow
+name: "docker"
+
 on:  # yamllint disable-line rule:truthy
   push:
     branches: [master]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,12 +13,14 @@ env:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write  # Required to push image to ghcr.io
 
     steps:
       - name: Checkout

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
       - 'docker/**'
       - requirements.txt
 
+concurrency:
+  group: docker
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -36,6 +36,8 @@ jobs:
           git switch master
 
       - name: Run rstcheck
+        env:
+          EVENT_NUMBER: ${{ github.event.number }}
         run: |
           # Disable color output
           export NO_COLOR=true
@@ -56,7 +58,7 @@ jobs:
 
           # Prepare the artifacts
           mkdir -p ./results
-          echo "${{ github.event.number }}" > ./results/id
+          echo "$EVENT_NUMBER" > ./results/id
           cp "$GITHUB_STEP_SUMMARY" ./results/summary
           echo "$(wc -l < _new-warn.log)" > ./results/problem-count
 

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update refs and settings
         run: |

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -11,6 +11,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -18,8 +21,6 @@ jobs:
     container:
       image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/rstcheck.yml
+++ b/.github/workflows/rstcheck.yml
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
     paths:
       - 'source/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -3,6 +3,10 @@ name: "vale"
 
 on: [pull_request]  # yamllint disable-line rule:truthy
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -7,6 +7,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   vale:
     name: vale
@@ -14,8 +17,6 @@ jobs:
     container:
       image: ghcr.io/staticrocket/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
-    permissions:
-      contents: read
 
     steps:
       - name: Prepare GitHub workdir

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -19,7 +19,7 @@ jobs:
     name: vale
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/staticrocket/processor-sdk-doc:latest
+      image: ghcr.io/texasinstruments/processor-sdk-doc:latest
       options: --entrypoint /bin/bash
 
     steps:
@@ -43,7 +43,7 @@ jobs:
             **.md
 
       - name: Run vale checks on modified files
-        uses: StaticRocket/vale-action@d377866f2e3305ae80ef6ce6516370a7ec4ea55a
+        uses: vale-cli/vale-action@v2
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           fail_on_error: false  # to be changed when upstream addresses 84

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -8,6 +8,9 @@ on:  # yamllint disable-line rule:truthy
       - '**.yaml'
       - '**.yml'
 
+permissions:
+  contents: read
+
 jobs:
   yamllint:
     name: yamllint

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -8,6 +8,10 @@ on:  # yamllint disable-line rule:truthy
       - '**.yaml'
       - '**.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: yamllint
         uses: reviewdog/action-yamllint@v1


### PR DESCRIPTION
- ci(comment): convert workflow to action

  No need to keep this level of isolation between these tasks.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: remove branch check for ready workflows

  The commit-check and component-owners workflows are currently ready to run on
  all branches. Remove the restraints for these two workflows.

  Other workflows will need to be adjusted before they can be released.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: assign workflow concurrency groups for prs

  Assign concurrency groups for PR based workflows to prevent issues with users
  submitting multiple pushes in a short time.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci(docker): add concurrency group for docker

  Interactions with tags and publishing container images should be purely 
  sequential. Limit job concurrency to prevent any issues with multiple rapid
  updates to docker components.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci(deploy): add a pages concurrency group

  There can only be one deployment at any one time and it has to be a full 
  snapshot. No piecemeal updates. Might as well use a concurrency limit to kill
  any other jobs that get in our way. Not that there ever should be any,
  considering the way this job is launched currently.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci(build): add a name for the collect job

  Add a description/name for the collect job in the build workflow.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: trim and document unusual permissions

  Remove any permissions not explicitly needed at the moment. Add inline 
  comments to explain the use of any remaining unusual workflow permissions.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: use env vars instead of template values

  Use env vars to pass values into scripts to prevent possible template 
  injection issues.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: clamp permissions for each workflow

  Clamp the workflow permissions to the minimum values required. Individual jobs
  can request other permissions if they need them.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci(build): use ref name env variable

  Use the ref name environment variable instead of the ref name directly to
  prevent any unusual command injection.

  Signed-off-by: Randolph Sapp <rs@ti.com>

- ci: disable persist-credentials on checkout

  No reason to keep any credentials around from this step.

  Signed-off-by: Randolph Sapp <rs@ti.com>

