### PR TITLE
fix(linux): update defconfigs for am62sip

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -283,8 +283,8 @@ All of these binaries are available in the SDK at :file:`<path to tisdk>/board-s
    |  AM62X LP SK  | ``am62x_lpsk_r5_defconfig``        | ``am62x_lpsk_r5_defconfig am62x_r5_usbdfu.config``       | ``am62x_lpsk_r5_defconfig am62x_r5_usbmsc.config``       |
    |               | ``am62x_lpsk_a53_defconfig``       | ``am62x_lpsk_a53_defconfig``                             | ``am62x_lpsk_a53_defconfig``                             |
    +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
-   |  AM62SIP SK   | ``am6254atl_evm_r5_defconfig``     | ``am6254atl_evm_r5_defconfig am62x_r5_usbdfu.config``    | ``am6254atl_evm_r5_defconfig am62x_r5_usbmsc.config``    |
-   |               | ``am6254atl_evm_a53_defconfig``    | ``am6254atl_evm_a53_defconfig``                          | ``am6254atl_evm_a53_defconfig``                          |
+   |  AM62SIP SK   | ``am6254xxl_evm_r5_defconfig``     | ``am6254xxl_evm_r5_defconfig am62x_r5_usbdfu.config``    | ``am6254xxl_evm_r5_defconfig am62x_r5_usbmsc.config``    |
+   |               | ``am6254xxl_evm_a53_defconfig``    | ``am6254xxl_evm_a53_defconfig``                          | ``am6254xxl_evm_a53_defconfig``                          |
    +---------------+------------------------------------+----------------------------------------------------------+----------------------------------------------------------+
 
    .. note::
@@ -320,7 +320,7 @@ All of these binaries are available in the SDK at :file:`<path to tisdk>/board-s
       $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
 
       For AM62SIP
-      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am6254atl_evm_r5_defconfig O=$UBOOT_DIR/out/r5
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" am6254xxl_evm_r5_defconfig O=$UBOOT_DIR/out/r5
       $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_32" O=$UBOOT_DIR/out/r5 BINMAN_INDIRS=$TI_LINUX_FW_DIR
 
       A53
@@ -335,7 +335,7 @@ All of these binaries are available in the SDK at :file:`<path to tisdk>/board-s
       $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
 
       For AM62SIP
-      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am6254atl_evm_a53_defconfig O=$UBOOT_DIR/out/a53
+      $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" am6254xxl_evm_a53_defconfig O=$UBOOT_DIR/out/a53
       $ make ARCH=arm CROSS_COMPILE="$CROSS_COMPILE_64" CC="$CC_64" BL31=$TFA_DIR/build/k3/lite/release/bl31.bin TEE=$OPTEE_DIR/out/arm-plat-k3/core/tee-pager_v2.bin O=$UBOOT_DIR/out/a53 BINMAN_INDIRS=$TI_LINUX_FW_DIR
 
 


### PR DESCRIPTION
update uboot defconfigs for am62sip in uboot build instructions.