### PR TITLE
feat(linux): Add AM62D benchmarks to performance table

### DIFF
--- a/source/linux/Foundational_Components/Machine_Learning/tflite.rst
+++ b/source/linux/Foundational_Components/Machine_Learning/tflite.rst
@@ -169,6 +169,8 @@ The following performance numbers are captured with :command:`benchmark_model` o
    "", "XNNPACK", "0.740743", "885.636", "150.484"
    "AM62L", "CPU only", "1.3708", "807.076", "111.152"
    "", "XNNPACK", "0.930577", "769.145", "150.496"
+   "AM62D", "CPU only", "1.10024", "127.263", "108.918"
+   "", "XNNPACK", "0.264193", "532.539", "151.066"
 
 Based on the above data, using the XNNPACK delegate significantly improves inference times across all SoCs, though it generally increases initialization time and overall memory footprint.
 


### PR DESCRIPTION
Add benchmarking results for AM62D SoC in Table 3.2, including both CPU-only and XNNPACK delegate performance measurements using the ssd_mobilenet_v2_coco.tflite model.

AM62D benchmarking results: https://gist.github.com/PrathamTI/2c3b2d9dad8b3083db67d04845c41adb