### PR TITLE
fix(build): update the build commands for AM62L TFA and Uboot

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Build-K3.rst
@@ -19,7 +19,7 @@ Build
 
       $ cd <path to tf-a dir>
 
-      $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3low TARGET_BOARD=am62lx am62l_bl1
+      $ make CROSS_COMPILE="$CROSS_COMPILE_64" ARCH=aarch64 PLAT=k3low TARGET_BOARD=am62lx bl1
 
       <or to build bl-1 and bl-31 binaries from TF-A repo>
 
@@ -445,8 +445,8 @@ All of these binaries are available in the SDK at :file:`<path to tisdk>/board-s
 
       # Build for BeagleBadge:
       $ export UBOOT_CONFIG=am62lx_badge_defconfig
-      $ export TFA_BOARD=am62l3_badge # on ti-tfa-2.14.y
-      $ export TFA_BOARD=am62lx_badge # on ti-master
+      $ export TFA_BOARD=am62l3-badge # on ti-tfa-2.14.y
+      $ export TFA_BOARD=am62l-badge # on ti-master
 
    .. note::
 

--- a/source/linux/Foundational_Components_ATF.rst
+++ b/source/linux/Foundational_Components_ATF.rst
@@ -118,8 +118,8 @@ Where <hash> is the commit shown in :ref:`release-specific-build-information`.
         .. code-block:: console
 
             $ export TFA_BOARD=am62lx # for AM62L EVM
-            $ export TFA_BOARD=am62l3_badge # for BeagleBadge on ti-tfa-2.14.y
-            $ export TFA_BOARD=am62lx_badge # for BeagleBadge on ti-master
+            $ export TFA_BOARD=am62l3-badge # for BeagleBadge on ti-tfa-2.14.y
+            $ export TFA_BOARD=am62l-badge # for BeagleBadge on ti-master
             $ export TFA_DIR=<path-to-arm-trusted-firmware>
 
         *Without OP-TEE enabled:*


### PR DESCRIPTION
The target boards mentioned for building TFA on AM62L-badge is incorrect. Updating it from 'am62l3_badge' to 'am62l3-badge'.

Build command for bl1 is incorrect as there is no make target for 'am62l_bl1' on ti-tfa-2.14.y. Updating it with correct build commands for both ti-master and ti-tfa.2.14.y.

Also enhancing the build instuctions by including the correct PLAT and TFA_BOARD configuration for building on both ti-master and ti-tfa-2.14.y.