### PR TITLE
feat(U-Boot): add QoS configuration section

### DIFF
--- a/.github/styles/config/vocabularies/PSDK/accept.txt
+++ b/.github/styles/config/vocabularies/PSDK/accept.txt
@@ -14,6 +14,7 @@ PVRCarbon
 PVRTune
 Sitara
 Slint
+SysConfig
 TFLite
 TVM
 Trixie

--- a/configs/AM62AX/AM62AX_linux_toc.txt
+++ b/configs/AM62AX/AM62AX_linux_toc.txt
@@ -44,6 +44,7 @@ linux/Foundational_Components/U-Boot/UG-DDRSS
 #linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-Falcon-Mode
+linux/Foundational_Components/U-Boot/UG-QoS
 
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD

--- a/configs/AM62DX/AM62DX_linux_toc.txt
+++ b/configs/AM62DX/AM62DX_linux_toc.txt
@@ -39,6 +39,7 @@ linux/Foundational_Components/U-Boot/UG-QSPI
 linux/Foundational_Components/U-Boot/UG-UART
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-Falcon-Mode
+linux/Foundational_Components/U-Boot/UG-QoS
 
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD

--- a/configs/AM62LX/AM62LX_linux_toc.txt
+++ b/configs/AM62LX/AM62LX_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-UART
 linux/Foundational_Components/U-Boot/UG-Secure-Boot
 linux/Foundational_Components/U-Boot/UG-Key-Writer-Lite
 linux/Foundational_Components/U-Boot/UG-Programming-OTPs
+linux/Foundational_Components/U-Boot/UG-QoS
 
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD

--- a/configs/AM62PX/AM62PX_linux_toc.txt
+++ b/configs/AM62PX/AM62PX_linux_toc.txt
@@ -44,6 +44,7 @@ linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-Splash-Screen
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-Falcon-Mode
+linux/Foundational_Components/U-Boot/UG-QoS
 
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD

--- a/configs/AM62X/AM62X_linux_toc.txt
+++ b/configs/AM62X/AM62X_linux_toc.txt
@@ -43,6 +43,7 @@ linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-Splash-Screen
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-Falcon-Mode
+linux/Foundational_Components/U-Boot/UG-QoS
 
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD

--- a/configs/AM64X/AM64X_linux_toc.txt
+++ b/configs/AM64X/AM64X_linux_toc.txt
@@ -41,6 +41,7 @@ linux/Foundational_Components/U-Boot/UG-NAND
 linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-PCIeBoot
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-TroubleShooting

--- a/configs/AM67/AM67_linux_toc.txt
+++ b/configs/AM67/AM67_linux_toc.txt
@@ -37,6 +37,7 @@ linux/Foundational_Components/U-Boot/UG-SATA
 linux/Foundational_Components/U-Boot/UG-DDR3
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/AM67A/AM67A_linux_toc.txt
+++ b/configs/AM67A/AM67A_linux_toc.txt
@@ -42,6 +42,7 @@ linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS
 linux/Foundational_Components/U-Boot/Apps-TroubleShooting
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components_Kernel
 linux/Foundational_Components_Kernel_Drivers
 linux/Foundational_Components/Kernel/Kernel_Drivers/ADC

--- a/configs/AM68/AM68_linux_toc.txt
+++ b/configs/AM68/AM68_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/AM68A/AM68A_linux_toc.txt
+++ b/configs/AM68A/AM68A_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/AM69/AM69_linux_toc.txt
+++ b/configs/AM69/AM69_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/AM69A/AM69A_linux_toc.txt
+++ b/configs/AM69A/AM69A_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/J7200/J7200_linux_toc.txt
+++ b/configs/J7200/J7200_linux_toc.txt
@@ -42,6 +42,7 @@ linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-AVS
 linux/Foundational_Components/U-Boot/UG-Thermal
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/J721E/J721E_linux_toc.txt
+++ b/configs/J721E/J721E_linux_toc.txt
@@ -46,6 +46,7 @@ linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS
 linux/Foundational_Components/U-Boot/Apps-TroubleShooting
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components_Kernel
 linux/Foundational_Components_Kernel_Drivers
 linux/Foundational_Components/Kernel/Kernel_Drivers/ADC

--- a/configs/J721S2/J721S2_linux_toc.txt
+++ b/configs/J721S2/J721S2_linux_toc.txt
@@ -42,6 +42,7 @@ linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
 linux/Foundational_Components/U-Boot/UG-AVS
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/J722S/J722S_linux_toc.txt
+++ b/configs/J722S/J722S_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-Network-K3
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/J742S2/J742S2_linux_toc.txt
+++ b/configs/J742S2/J742S2_linux_toc.txt
@@ -40,6 +40,7 @@ linux/Foundational_Components/U-Boot/UG-UFS
 linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/J784S4/J784S4_linux_toc.txt
+++ b/configs/J784S4/J784S4_linux_toc.txt
@@ -41,6 +41,7 @@ linux/Foundational_Components/U-Boot/UG-DDRSS-J7
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-HSM
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/configs/TDA4VM/TDA4VM_linux_toc.txt
+++ b/configs/TDA4VM/TDA4VM_linux_toc.txt
@@ -41,6 +41,7 @@ linux/Foundational_Components/U-Boot/UG-DDR3
 linux/Foundational_Components/U-Boot/UG-HyperBus
 linux/Foundational_Components/U-Boot/UG-RemoteProc
 linux/Foundational_Components/U-Boot/UG-AVS
+linux/Foundational_Components/U-Boot/UG-QoS
 linux/Foundational_Components/U-Boot/Applications
 linux/Foundational_Components/U-Boot/Apps-SPL-Debug-OpenOCD
 linux/Foundational_Components/U-Boot/Apps-Load-in-CCS

--- a/source/linux/Foundational_Components/U-Boot/UG-QoS.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-QoS.rst
@@ -1,0 +1,40 @@
+Quality of Service (QoS)
+########################
+
+The Common Bus Architecture (CBASS) module includes Quality of Service
+(QoS) blocks to route and prioritize SoC bus traffic. By adjusting
+attributes such as priority, Address Selection (ASEL), and Order ID
+(orderID), you can optimize transaction handling.
+
+For example, most K3 SoC External Memory Interface (EMIF) controllers
+use two ports. Setting an Order ID between 8 and 15 routes traffic
+through a high-priority port, ensuring it gets serviced before standard
+traffic. Applying this to the display subsystem helps prevent stuttering
+and jitter.
+
+For more details, see your processor's Technical Reference Manual (TRM).
+
+Modifying QoS defaults
+======================
+
+Most transactions default to the lowest priority (ASEL 0, orderID 0).
+During boot-up, `U-Boot can update`_ these settings by using data from
+the SysConfig tool, which you can download or use online `here`_.
+
+.. _U-Boot can update: https://source.denx.de/u-boot/u-boot/-/blob/v2026.04/arch/arm/mach-k3/am62px/am62p5_init.c?ref_type=tags#L216
+.. _here: https://www.ti.com/tool/SYSCONFIG
+
+The MCU+ SDK documentation has an excellent `guide`_ on how to use the
+SysConfig tool to generate the needed :file:`<soc>_qos_uboot.c`
+configuration file. Once generated, copy it into
+:file:`arch/arm/mach-k3/r5/<soc>/<soc>_qos_uboot.c`, where ``<soc>``
+is your SoC name, e.g. ``am62px``. Then rebuild U-Boot to apply your
+changes.
+
+.. _guide: https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/DRIVERS_QOS_PAGE.html
+
+.. note::
+
+   Configuring the QoS blocks of a running system can cause issues.
+   You can only change these settings during boot-up by using the
+   bootloaders, when many of the systems in the SoC are idle.

--- a/source/linux/Foundational_Components/U-Boot/Users-Guide.rst
+++ b/source/linux/Foundational_Components/U-Boot/Users-Guide.rst
@@ -35,3 +35,4 @@ User's Guide
    UG-Key-Writer-Lite
    UG-Programming-OTPs
    UG-Falcon-Mode
+   UG-QoS


### PR DESCRIPTION
Add basic documentation on how the CBASS QoS blocks function and how Sysconfig can be used to generate the files for U-Boot to apply during the SoC's bootup phase.

Picked up from @bryanbrattlof, old PR is #582.
