### PR TITLE
feat: J722S 11.2 release documentation updates

### DIFF
--- a/source/devices/J722S/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/J722S/linux/Release_Specific_Release_Notes.rst
@@ -322,6 +322,7 @@ Linux Known Issues
    TAP (no-PHY) DDR mode
    TAP (no-PHY) SDR mode"
    "LCPD-24654","MCAN: Implement workaround for errata i2279","j7200-evm,j721e-idk-gw,j721s2-evm,j722s_evm-fs,j742s2_evm-fs,j784s4-evm",""
+   "LCPD-47749","NFS boot fails when EthFW is enabled on MCU2_0 R5F core due to CPSW Proxy Client driver circular dependency","j722s_evm-fs,j722s_evm-se",""
 
 
 |

--- a/source/devices/J7_Family/linux/Release_Specific_Release_Notes.rst
+++ b/source/devices/J7_Family/linux/Release_Specific_Release_Notes.rst
@@ -107,7 +107,7 @@ U-Boot
 
    .. note::
 
-      meta-edgeai Yocto layer contains additional patches for U-Boot `here <https://git.ti.com/cgit/edgeai/meta-edgeai/tree/recipes-bsp/u-boot?h=REL.PSDK.ANALYTICS.11.02.00.06>`__.
+      meta-edgeai Yocto layer contains additional patches for U-Boot `here <https://git.ti.com/cgit/edgeai/meta-edgeai/tree/recipes-bsp/u-boot?h=REL.PSDK.ANALYTICS.11.02.00.10>`__.
 
 .. _kernel-release-notes:
 
@@ -135,7 +135,7 @@ Kernel
 
    .. note::
 
-      meta-edgeai Yocto layer contains additional patches for Kernel `here <https://git.ti.com/cgit/edgeai/meta-edgeai/tree/recipes-kernel/linux?h=REL.PSDK.ANALYTICS.11.02.00.06>`__.
+      meta-edgeai Yocto layer contains additional patches for Kernel `here <https://git.ti.com/cgit/edgeai/meta-edgeai/tree/recipes-kernel/linux?h=REL.PSDK.ANALYTICS.11.02.00.10>`__.
 
 TF-A
 ----
@@ -204,24 +204,24 @@ Yocto
 
 .. rubric:: meta-tisdk
 
-| Head Commit: 078b37b05e191a0e69ddbe74b402e0f1b29e6b30 tisdk-evse-image: add image recipe for EVSE OOB
-| Date: Tue Dec 23 00:26:58 2025 -0600
+| Head Commit: 8ccd0f212ef01517a9c92f77dfb4da0f4ee0cb65 recipes-graphics: disable emptty for AM62A
+| Date: Wed Jan 28 00:33:58 2026 -0600
 
 | Repo: https://github.com/TexasInstruments/meta-tisdk.git
 | Branch: scarthgap
-| Release Tag: REL.PSDK.ANALYTICS.11.02.00.06
+| Release Tag: REL.PSDK.ANALYTICS.11.02.00.10
 |
 
 .. ifconfig:: CONFIG_image_type in ('edgeai', 'adas')
 
    .. rubric:: meta-edgeai
 
-   | Head Commit: 7d07e25a15632494d6c30efb09d68de1c95f9394 recipes-core/packagegroup: Add yaml-cpp packagegroup
-   | Date: Fri Jan 23 04:50:28 2026 -0600
+   | Head Commit: 216d5badbf187e8e8cfa298534e5e1d37d7d69a1 [ti-linux-staging]: j722s: Restore CSI2 expansion interface reset GPIO pinmux to main device tree
+   | Date: Sun May 17 04:50:02 2026 -0500
 
    | Clone: git://git.ti.com/edgeai/meta-edgeai.git
    | Branch: scarthgap
-   | Release Tag: REL.PSDK.ANALYTICS.11.02.00.06
+   | Release Tag: REL.PSDK.ANALYTICS.11.02.00.10
    |
 
 Issues Tracker

--- a/source/linux/How_to_Guides/Host/Moving_Files_to_the_Target_System.rst
+++ b/source/linux/How_to_Guides/Host/Moving_Files_to_the_Target_System.rst
@@ -22,50 +22,52 @@ is time consuming during development.  Using a NFS during development is
 the preferred method and makes moving files between the host and target
 trivial.
 
-.. rubric:: File System on Network File System (NFS)
-   :name: file-system-on-network-file-system-nfs
+.. ifconfig:: CONFIG_part_variant not in ('J722S',)
 
-When the target file system is served from the Linux development host
-machine it is trivial to move files between the host and target.  The
-NFS directory is set up on the host machine by the SDK installer.  The
-default location in the SDK environment is :file:`${PSDK_PATH}/targetNFS`
-This could vary depending on the version of the SDK and how it was installed.
-An :command:`ls -l` of this directory in the host system will show what will be the root
-directory of the target when it boots up.
+   .. rubric:: File System on Network File System (NFS)
+      :name: file-system-on-network-file-system-nfs
 
-.. code-block:: console
+   When the target file system is served from the Linux development host
+   machine it is trivial to move files between the host and target.  The
+   NFS directory is set up on the host machine by the SDK installer.  The
+   default location in the SDK environment is :file:`${PSDK_PATH}/targetNFS`
+   This could vary depending on the version of the SDK and how it was installed.
+   An :command:`ls -l` of this directory in the host system will show what will be the root
+   directory of the target when it boots up.
 
-    user@U1004GT:~/ti-sdk-AM3715-evm-4.0.0.0/filesystem$ pwd
-    /home/user/ti-sdk-AM3715-evm-4.0.0.0/filesystem
-    user@U1004GT:~/ti-sdk-AM3715-evm-4.0.0.0/filesystem$ ls -l
-    total 68
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 bin
-    drwxr-xr-x  4 root root 4096 Mar  9  2018 boot
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 dev
-    drwxr-xr-x 55 root root 4096 Mar  9  2018 etc
-    drwxr-xr-x  4 root root 4096 Mar  9  2018 home
-    drwxr-xr-x 10 root root 4096 Mar  9  2018 lib
-    lrwxrwxrwx  1 root root   19 Mar  9  2018 linuxrc -> /bin/busybox.nosuid
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 media
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 mnt
-    drwxr-xr-x 14 root root 4096 Mar  9  2018 opt
-    dr-xr-xr-x  2 root root 4096 Mar  9  2018 proc
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 run
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 sbin
-    drwxr-xr-x  2 root root 4096 Mar  9  2018 srv
-    dr-xr-xr-x  2 root root 4096 Mar  9  2018 sys
-    drwxrwxrwt  2 root root 4096 Mar  9  2018 tmp
-    drwxr-xr-x 12 root root 4096 Mar  9  2018 usr
-    drwxr-xr-x  9 root root 4096 Mar  9  2018 var
+   .. code-block:: console
 
-So from the perspective of the host, the target filesystem is just a
-sub-directory of the host.  If the file is in :file:`./targetNFS` on the host,
-then the same file will show up in the root directory of the target
-after the target boots into the NFS.  And if the file is in a
-subdirectory of :file:`./targetNFS` (example :file:`./targetNFS/{sub-dir}/`) then it will
-show up in the /sub-dir directory of the target after the target boots
-into the NFS.
+       user@U1004GT:~/ti-sdk-AM3715-evm-4.0.0.0/filesystem$ pwd
+       /home/user/ti-sdk-AM3715-evm-4.0.0.0/filesystem
+       user@U1004GT:~/ti-sdk-AM3715-evm-4.0.0.0/filesystem$ ls -l
+       total 68
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 bin
+       drwxr-xr-x  4 root root 4096 Mar  9  2018 boot
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 dev
+       drwxr-xr-x 55 root root 4096 Mar  9  2018 etc
+       drwxr-xr-x  4 root root 4096 Mar  9  2018 home
+       drwxr-xr-x 10 root root 4096 Mar  9  2018 lib
+       lrwxrwxrwx  1 root root   19 Mar  9  2018 linuxrc -> /bin/busybox.nosuid
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 media
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 mnt
+       drwxr-xr-x 14 root root 4096 Mar  9  2018 opt
+       dr-xr-xr-x  2 root root 4096 Mar  9  2018 proc
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 run
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 sbin
+       drwxr-xr-x  2 root root 4096 Mar  9  2018 srv
+       dr-xr-xr-x  2 root root 4096 Mar  9  2018 sys
+       drwxrwxrwt  2 root root 4096 Mar  9  2018 tmp
+       drwxr-xr-x 12 root root 4096 Mar  9  2018 usr
+       drwxr-xr-x  9 root root 4096 Mar  9  2018 var
 
-The top level makefile of the TI SDK supports an install target that
-will copy applications into the NFS of the SDK. See the README file at
-the top level of the SDK for information about the install target.
+   So from the perspective of the host, the target filesystem is just a
+   sub-directory of the host.  If the file is in :file:`./targetNFS` on the host,
+   then the same file will show up in the root directory of the target
+   after the target boots into the NFS.  And if the file is in a
+   subdirectory of :file:`./targetNFS` (example :file:`./targetNFS/{sub-dir}/`) then it will
+   show up in the /sub-dir directory of the target after the target boots
+   into the NFS.
+
+   The top level makefile of the TI SDK supports an install target that
+   will copy applications into the NFS of the SDK. See the README file at
+   the top level of the SDK for information about the install target.


### PR DESCRIPTION
Update the J722S Linux documentation for the 11.2.00 release with known issues and Yocto layer updates:
- Add known issue to J722S release notes documenting NFS boot failure when EthFW is enabled on MCU2_0 R5F core
- Update meta-tisdk & meta-edgeai layer tag references for J722S
- Ensures correct Yocto build configuration for 11.02.00 release
- 
Signed-off-by: Puyush Gupta <p-gupta5@ti.com>