### PR TITLE
fix(u-boot): fix incorrect bootflow diagram in AM62D/AM62P/AM62L docs

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/BG-Bootflow-K3.rst
+++ b/source/linux/Foundational_Components/U-Boot/BG-Bootflow-K3.rst
@@ -9,7 +9,7 @@ bootloader has to run on R5 core. In order to meet this constraint, keeping
 safety in picture and to have faster boot time, the software boot architecture
 is designed as below:
 
-.. ifconfig:: CONFIG_part_family not in ('J7_family', 'AM64X_family', 'AM62X_family', 'AM62AX_family')
+.. ifconfig:: CONFIG_part_family not in ('J7_family', 'AM64X_family', 'AM62X_family', 'AM62AX_family', 'AM62DX_family', 'AM62PX_family', 'AM62LX_family')
 
    .. code-block:: text
 
@@ -339,7 +339,7 @@ is designed as below:
       |                        |                       |                       |                       |
       +------------------------------------------------------------------------+-----------------------+
 
-.. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62PX', 'J722S')
+.. ifconfig:: CONFIG_part_variant in ('AM62X', 'AM62AX', 'AM62DX', 'AM62PX', 'J722S')
 
    .. code-block:: text
 


### PR DESCRIPTION
Generic K3 bootflow diagram was inappropriately included in SoC variants where it doesn't apply. Each SoC family has its own specific boot flow sequence already documented, making this common block redundant and misleading.