### PR TITLE
fix(u-boot): correct I2C bus number for Vpp programming in eFuse docs

### DIFF
--- a/source/linux/Foundational_Components/U-Boot/UG-Key-Writer-Lite.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Key-Writer-Lite.rst
@@ -111,11 +111,11 @@ A typical flow to do OTP key writer lite is as follows:
    which then toggles the IO pin connected to the Vpp pin, thereby controlling the power supply to the pin.
    On TI EVM, Vpp pin can be turned on using the below commands:
 
-    .. rubric:: Select i2c bus 2, as chip 22 is connected to it, and probe the chip:
+    .. rubric:: Select i2c bus 1, as chip 22 is connected to it, and probe the chip:
 
     .. code-block:: text
 
-       => i2c dev 2
+       => i2c dev 1
        => i2c probe 22
 
     .. rubric:: To turn off Vpp:

--- a/source/linux/Foundational_Components/U-Boot/UG-Programming-OTPs.rst
+++ b/source/linux/Foundational_Components/U-Boot/UG-Programming-OTPs.rst
@@ -56,8 +56,8 @@ Follow these steps to enable or disable Vpp:
 
    .. code-block:: text
 
-      # Select i2c bus 2 (chip 22 is connected to it)
-      => i2c dev 2
+      # Select i2c bus 1 (chip 22 is connected to it)
+      => i2c dev 1
 
       # Probe the chip
       => i2c probe 22


### PR DESCRIPTION
Update I2C bus number from 2 to 1 in the eFuse programming documentation. The IO expander controlling the Vpp signal for eFuse programming is connected to I2C bus 1, not bus 2 as previously documented.