### PR TITLE
feat(debian): Add BeagleBadge support and proxy instruction

### DIFF
--- a/source/debian/Building_Debian_Image.rst
+++ b/source/debian/Building_Debian_Image.rst
@@ -30,17 +30,6 @@ Therefore, the first step is to fetch TI's fork:
 
    git clone https://github.com/TexasInstruments/armbian-build.git
 
-.. ifconfig:: CONFIG_part_variant in ('AM62LX')
-
-   .. note::
-
-      BeagleBadge is supported in Armbian but is not yet supported on **ti-main** branch, therefore run the following command
-      before building for BeagleBadge:
-
-      .. code-block:: console
-
-         git checkout 2025.12-beaglebadge
-
 Repository Structure
 --------------------
 
@@ -92,6 +81,12 @@ Armbian supports both an interactive UI and a noninteractive build process.
       sudo usermod -aG docker $USER
       newgrp docker
 
+   If the host machine is behind a proxy, be sure to set **at minimum** the HTTP_PROXY environment variable before building:
+
+   .. code-block:: console
+
+      export HTTP_PROXY=http://<proxy_address>:<proxy_port>
+
 -  To build interactively:
 
    .. code-block:: console
@@ -132,8 +127,9 @@ For a list of boards and branches supported by each SoC, refer:
       AM62-LP,sk-am62-lp,``config/boards/sk-am62-lp.conf``,"vendor, vendor-rt, vendor-edge, edge"
       AM62SIP,sk-am62-sip,``config/boards/sk-am62-sip.conf``,"vendor, vendor-rt, vendor-edge, edge"
       AM62Lx,tmds62levm,``config/boards/tmds62levm.conf``,"vendor, vendor-rt, vendor-edge"
-      AM62Lx,beaglebadge,``config/boards/beaglebadge.conf``,"vendor-edge"
+      AM62Lx,beaglebadge,``config/boards/beaglebadge.conf``,"vendor, vendor-rt, vendor-edge"
       AM62Px,sk-am62p,``config/boards/sk-am62p.conf``,"vendor, vendor-rt, vendor-edge, edge"
       AM64x,sk-am64b,``config/boards/sk-am64b.conf``,"vendor, vendor-rt, vendor-edge, edge"
+      AM64x,tmds64evm,``config/boards/tmds64evm.conf``,"vendor, vendor-rt, vendor-edge, edge"
 
 ``output/images/`` stores the built images. These images have a ``.img`` extension.


### PR DESCRIPTION
BeagleBadge now in `ti-main` branch of TI/armbian-build:
https://github.com/TexasInstruments/armbian-build/blob/ti-main/config/boards/beaglebadge.conf 

Users can now build on proxy if they have `HTTP_PROXY` set: https://github.com/armbian/build/pull/9741 