### PR TITLE
docs(linux): Update linuxptp clone URL and branch for HSR/PRP PTP

### DIFF
--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Network/HSR_PRP_PTP.rst
@@ -4,8 +4,8 @@
 HSR and PRP PTP support
 =======================
 
-The `linuxptp-hsr <https://git.kernel.org/pub/scm/linux/kernel/git/bigeasy/linuxptp-hsr.git>`_
-implementation on the ``hsr_prp_v2_plus`` branch supports PTP (Precision Time Protocol)
+The `TI fork of linuxptp <https://git.ti.com/cgit/processor-sdk/linuxptp>`_
+on the ``hsr_prp_ptp`` branch supports PTP (Precision Time Protocol)
 synchronization over High-availability Seamless Redundancy (HSR) and Parallel Redundancy
 Protocol (PRP) interfaces.
 
@@ -15,25 +15,12 @@ In the following commands, replace ``<proto>`` with ``hsr`` or ``prp`` as approp
 
 Complete the following steps on each node.
 
-Clone linuxptp-hsr:
+Clone linuxptp:
 
 .. code-block:: console
 
-   git clone https://git.kernel.org/pub/scm/linux/kernel/git/bigeasy/linuxptp-hsr.git
-   cd linuxptp-hsr
-   git checkout hsr_prp_v2_plus
-
-Patch the config files with the actual interface names and the P2P destination MAC
-address. The config files use INI-style sections where ``[eth1]`` and ``[eth2]``
-denote the two physical interfaces. The first command appends the ``p2p_dst_mac``
-key (destination MAC for P2P delay-request messages) into the ``[global]``
-section just after the ``delay_mechanism`` key. The second command replaces the
-``[eth1]`` and ``[eth2]`` section headers with the actual interface names:
-
-.. code-block:: console
-
-   sed -i '/^delay_mechanism/a p2p_dst_mac 01:1B:19:00:00:01' configs/<proto>-master.cfg configs/<proto>-slave.cfg
-   sed -i 's/^\[eth1\]/[<INTF_A>]/; s/^\[eth2\]/[<INTF_B>]/' configs/<proto>-master.cfg configs/<proto>-slave.cfg
+   git clone --single-branch --branch hsr_prp_ptp https://git.ti.com/cgit/processor-sdk/linuxptp
+   cd linuxptp
 
 Build and install:
 


### PR DESCRIPTION
Update the linuxptp repository URL from the bigeasy fork to the mda fork, and update the branch from hsr_prp_v2_plus to hsr_prp_ptp. Also remove the now-unnecessary config file patching steps.