### PR TITLE
ci(vale): work around redhat style bug

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,3 +10,4 @@ BasedOnStyles = RedHat
 RedHat.PascalCamelCase = NO
 RedHat.GitLinks = NO
 RedHat.MergeConflictMarkers = NO
+RedHat.NoGerundsInTitles = NO


### PR DESCRIPTION
There's a new check that requires an external script to offer suggestions [1]. I do not want to carry script that needs to be in sync with a style that cannot be version pinned here.

[1] https://github.com/redhat-documentation/vale-at-red-hat/issues/1045