### PR TITLE
feat(linux): Add crypto implementation options guide

### DIFF
--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -753,6 +753,7 @@ Listed for each algorithm are the code snippets used to run each
 
     time -v openssl speed -elapsed -evp aes-128-cbc
 
+.. _crypto-performance:
 
 Crypto Performance Comparison
 -----------------------------

--- a/source/devices/AM64X/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM64X/linux/Linux_Performance_Guide.rst
@@ -43,6 +43,8 @@ System Benchmarks
 CRYPTO
 ======
 
+.. _crypto-performance:
+
 Crypto Performance Comparison
 -----------------------------
 

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/DTHEv2.rst
@@ -23,6 +23,43 @@ devices:
                   Hashing                         - MD5, SHA224, SHA256, SHA384, SHA512
                   Message Authentication          - HMAC(MD5), HMAC(SHA224), HMAC(SHA256), HMAC(SHA384), HMAC(SHA512)
 
+
+*****************************
+Crypto Implementation Options
+*****************************
+
+Users can implement cryptographic operations by using one of the following approaches:
+
+1. **Hardware Accelerator (DTHEv2)**
+
+   - Offloads crypto operations to dedicated hardware engine
+   - Frees up CPU cycles for other tasks
+   - In general lower throughput but optimized for multi-tasking systems
+
+2. **ARM CPU with Cryptographic Extension (ARM CE)**
+
+   - Uses ARM core's built-in cryptographic hardware level instruction extensions
+   - Delivers higher throughput (faster than hardware accelerator)
+   - Might require high CPU usage
+
+Choosing the Right Implementation
+=================================
+
+**Use Hardware Accelerator (DTHEv2) when:**
+
+- **Multi-tasking systems** - system runs computation heavy services that need CPU resources alongside crypto operations
+- **Functional safety/security requirements** - ASIL or safety-critical applications require offloading crypto operations away from Linux kernel to reduce attack surface and ensure isolation
+- **Compliance/regulatory requirements** - FIPS certification, Common Criteria, or TEE integration mandates hardware acceleration
+
+**Use ARM CPU (CE) when:**
+
+- **Maximum throughput required** - Need high throughput for bulk data encryption, video transcoding, or media processing
+- **Dedicated crypto workload** - Crypto is the primary task and high CPU usage is acceptable
+- **Small/infrequent operations** - One-time encryption with small data blocks where accelerator overhead is minimal
+
+**Performance Comparison** : For a detailed comparison of DTHEv2 accelerator performance against ARM Cryptographic Extension (CE) and baseline ARM CPU, see :ref:`crypto-performance` in the Linux Performance Guide.
+
+
 ********************
 Building the Drivers
 ********************

--- a/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/SA2UL_OMAP.rst
+++ b/source/linux/Foundational_Components/Kernel/Kernel_Drivers/Crypto/SA2UL_OMAP.rst
@@ -72,6 +72,41 @@ The following is a list of supported hardware accelerated algorithms:
      - SHA256, SHA512
      - CMAC(AES)
 
+*****************************
+Crypto Implementation Options
+*****************************
+
+Users can implement cryptographic operations by using one of the following approaches:
+
+1. **Hardware Accelerator**
+
+   - Offloads crypto operations to dedicated hardware engine
+   - Frees up CPU cycles for other tasks
+   - In general lower throughput but optimized for multi-tasking systems
+
+2. **ARM CPU with Cryptographic Extension (ARM CE)**
+
+   - Uses ARM core's built-in cryptographic hardware level instruction extensions
+   - Delivers higher throughput (faster than hardware accelerator)
+   - Might require high CPU usage
+
+Choosing the Right Implementation
+=================================
+
+**Use Hardware Accelerator when:**
+
+- **Multi-tasking systems** - system runs computation heavy services that need CPU resources alongside crypto operations
+- **Functional safety/security requirements** - ASIL or safety-critical applications require offloading crypto operations away from Linux kernel to reduce attack surface and ensure isolation
+- **Compliance/regulatory requirements** - FIPS certification, Common Criteria, or TEE integration mandates hardware acceleration
+
+**Use ARM CPU (CE) when:**
+
+- **Maximum throughput required** - Need high throughput for bulk data encryption, video transcoding, or media processing
+- **Dedicated crypto workload** - Crypto is the primary task and high CPU usage is acceptable
+- **Small/infrequent operations** - One-time encryption with small data blocks where accelerator overhead is minimal
+
+**Performance Comparison** : For a detailed comparison of hardware accelerator performance against ARM Cryptographic Extension (CE) and baseline ARM CPU, see :ref:`crypto-performance` in the Linux Performance Guide.
+
 ********************
 Building the Drivers
 ********************
@@ -376,7 +411,6 @@ you can use **rngd** (the random number generator daemon) to feed the
 Hardware Accelerator testing
 ****************************
 
-===============================
 Testing using the tcrypt module
 ===============================
 
@@ -420,7 +454,6 @@ Testing using the tcrypt module
    [ 3036.492101] tcrypt:
    ...
 
-=============
 IPSec Testing
 =============
 


### PR DESCRIPTION
Add documentation on crypto implementation options including hardware crypto accelerators and ARM-based crypto extensions, and the trade-offs of using them.