### PR TITLE
ci(vale): enforce known term usage

### DIFF
--- a/.github/styles/PSDK/TermsErrors.yml
+++ b/.github/styles/PSDK/TermsErrors.yml
@@ -1,0 +1,10 @@
+---
+extends: substitution
+ignorecase: true
+level: error
+message: "Use '%s' rather than '%s'."
+action:
+  name: replace
+swap:
+  'deep\s+sleep': DeepSleep
+  'key\s+writer': Keywriter

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 # vale configs and intermediary data
 .github/styles/*
 !.github/styles/config
+!.github/styles/PSDK

--- a/.vale.ini
+++ b/.vale.ini
@@ -6,7 +6,7 @@ Packages = RedHat
 Vocab = PSDK
 
 [*.{md,rst}]
-BasedOnStyles = RedHat
+BasedOnStyles = RedHat, PSDK
 RedHat.PascalCamelCase = NO
 RedHat.GitLinks = NO
 RedHat.MergeConflictMarkers = NO


### PR DESCRIPTION
Both Keywriter and DeepSleep term usage were recently solidified. Add a style to get vale to enforce these decisions globally.