### PR TITLE
feat(linux): Add Ethernet performance numbers for 12.01 release

### DIFF
--- a/source/devices/AM62LX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62LX/linux/Linux_Performance_Guide.rst
@@ -429,6 +429,121 @@ ALSA SoC Audio Driver
     "96000","3073222.00 (min 3073203.00, max 3073253.00)","0.57 (min 0.31, max 0.97)"
 
 
+Ethernet
+--------
+
+Ethernet performance benchmarks were measured using :command:`netperf` 2.7.1 https://hewlettpackard.github.io/netperf/doc/netperf.html
+Test procedures were modeled after those defined in RFC-2544:
+https://tools.ietf.org/html/rfc2544, where the DUT is the TI device
+and the "tester" used was a Linux PC. To produce consistent results,
+it is recommended to carry out performance tests in a private network and to avoid
+running NFS on the same interface used in the test. In these results,
+CPU utilization was captured as the total percentage used across all cores on the device,
+while running the performance test over one external interface.
+
+UDP Throughput (0% loss) was measured by the procedure defined in RFC-2544 section 26.1: Throughput.
+In this scenario, :command:`netperf` options burst_size (-b) and wait_time (-w) are used to limit bandwidth
+during different trials of the test, with the goal of finding the highest rate at which
+no loss is seen. For example, to limit bandwidth to 500Mbits/sec with 1472B datagram:
+
+.. code-block:: console
+
+   burst_size = <bandwidth (bits/sec)> / 8 (bits -> bytes) / <UDP datagram size> / 100 (seconds -> 10 ms)
+   burst_size = 500000000 / 8 / 1472 / 100 = 425
+
+   wait_time = 10 milliseconds (minimum supported by Linux PC used for testing)
+
+UDP Throughput (possible loss) was measured by capturing throughput and packet loss statistics when
+running the :command:`netperf` test with no bandwidth limit (remove -b/-w options).
+
+The following commands were used to tune the socket buffer sizes on the DUT before running the performance tests:
+
+.. code-block:: console
+
+   sysctl -w net.core.rmem_default=33554432
+   sysctl -w net.core.rmem_max=67108864
+
+In order to start a :command:`netperf` client on one device, the other device must have :command:`netserver` running.
+To start :command:`netserver`:
+
+.. code-block:: console
+
+   netserver [-p <port_number>] [-4 (IPv4 addressing)] [-6 (IPv6 addressing)]
+
+Running the following shell script from the DUT will trigger :command:`netperf` clients to measure
+bidirectional TCP performance for 60 seconds and report CPU utilization. Parameter -k is used in
+client commands to summarize selected statistics on their own line and -j is used to gain
+additional timing measurements during the test.
+
+.. code-block:: console
+
+   #!/bin/bash
+   for i in 1
+   do
+      netperf -H <tester ip> -j -c -l 60 -t TCP_STREAM --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+
+      netperf -H <tester ip> -j -c -l 60 -t TCP_MAERTS --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+   done
+
+Running the following commands will trigger :command:`netperf` clients to measure UDP burst performance for
+60 seconds at various burst/datagram sizes and report CPU utilization.
+
+- For UDP egress tests, run :command:`netperf` client from DUT and start :command:`netserver` on tester.
+
+.. code-block:: console
+
+   netperf -H <tester ip> -j -c -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+- For UDP ingress tests, run :command:`netperf` client from tester and start :command:`netserver` on DUT.
+
+.. code-block:: console
+
+   netperf -H <DUT ip> -j -C -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+CPSW/CPSW2g/CPSW3g Ethernet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+TCP Bidirectional Throughput
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput
+    :header: "Command Used","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1215.82","98.99"
+
+TCP Bidirectional Throughput Interrupt Pacing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
+    :header: "Command Used","am62lxx_evm-fs: THROUGHPUT (Mbits/sec)","am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1266.92","99.09"
+
+UDP Throughput
+~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g UDP Egress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62lxx_evm-fs: THROUGHPUT (Mbits/sec)", "am62lxx_evm-fs: Packets Per Second (kPPS)", "am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","41.23","81","77.62"
+    "128","80.45","79","77.20"
+    "256","145.58","71","75.10"
+    "1024","571.23","70","75.05"
+    "1518","810.12","69","74.91"
+
+.. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62lxx_evm-fs: THROUGHPUT (Mbits/sec)", "am62lxx_evm-fs: Packets Per Second (kPPS)", "am62lxx_evm-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","48.36","94","77.82"
+    "128","104.64","102","76.83"
+    "256","205.60","100","75.71"
+    "1024","651.14","79","73.67"
+    "1518","810.12","69","74.91"
+
 |
 
 Linux OSPI Flash Driver

--- a/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62PX/linux/Linux_Performance_Guide.rst
@@ -412,6 +412,123 @@ Run Glmark2 and capture performance reported (Score). All display outputs (HDMI,
     "Glmark2-Wayland","776.40 (min 765.00, max 786.00)"
 
 
+Ethernet
+--------
+
+Ethernet performance benchmarks were measured using :command:`netperf` 2.7.1 https://hewlettpackard.github.io/netperf/doc/netperf.html
+Test procedures were modeled after those defined in RFC-2544:
+https://tools.ietf.org/html/rfc2544, where the DUT is the TI device
+and the "tester" used was a Linux PC. To produce consistent results,
+it is recommended to carry out performance tests in a private network and to avoid
+running NFS on the same interface used in the test. In these results,
+CPU utilization was captured as the total percentage used across all cores on the device,
+while running the performance test over one external interface.
+
+UDP Throughput (0% loss) was measured by the procedure defined in RFC-2544 section 26.1: Throughput.
+In this scenario, :command:`netperf` options burst_size (-b) and wait_time (-w) are used to limit bandwidth
+during different trials of the test, with the goal of finding the highest rate at which
+no loss is seen. For example, to limit bandwidth to 500Mbits/sec with 1472B datagram:
+
+.. code-block:: console
+
+   burst_size = <bandwidth (bits/sec)> / 8 (bits -> bytes) / <UDP datagram size> / 100 (seconds -> 10 ms)
+   burst_size = 500000000 / 8 / 1472 / 100 = 425
+
+   wait_time = 10 milliseconds (minimum supported by Linux PC used for testing)
+
+UDP Throughput (possible loss) was measured by capturing throughput and packet loss statistics when
+running the :command:`netperf` test with no bandwidth limit (remove -b/-w options).
+
+The following commands were used to tune the socket buffer sizes on the DUT before running the performance tests:
+
+.. code-block:: console
+
+   sysctl -w net.core.rmem_default=33554432
+   sysctl -w net.core.rmem_max=67108864
+
+In order to start a :command:`netperf` client on one device, the other device must have :command:`netserver` running.
+To start :command:`netserver`:
+
+.. code-block:: console
+
+   netserver [-p <port_number>] [-4 (IPv4 addressing)] [-6 (IPv6 addressing)]
+
+Running the following shell script from the DUT will trigger :command:`netperf` clients to measure
+bidirectional TCP performance for 60 seconds and report CPU utilization. Parameter -k is used in
+client commands to summarize selected statistics on their own line and -j is used to gain
+additional timing measurements during the test.
+
+.. code-block:: console
+
+   #!/bin/bash
+   for i in 1
+   do
+      netperf -H <tester ip> -j -c -l 60 -t TCP_STREAM --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+
+      netperf -H <tester ip> -j -c -l 60 -t TCP_MAERTS --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+   done
+
+Running the following commands will trigger :command:`netperf` clients to measure UDP burst performance for
+60 seconds at various burst/datagram sizes and report CPU utilization.
+
+- For UDP egress tests, run :command:`netperf` client from DUT and start :command:`netserver` on tester.
+
+.. code-block:: console
+
+   netperf -H <tester ip> -j -c -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+- For UDP ingress tests, run :command:`netperf` client from tester and start :command:`netserver` on DUT.
+
+.. code-block:: console
+
+   netperf -H <DUT ip> -j -C -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+CPSW/CPSW2g/CPSW3g Ethernet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- CPSW3g: AM62px
+
+TCP Bidirectional Throughput
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput
+    :header: "Command Used","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1828.16","43.22"
+
+TCP Bidirectional Throughput Interrupt Pacing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
+    :header: "Command Used","am62pxx_sk-fs: THROUGHPUT (Mbits/sec)","am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1789.37","41.18"
+
+UDP Throughput
+~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g UDP Egress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62pxx_sk-fs: THROUGHPUT (Mbits/sec)", "am62pxx_sk-fs: Packets Per Second (kPPS)", "am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","46.50","91","37.58"
+    "128","90.35","88","37.33"
+    "256","179.38","88","37.18"
+    "1024","673.26","82","35.55"
+    "1518","956.86","81","40.26"
+
+.. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62pxx_sk-fs: THROUGHPUT (Mbits/sec)", "am62pxx_sk-fs: Packets Per Second (kPPS)", "am62pxx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","30.46","59","9.72"
+    "128","64.61","63","12.30"
+    "256","156.26","76","16.65"
+    "1024","939.47","115","36.24"
+    "1518","908.82","77","36.28"
+
 |
 
 Linux OSPI Flash Driver

--- a/source/devices/AM62X/linux/Linux_Performance_Guide.rst
+++ b/source/devices/AM62X/linux/Linux_Performance_Guide.rst
@@ -468,6 +468,123 @@ Run Glmark2 and capture performance reported (Score). All display outputs (HDMI,
 
 
 
+Ethernet
+--------
+
+Ethernet performance benchmarks were measured using :command:`netperf` 2.7.1 https://hewlettpackard.github.io/netperf/doc/netperf.html
+Test procedures were modeled after those defined in RFC-2544:
+https://tools.ietf.org/html/rfc2544, where the DUT is the TI device
+and the "tester" used was a Linux PC. To produce consistent results,
+it is recommended to carry out performance tests in a private network and to avoid
+running NFS on the same interface used in the test. In these results,
+CPU utilization was captured as the total percentage used across all cores on the device,
+while running the performance test over one external interface.
+
+UDP Throughput (0% loss) was measured by the procedure defined in RFC-2544 section 26.1: Throughput.
+In this scenario, :command:`netperf` options burst_size (-b) and wait_time (-w) are used to limit bandwidth
+during different trials of the test, with the goal of finding the highest rate at which
+no loss is seen. For example, to limit bandwidth to 500Mbits/sec with 1472B datagram:
+
+.. code-block:: console
+
+   burst_size = <bandwidth (bits/sec)> / 8 (bits -> bytes) / <UDP datagram size> / 100 (seconds -> 10 ms)
+   burst_size = 500000000 / 8 / 1472 / 100 = 425
+
+   wait_time = 10 milliseconds (minimum supported by Linux PC used for testing)
+
+UDP Throughput (possible loss) was measured by capturing throughput and packet loss statistics when
+running the :command:`netperf` test with no bandwidth limit (remove -b/-w options).
+
+The following commands were used to tune the socket buffer sizes on the DUT before running the performance tests:
+
+.. code-block:: console
+
+   sysctl -w net.core.rmem_default=33554432
+   sysctl -w net.core.rmem_max=67108864
+
+In order to start a :command:`netperf` client on one device, the other device must have :command:`netserver` running.
+To start :command:`netserver`:
+
+.. code-block:: console
+
+   netserver [-p <port_number>] [-4 (IPv4 addressing)] [-6 (IPv6 addressing)]
+
+Running the following shell script from the DUT will trigger :command:`netperf` clients to measure
+bidirectional TCP performance for 60 seconds and report CPU utilization. Parameter -k is used in
+client commands to summarize selected statistics on their own line and -j is used to gain
+additional timing measurements during the test.
+
+.. code-block:: console
+
+   #!/bin/bash
+   for i in 1
+   do
+      netperf -H <tester ip> -j -c -l 60 -t TCP_STREAM --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+
+      netperf -H <tester ip> -j -c -l 60 -t TCP_MAERTS --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+   done
+
+Running the following commands will trigger :command:`netperf` clients to measure UDP burst performance for
+60 seconds at various burst/datagram sizes and report CPU utilization.
+
+- For UDP egress tests, run :command:`netperf` client from DUT and start :command:`netserver` on tester.
+
+.. code-block:: console
+
+   netperf -H <tester ip> -j -c -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+- For UDP ingress tests, run :command:`netperf` client from tester and start :command:`netserver` on DUT.
+
+.. code-block:: console
+
+   netperf -H <DUT ip> -j -C -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+CPSW/CPSW2g/CPSW3g Ethernet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- CPSW3g: AM62x
+
+TCP Bidirectional Throughput
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput
+    :header: "Command Used","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1657.01","67.11","1822.62","66.72","1763.18","67.48"
+
+TCP Bidirectional Throughput Interrupt Pacing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
+    :header: "Command Used","am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xx_sk-fs: THROUGHPUT (Mbits/sec)","am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)","am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)","am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1794.07","63.53","1828.80","57.91","1543.11","49.30"
+
+UDP Throughput
+~~~~~~~~~~~~~~
+
+.. csv-table:: CPSW2g UDP Egress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)", "am62xx_lp_sk-fs: Packets Per Second (kPPS)", "am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)", "am62xx_sk-fs: THROUGHPUT (Mbits/sec)", "am62xx_sk-fs: Packets Per Second (kPPS)", "am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)", "am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)", "am62xxsip_sk-fs: Packets Per Second (kPPS)", "am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","38.61","75","36.53","44.13","86","37.14","45.71","89","37.74"
+    "128","76.11","74","36.58","85.34","83","36.72","91.47","89","37.33"
+    "256","148.89","73","36.41","169.41","83","36.51","170.76","83","36.89"
+    "1024","592.94","72","36.75","659.08","80","36.45","704.41","86","37.13"
+    "1518","846.54","72","36.56","208.42","18","11.87","916.55","78","39.59"
+
+.. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am62xx_lp_sk-fs: THROUGHPUT (Mbits/sec)", "am62xx_lp_sk-fs: Packets Per Second (kPPS)", "am62xx_lp_sk-fs: CPU Load % (LOCAL_CPU_UTIL)", "am62xx_sk-fs: THROUGHPUT (Mbits/sec)", "am62xx_sk-fs: Packets Per Second (kPPS)", "am62xx_sk-fs: CPU Load % (LOCAL_CPU_UTIL)", "am62xxsip_sk-fs: THROUGHPUT (Mbits/sec)", "am62xxsip_sk-fs: Packets Per Second (kPPS)", "am62xxsip_sk-fs: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","33.53","65","15.91","41.16","80","19.91","30.41","59","12.23"
+    "128","63.90","62","15.10","66.05","65","15.68","61.95","60","14.96"
+    "256","170.41","83","26.12","148.27","72","18.20","142.13","69","13.55"
+    "1024","611.97","75","26.40","754.92","92","31.48","681.07","83","41.67"
+    "1518","954.54","81","39.92","956.88","81","38.55","710.47","60","31.15"
+
 |
 
 Linux OSPI Flash Driver

--- a/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
+++ b/source/devices/AM64X/linux/RT_Linux_Performance_Guide.rst
@@ -273,6 +273,166 @@ Boot media: MMCSD
 Boot time numbers [avg, min, max] are measured from "Starting kernel" to Linux prompt across 20 boot cycles.
  
 
+Ethernet
+--------
+
+Ethernet performance benchmarks were measured using :command:`netperf` 2.7.1 https://hewlettpackard.github.io/netperf/doc/netperf.html
+Test procedures were modeled after those defined in RFC-2544:
+https://tools.ietf.org/html/rfc2544, where the DUT is the TI device
+and the "tester" used was a Linux PC. To produce consistent results,
+it is recommended to carry out performance tests in a private network and to avoid
+running NFS on the same interface used in the test. In these results,
+CPU utilization was captured as the total percentage used across all cores on the device,
+while running the performance test over one external interface.
+
+UDP Throughput (0% loss) was measured by the procedure defined in RFC-2544 section 26.1: Throughput.
+In this scenario, :command:`netperf` options burst_size (-b) and wait_time (-w) are used to limit bandwidth
+during different trials of the test, with the goal of finding the highest rate at which
+no loss is seen. For example, to limit bandwidth to 500Mbits/sec with 1472B datagram:
+
+.. code-block:: console
+
+   burst_size = <bandwidth (bits/sec)> / 8 (bits -> bytes) / <UDP datagram size> / 100 (seconds -> 10 ms)
+   burst_size = 500000000 / 8 / 1472 / 100 = 425
+
+   wait_time = 10 milliseconds (minimum supported by Linux PC used for testing)
+
+UDP Throughput (possible loss) was measured by capturing throughput and packet loss statistics when
+running the :command:`netperf` test with no bandwidth limit (remove -b/-w options).
+
+The following commands were used to tune the socket buffer sizes on the DUT before running the performance tests:
+
+.. code-block:: console
+
+   sysctl -w net.core.rmem_default=33554432
+   sysctl -w net.core.rmem_max=67108864
+
+In order to start a :command:`netperf` client on one device, the other device must have :command:`netserver` running.
+To start :command:`netserver`:
+
+.. code-block:: console
+
+   netserver [-p <port_number>] [-4 (IPv4 addressing)] [-6 (IPv6 addressing)]
+
+Running the following shell script from the DUT will trigger :command:`netperf` clients to measure
+bidirectional TCP performance for 60 seconds and report CPU utilization. Parameter -k is used in
+client commands to summarize selected statistics on their own line and -j is used to gain
+additional timing measurements during the test.
+
+.. code-block:: console
+
+   #!/bin/bash
+   for i in 1
+   do
+      netperf -H <tester ip> -j -c -l 60 -t TCP_STREAM --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+
+      netperf -H <tester ip> -j -c -l 60 -t TCP_MAERTS --
+         -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE &
+   done
+
+Running the following commands will trigger :command:`netperf` clients to measure UDP burst performance for
+60 seconds at various burst/datagram sizes and report CPU utilization.
+
+- For UDP egress tests, run :command:`netperf` client from DUT and start :command:`netserver` on tester.
+
+.. code-block:: console
+
+   netperf -H <tester ip> -j -c -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+- For UDP ingress tests, run :command:`netperf` client from tester and start :command:`netserver` on DUT.
+
+.. code-block:: console
+
+   netperf -H <DUT ip> -j -C -l 60 -t UDP_STREAM -b <burst_size> -w <wait_time> -- -m <UDP datagram size>
+      -k DIRECTION,THROUGHPUT,MEAN_LATENCY,LOCAL_CPU_UTIL,REMOTE_CPU_UTIL,LOCAL_BYTES_SENT,REMOTE_BYTES_RECVD,LOCAL_SEND_SIZE
+
+CPSW/CPSW2g/CPSW3g Ethernet
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- CPSW3g: AM64x
+
+TCP Bidirectional Throughput
+""""""""""""""""""""""""""""
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput
+    :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1031.66","86.53"
+
+TCP Bidirectional Throughput Interrupt Pacing
+"""""""""""""""""""""""""""""""""""""""""""""
+
+.. csv-table:: CPSW2g TCP Bidirectional Throughput Interrupt Pacing
+    :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.0.1 -j -c -C -l 60 -t TCP_MAERTS","1168.10","98.39"
+
+UDP Throughput
+""""""""""""""
+
+.. csv-table:: CPSW2g UDP Egress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am64xx-hsevm: THROUGHPUT (Mbits/sec)", "am64xx-hsevm: Packets Per Second (kPPS)", "am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","46.16","90","95.13"
+    "128","87.08","85","94.65"
+    "256","172.14","84","95.07"
+    "1024","607.39","74","92.62"
+    "1518","875.48","74","95.21"
+
+.. csv-table:: CPSW2g UDP Ingress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am64xx-hsevm: THROUGHPUT (Mbits/sec)", "am64xx-hsevm: Packets Per Second (kPPS)", "am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","27.08","53","30.34"
+    "128","62.77","61","35.48"
+    "256","135.17","66","38.06"
+    "1024","570.15","70","50.77"
+    "1518","710.16","60","55.83"
+
+ICSSG Ethernet
+^^^^^^^^^^^^^^^
+
+ICSSG TCP Bidirectional Throughput
+"""""""""""""""""""""""""""""""""""
+
+.. csv-table:: ICSSG TCP Bidirectional Throughput
+    :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","1033.68","96.75"
+
+ICSSG TCP Bidirectional Throughput Interrupt Pacing
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. csv-table:: ICSSG TCP Bidirectional Throughput Interrupt Pacing
+    :header: "Command Used","am64xx-hsevm: THROUGHPUT (Mbits/sec)","am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_STREAM; netperf -H 192.168.2.1 -j -c -C -l 60 -t TCP_MAERTS","1041.18","98.12"
+
+UDP Egress Throughput
+"""""""""""""""""""""
+
+.. csv-table:: ICSSG UDP Egress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am64xx-hsevm: THROUGHPUT (Mbits/sec)", "am64xx-hsevm: Packets Per Second (kPPS)", "am64xx-hsevm: CPU Load % (LOCAL_CPU_UTIL)"
+
+    "64","45.86","90","94.83"
+    "128","90.03","88","95.12"
+    "256","171.28","84","94.77"
+    "1024","591.59","72","91.82"
+    "1472","828.03","70","92.46"
+
+UDP Ingress Throughput
+""""""""""""""""""""""
+
+.. csv-table:: ICSSG UDP Ingress Throughput 0 loss
+    :header: "Frame Size(bytes)", "am64xx-hsevm: THROUGHPUT (Mbits/sec)", "am64xx-hsevm: Packets Per Second (kPPS)", "am64xx-hsevm: CPU Load %"
+
+    "64","37.94","74","45.32"
+    "128","79.56","78","46.82"
+    "256","151.35","74","47.36"
+    "1024","504.03","62","50.76"
+    "1472","680.08","58","52.83"
+
 |
 
 OSPI Flash Driver


### PR DESCRIPTION
Add netperf Ethernet performance data for AM62X, AM62PX, AM62LX and AM64X in their respective performance guide RST files. Each section covers CPSW TCP bidirectional throughput (with and without interrupt pacing) and UDP egress/ingress 0-loss throughput across 64/128/256/ 1024/1518B frame sizes. AM64X additionally includes ICSSG results.