### PR TITLE
fix(mcu-plus-sdk): update MCU+ SDK docs links and versions

### DIFF
--- a/source/devices/AM62LX/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62LX/linux/Overview/Download_and_Install_the_SDK.rst
@@ -85,8 +85,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    AM62L Linux SDK contains only the Linux specific source and application intended
    to run on A53/Linux core. For A53 based FreeRTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/api_guide_am62lx/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_02_00_23/exports/docs/api_guide_am62lx/index.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/api_guide_am62lx/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_02_00_23/exports/docs/api_guide_am62lx/CCS_SETUP_PAGE.html>`__

--- a/source/devices/AM62LX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62LX/linux/Release_Specific_Build_Sheet.rst
@@ -6,7 +6,7 @@ Software Build Sheet
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__|
 Release. The following table lists the supported features and modules with the support status
-for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_00_00_23/exports/docs/build_sheet/am62l-sw-buildsheet.html>`__
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62LX/11_02_00_23/exports/docs/api_guide_am62lx/BUILDSHEET.html>`__
 for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:

--- a/source/devices/AM62PX/index_RTOS.rst
+++ b/source/devices/AM62PX/index_RTOS.rst
@@ -8,4 +8,4 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/device/am62px/main_page.html>`__

--- a/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
+++ b/source/devices/AM62PX/linux/Overview/Download_and_Install_the_SDK.rst
@@ -85,8 +85,8 @@ by double clicking on it within your Linux host PC.
 .. note::
    Processor SDK Linux AM62Px contains only the Linux specific source and application intended
    to runs on A53/Linux core. For R5F and RTOS/NO-RTOS side source and applications, refer **MCU+ SDK**
-   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/index.html>`__.
+   package `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/device/am62px/main_page.html>`__.
 
 **Instructions to set-up CCS**
 
--  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/CCS_SETUP_PAGE.html>`__
+-  Refer `[Use Link] <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/getting_started/ccs_setup.html>`__

--- a/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62PX/linux/Release_Specific_Build_Sheet.rst
@@ -6,7 +6,7 @@ Software Build Sheet
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
 The following table lists the supported features and modules with the support status
-for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/build_sheet/am62p-sw-buildsheet.html>`__
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/buildsheet/buildsheet_am62px.html>`__
 for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:

--- a/source/devices/AM62X/index_RTOS.rst
+++ b/source/devices/AM62X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/11_01_00_16/exports/docs/api_guide_am62x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/12_00_00_27/exports/docs/api_guide_am62x/index.html>`__
 

--- a/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM62X/linux/Release_Specific_Build_Sheet.rst
@@ -6,7 +6,7 @@ Software Build Sheet
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
 The following table lists the supported features and modules with the support status
-for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/11_01_00_16/exports/docs/build_sheet/am62x-sw-buildsheet.html>`__
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/12_00_00_27/exports/docs/api_guide_am62x/BUILDSHEET.html>`__
 for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:

--- a/source/devices/AM64X/index_RTOS.rst
+++ b/source/devices/AM64X/index_RTOS.rst
@@ -8,5 +8,5 @@ RTOS/NO-RTOS [MCU+ SDK]
 
 **For MCU+ SDK RTOS/NO-RTOS documentation, refer below links**
 
--  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/api_guide_am64x/index.html>`__
+-  `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/12_00_00_27/exports/docs/api_guide_am64x/index.html>`__
 

--- a/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
+++ b/source/devices/AM64X/linux/Release_Specific_Build_Sheet.rst
@@ -6,7 +6,7 @@ Software Build Sheet
 
 Build Sheet of supported features and modules for this |__SDK_FULL_NAME__| Release.
 The following table lists the supported features and modules with the support status
-for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/11_01_00_17/exports/docs/build_sheet/am64x-sw-buildsheet.html>`__
+for Linux on A53. Please refer to `RTOS Build Sheet <https://software-dl.ti.com/mcu-plus-sdk/esd/AM64X/12_00_00_27/exports/docs/api_guide_am64x/BUILDSHEET.html>`__
 for the supported features and modules on RTOS.
 
 The support status is indicated by the following codes:

--- a/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
+++ b/source/linux/Demo_User_Guides/Display_Cluster_User_Guide.rst
@@ -70,4 +70,4 @@ Building the Display Cluster Demo from source
 Building the MCU Firmware from sources
 --------------------------------------
 
-    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/group__DRV__DSS__MODULE.html>`__
+    #. Please refer to the `MCU+ SDK Documentation <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/components/drivers/dss.html>`__

--- a/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
+++ b/source/linux/Foundational_Components/Power_Management/pm_wakeup_sources.rst
@@ -1034,7 +1034,7 @@ MCU IPC based Wakeup
 
    .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-      `MCU+ SDK for AM62Px <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_00_00_27/exports/docs/api_guide_am62px/index.html>`__
+      `MCU+ SDK for AM62Px <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/device/am62px/main_page.html>`__
 
    .. ifconfig:: CONFIG_part_variant in ('AM62DX')
 

--- a/source/linux/Foundational_Components/Tools/Flash_via_UART.rst
+++ b/source/linux/Foundational_Components/Tools/Flash_via_UART.rst
@@ -18,4 +18,4 @@ Detailed instructions on using the tool can be found in MCU+SDK docs.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-   `MCU+SDK Flash Tools Documentation  <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/11_01_01_08/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`__.
+   `MCU+SDK Flash Tools Documentation  <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/components/tools/tools_flash.html>`__.

--- a/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
+++ b/source/linux/How_to_Guides/Target/How_to_boot_quickly.rst
@@ -127,15 +127,15 @@ Reducing bootloader time
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
-   You can track current performance numbers here: `AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/DATASHEET_AM62X_EVM.html#autotoc_md184>`_
+   You can track current performance numbers here: `AM62X <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62X/latest/exports/docs/api_guide_am62x/DATASHEET_AM62X_EVM.html#autotoc_md184>`__
 
 .. ifconfig:: CONFIG_part_variant in ('AM62AX')
 
-   You can track current performance numbers here: `AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/11_01_00_16/exports/docs/api_guide_am62ax/DATASHEET_AM62AX_EVM.html#autotoc_md148>`_
+   You can track current performance numbers here: `AM62AX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62AX/11_01_00_16/exports/docs/api_guide_am62ax/DATASHEET_AM62AX_EVM.html#autotoc_md148>`__
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-   You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_00_00_27/exports/docs/api_guide_am62px/DATASHEET_AM62PX_EVM.html#autotoc_md119>`_
+   You can track current performance numbers here: `AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/datasheet/datasheet_am62px_evm.html>`__
 
 
 - Flashing binaries:
@@ -158,7 +158,7 @@ Reducing bootloader time
 
    .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-      - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_00_00_27/exports/docs/api_guide_am62px/TOOLS_FLASH.html>`_
+      - `UART flashing tool AM62PX <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/components/tools/tools_flash.html#uart-uniflash>`_
 
       - U-Boot eMMC flashing tool AM62PX: :ref:`u-boot-build-guide-environment-k3`
 
@@ -176,7 +176,7 @@ Secondary Boot Loader (SBL)
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-   The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_00_00_27/exports/docs/api_guide_am62px/EXAMPLES_DRIVERS_SBL.html>`_.
+   The following section will reference `AM62PX MCU+ SDK's SBL examples <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/examples/examples_drivers_sbl.html>`_.
 
 .. ifconfig:: CONFIG_part_variant in ('AM62X')
 
@@ -188,7 +188,7 @@ Secondary Boot Loader (SBL)
 
 .. ifconfig:: CONFIG_part_variant in ('AM62PX')
 
-   - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_00_00_27/exports/docs/api_guide_am62px/TOOLS_BOOT.html#LINUX_APPIMAGE_GEN_TOOL>`_
+   - `AM62PX Falcon Mode <https://software-dl.ti.com/mcu-plus-sdk/esd/AM62PX/12_01_00_28/exports/docs/api_guide_am62px/components/tools/tools_boot.html#linux-appimage-generator-tool>`_
 
 - Removing unnecessary prints
 


### PR DESCRIPTION
Update MCU+ SDK links for latest releases across AM62LX, AM62PX, AM62X, and AM64X devices.